### PR TITLE
fix inode flood (update DESKTOP_DIRS to be filled with <data-dir>/applications)

### DIFF
--- a/ulauncher/config.py
+++ b/ulauncher/config.py
@@ -20,7 +20,8 @@ from ulauncher.util.decorator.lru_cache import lru_cache
 CACHE_DIR = os.path.join(xdg_cache_home, 'ulauncher_cache')
 CONFIG_DIR = os.path.join(xdg_config_home, 'ulauncher')
 SETTINGS_FILE_PATH = os.path.join(CONFIG_DIR, 'settings.json')
-DESKTOP_DIRS = filter(os.path.exists, xdg_data_dirs)
+# spec: https://specifications.freedesktop.org/menu-spec/latest/ar01s02.html
+DESKTOP_DIRS = [os.path.join(dir_, "applications") for dir_ in filter(os.path.exists, xdg_data_dirs)]
 EXTENSIONS_DIR = os.path.join(CACHE_DIR, 'extensions')
 EXT_PREFERENCES_DIR = os.path.join(CONFIG_DIR, 'ext_preferences')
 ULAUNCHER_APP_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), '..'))

--- a/ulauncher/config.py
+++ b/ulauncher/config.py
@@ -21,7 +21,7 @@ CACHE_DIR = os.path.join(xdg_cache_home, 'ulauncher_cache')
 CONFIG_DIR = os.path.join(xdg_config_home, 'ulauncher')
 SETTINGS_FILE_PATH = os.path.join(CONFIG_DIR, 'settings.json')
 # spec: https://specifications.freedesktop.org/menu-spec/latest/ar01s02.html
-DESKTOP_DIRS = [os.path.join(dir_, "applications") for dir_ in filter(os.path.exists, xdg_data_dirs)]
+DESKTOP_DIRS = filter(os.path.exists, [os.path.join(dir_, "applications") for dir_ in xdg_data_dirs])
 EXTENSIONS_DIR = os.path.join(CACHE_DIR, 'extensions')
 EXT_PREFERENCES_DIR = os.path.join(CONFIG_DIR, 'ext_preferences')
 ULAUNCHER_APP_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), '..'))


### PR DESCRIPTION
Currently inotify watch is added to each xdg data dir like `/usr/share` and recursively adds every directory running out of user watches and spamming logs hundreds of error messages like this
```
ERROR | pyinotify: add_watch() | add_watch: cannot watch /usr/share/icu WD=-1, Errno=No space left on device (ENOSPC)
```
While one fix is to increase user watches same as in #51 after looking over the code it became clear that the watch should be done on the `applications/` folder for each XDG data dir as per XDG spec: https://specifications.freedesktop.org/menu-spec/latest/ar01s02.html.

> $XDG_DATA_DIRS/applications/
>
> This directory contains a .desktop file for each possible menu item. Each directory in the $XDG_DATA_DIRS search path should be used (i.e. desktop entries are collected from all of them, not just the first one that exists). When two desktop entries have the same name, the one appearing earlier in the path is used. 
> 

This patch addresses this issue.