### PR TITLE
Comply with XDG spec on .desktop location, dedup .desktop search per XDG_DATA_DIR and fix search to not collapse same Name

### DIFF
--- a/tests/search/apps/test_AppDb.py
+++ b/tests/search/apps/test_AppDb.py
@@ -13,27 +13,94 @@ class TestAppDb(object):
     @pytest.fixture
     def db_with_data(self, app_db):
         values = [
-            {'name': 'john', 'description': 'test', 'search_name': 'john',
-                'desktop_file': 'john.desktop', 'icon': 'icon'},
-            {'name': 'james', 'description': 'test', 'search_name': 'james',
-                'desktop_file': 'james.desktop', 'icon': 'icon'},
-            {'name': 'o.jody', 'description': 'test', 'search_name': 'o.jody',
-                'desktop_file': 'o.jdy.desktop', 'icon': 'icon'},
-            {'name': 'sandy', 'description': 'test', 'search_name': 'sandy',
-                'desktop_file': 'sandy.desktop', 'icon': 'icon'},
-            {'name': 'jane', 'description': 'test', 'search_name': 'jane',
-                'desktop_file': 'jane.desktop', 'icon': 'icon'},
-            {'name': 'LibreOffice Calc', 'description': 'test', 'search_name': 'LibreOffice Calc',
-                'desktop_file': 'libre.calc', 'icon': 'icon'},
-            {'name': 'Calc', 'description': 'test', 'search_name': 'Calc',
-                'desktop_file': 'calc', 'icon': 'icon'},
-            {'name': 'Guake Terminal', 'description': 'test', 'search_name': 'Guake Terminal',
-                'desktop_file': 'Guake Terminal', 'icon': 'icon'},
-            {'name': 'Keyboard', 'description': 'test', 'search_name': 'Keyboard',
-                'desktop_file': 'Keyboard', 'icon': 'icon'}
+            {
+                'name': 'john',
+                'description': 'test',
+                'search_name': 'john',
+                'desktop_file': '/foo/john.desktop',
+                'desktop_file_short': 'john.desktop',
+                'icon': 'icon'
+            },
+            {
+                'name': 'james',
+                'description': 'test',
+                'search_name': 'james',
+                'desktop_file': '/foo/james.desktop',
+                'desktop_file_short': 'james.desktop',
+                'icon': 'icon'
+            },
+            {
+                'name': 'o.jody',
+                'description': 'test',
+                'search_name': 'o.jody',
+                'desktop_file': '/foo/o.jdy.desktop',
+                'desktop_file_short': 'o.jdy.desktop',
+                'icon': 'icon'
+            },
+            {
+                'name': 'sandy',
+                'description': 'test',
+                'search_name': 'sandy',
+                'desktop_file': '/foo/sandy.desktop',
+                'desktop_file_short': 'sandy.desktop',
+                'icon': 'icon'
+            },
+            {
+                'name': 'jane',
+                'description': 'test',
+                'search_name': 'jane',
+                'desktop_file': '/foo/jane.desktop',
+                'desktop_file_short': 'jane.desktop',
+                'icon': 'icon'
+            },
+            {
+                'name': 'LibreOffice Calc',
+                'description': 'test',
+                'search_name': 'LibreOffice Calc',
+                'desktop_file': '/foo/libre.calc',
+                'desktop_file_short': 'libre.calc',
+                'icon': 'icon'},
+            {
+                'name': 'Calc',
+                'description': 'test',
+                'search_name': 'Calc',
+                'desktop_file': 'calc',
+                'desktop_file_short': 'calc',
+                'icon': 'icon'
+            },
+            {
+                'name': 'Guake Terminal',
+                'description': 'test',
+                'search_name': 'Guake Terminal',
+                'desktop_file': 'Guake Terminal',
+                'desktop_file_short': 'Guake Terminal',
+                'icon': 'icon'
+            },
+            {
+                'name': 'Keyboard',
+                'description': 'test',
+                'search_name': 'Keyboard',
+                'desktop_file': 'Keyboard',
+                'desktop_file_short': 'Keyboard',
+                'icon': 'icon'
+            }
         ]
