### PR TITLE
Lowercase 'Keyword' in extensions preferences pane

### DIFF
--- a/data/preferences/src/components/pages/ExtensionConfig.vue
+++ b/data/preferences/src/components/pages/ExtensionConfig.vue
@@ -30,7 +30,7 @@
       <template v-for="pref in extension.preferences">
         <b-form-fieldset
           v-if="pref.type == 'keyword'"
-          :label="`${pref.name} Keyword`"
+          :label="`${pref.name} keyword`"
           class="keyword-input"
           :description="pref.description"
           >


### PR DESCRIPTION
I'm not a grammar expert, but I'm pretty sure Title Case should only be used in headings and in texts for names, products or companies (like "Pulp Fiction" or "America Online"). The keyword preferences capitalizes the word "Keyword", which looks quirky to me. Some keywords are lowercased too, making the labels "npm Keyword" or "md5 Keyword".

Before (with lowercased keywords)

![2018-09-23_16-37](https://user-images.githubusercontent.com/515120/45929237-04e15d00-bf4f-11e8-9827-fd09e47487fd.png)

After (with Title Cased keyword)

![screenshot from 2018-09-23 17-16-46](https://user-images.githubusercontent.com/515120/45929613-7e2f7e80-bf54-11e8-9eae-b2b0a1a8a1a0.png)