-        app_db.get_cursor().executemany("""INSERT INTO app_db (name, desktop_file, description, search_name)
-            VAlUES (:name, :desktop_file, :description, :search_name)""", values)
+        app_db.get_cursor().executemany("""
+            INSERT INTO app_db (
+                name,
+                desktop_file,
+                desktop_file_short,
+                description,
+                search_name
+            )
+            VAlUES (
+                :name,
+                :desktop_file,
+                :desktop_file_short,
+                :description,
+                :search_name
+            )
+        """, values)
         for rec in values:
             app_db.get_icons()[rec['desktop_file']] = rec['icon']
         return app_db
@@ -48,21 +115,22 @@ class TestAppDb(object):
         force_unicode.side_effect = lambda x: x
 
     def test_remove_by_path(self, db_with_data):
-        assert db_with_data.get_by_path('jane.desktop')
-        db_with_data.remove_by_path('jane.desktop')
-        assert not db_with_data.get_by_path('jane.desktop')
+        assert db_with_data.get_by_path('/foo/jane.desktop')
+        db_with_data.remove_by_path('/foo/jane.desktop')
+        assert not db_with_data.get_by_path('/foo/jane.desktop')
 
     def test_put_app(self, app_db, get_app_icon_pixbuf, mocker):
         app = mock.MagicMock()
-        app.get_filename.return_value = 'file_name_test1'
+        app.get_filename.return_value = '/foo/file_name_test1'
         app.get_string.return_value = None
         app.get_name.return_value = 'name_test1'
         app.get_description.return_value = 'description_test1'
 
         app_db.put_app(app)
 
-        assert app_db.get_by_path('file_name_test1') == {
-            'desktop_file': 'file_name_test1',
+        assert app_db.get_by_path('/foo/file_name_test1') == {
+            'desktop_file': '/foo/file_name_test1',
+            'desktop_file_short': 'file_name_test1',
             'name': 'name_test1',
             'description': 'description_test1',
             'search_name': 'name_test1',
@@ -89,17 +157,19 @@ class TestAppDb(object):
         assert db_with_data.get_by_name('JohN') == {
             'name': 'john',
             'description': 'test',
-            'desktop_file': 'john.desktop',
+            'desktop_file': '/foo/john.desktop',
+            'desktop_file_short': 'john.desktop',
             'icon': 'icon',
             'search_name': 'john'
         }
 
     def test_get_by_path(self, db_with_data):
         # also test case insensitive search
-        assert db_with_data.get_by_path('libre.calc') == {
+        assert db_with_data.get_by_path('/foo/libre.calc') == {
             'name': 'LibreOffice Calc',
             'description': 'test',
-            'desktop_file': 'libre.calc',
+            'desktop_file': '/foo/libre.calc',
+            'desktop_file_short': 'libre.calc',
             'icon': 'icon',
             'search_name': 'LibreOffice Calc'
         }

--- a/ulauncher/search/apps/AppDb.py
+++ b/ulauncher/search/apps/AppDb.py
@@ -39,9 +39,16 @@ class AppDb(object):
 
     def _create_table(self):
         self._conn.executescript('''
-            CREATE TABLE app_db (name VARCHAR PRIMARY KEY, desktop_file VARCHAR,
-            description VARCHAR, search_name VARCHAR);
-            CREATE INDEX desktop_file_idx ON app_db (desktop_file);''')
+            CREATE TABLE app_db (
+              name VARCHAR, 
+              desktop_file VARCHAR,
+              desktop_file_short VARCHAR,
+              description VARCHAR,
+              search_name VARCHAR,
+              PRIMARY KEY (desktop_file_short)
+            );
+            CREATE INDEX desktop_file_idx ON app_db (desktop_file);
+        ''')
 
     def _row_to_rec(self, row):
         """
@@ -49,6 +56,7 @@ class AppDb(object):
         """
         return {
             'desktop_file': row['desktop_file'],
+            'desktop_file_short': row['desktop_file_short'],
             'name': row['name'],
             'description': row['description'],
             'search_name': row['search_name'],
@@ -66,14 +74,15 @@ class AppDb(object):
         exec_name = force_unicode(app.get_string('Exec') or '')
         record = {
             "desktop_file": force_unicode(app.get_filename()),
+            "desktop_file_short": force_unicode(os.path.basename(app.get_filename())),
             "description": force_unicode(app.get_description() or ''),
             "name": name,
             "search_name": search_name(name, exec_name)
         }
         self._icons[record['desktop_file']] = get_app_icon_pixbuf(app, AppResultItem.ICON_SIZE)
 
-        query = '''INSERT OR REPLACE INTO app_db (name, desktop_file, description, search_name)
-                   VALUES (:name, :desktop_file, :description, :search_name)'''
+        query = '''INSERT OR REPLACE INTO app_db (name, desktop_file, desktop_file_short, description, search_name)
+                   VALUES (:name, :desktop_file, :desktop_file_short, :description, :search_name)'''
         try:
             self._conn.execute(query, record)
             self.commit()

--- a/ulauncher/search/apps/AppDb.py
+++ b/ulauncher/search/apps/AppDb.py
@@ -40,7 +40,7 @@ class AppDb(object):
     def _create_table(self):
         self._conn.executescript('''
             CREATE TABLE app_db (
-              name VARCHAR, 
+              name VARCHAR,
               desktop_file VARCHAR,
               desktop_file_short VARCHAR,
               description VARCHAR,

--- a/ulauncher/util/desktop/reader.py
+++ b/ulauncher/util/desktop/reader.py
@@ -3,6 +3,8 @@ import logging
 from itertools import chain
 from gi.repository import Gio
 
+from collections import OrderedDict
+
 from ulauncher.util.file_finder import find_files
 from ulauncher.config import DESKTOP_DIRS, CACHE_DIR
 from ulauncher.util.Settings import Settings
@@ -17,12 +19,23 @@ def find_desktop_files(dirs=DESKTOP_DIRS):
     :param list dirs:
     :rtype: list
     """
-    files = chain.from_iterable(
+
+    all_files = chain.from_iterable(
         map(lambda f: os.path.join(f_path, f), find_files(f_path, '*.desktop')) for f_path in dirs)
+
+    # dedup desktop file according to folow XDG data dir order
+    # specifically the first file name (i.e. firefox.desktop) take precedence
+    # and other files with the same name shoudl be ignored
+    deduped_file_dict = OrderedDict()
+    for file_path in all_files:
+        file_name = os.path.basename(file_path)
+        if file_name not in deduped_file_dict:
+            deduped_file_dict[file_name] = file_path
+    deduped_files = deduped_file_dict.itervalues()
 
     blacklisted_dirs_srt = Settings.get_instance().get_property('blacklisted-desktop-dirs')
     blacklisted_dirs = blacklisted_dirs_srt.split(':') if blacklisted_dirs_srt else []
-    for file in files:
+    for file in deduped_files:
         try:
             if any([force_unicode(file).startswith(dir) for dir in blacklisted_dirs]):
                 continue


### PR DESCRIPTION
This fix addresses 2 related situations. Both fixes are needed to help Ulauncher find .desktop folders in the same way as XDG spec defines it.

Fix 1:
Dedup the scanned .desktop files following the XDG spec where only the .desktop file found in the first XDG_DATA_DIR paths is the one we use. This is not happening currently and files located in the $HOME/.local/share/applications were not found/prefered in some scenarios where they file in /usr/share or other folder were either found first or updated on user watch (i.e. upgrade of software). Specific issue encountered is that I had copied and modified a specific desktop file from `/usr/share/applications` to `~/.local/share/applications` but it was not  prefered.

Changes for this fix are only in util/desktop/reader.py

To clarify with an example:
Assuming XDG_DATA_DIR="/foo:/bar" and both /foo/firefox.desktop and /bar/firefox.desktop exist, we should always pick /foo/firefox.desktop to respect the XDG spec.

Fix 2:
If two different .desktop files have the same Name= value only one currently is shown in the search. However, per XDG spec the Name value does not need to be unique, and only the .desktop file name found in first XDG_DATA_DIR path should be (see Fix 1). Specifically I had firefox and firefox-esr packages installed side by side which had a firefox.desktop and firefox-esr.desktop both with the same name of "Firefox Web Browser". WIthout this fix only one was showing (one that was scanned after the first one and replaced first result in the sqlite db.

Changes for this fix are only in search/apps/AppdDb.py