### PR TITLE
Development toolchain cleanup

### DIFF
--- a/build-utils/build-deb.sh
+++ b/build-utils/build-deb.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 ######################
 # Builds Ulauncher.deb

--- a/build-utils/build-doc.sh
+++ b/build-utils/build-doc.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -ex
 

--- a/build-utils/build-preferences.sh
+++ b/build-utils/build-preferences.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 #############################################
 # Builds Ulauncher Preferences UI with nodejs

--- a/build-utils/build-rpm.sh
+++ b/build-utils/build-rpm.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 ######################
 # Builds Ulauncher.rpm

--- a/build-utils/build-targz.sh
+++ b/build-utils/build-targz.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 ##############################################################
 # Builds tar.gz file with (un)install script and Ulauncher src

--- a/build-utils/create-build-images.sh
+++ b/build-utils/create-build-images.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 ################################################
 # Creates Docker images for building and testing

--- a/build-utils/dev-container.sh
+++ b/build-utils/dev-container.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 ##########################################################
 # Runs Docker container to run build scripts from this dir

--- a/build-utils/extract-launchpad-ssh.sh
+++ b/build-utils/extract-launchpad-ssh.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # extracts ~/.shh for uploading package to ppa.launchpad.net via sftp
 

--- a/build-utils/functions.sh
+++ b/build-utils/functions.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 export BUILD_IMAGE=ulauncher/build-image:3.1
 export RPM_BUILD_IMAGE=ulauncher/rpm-build-image:3.0

--- a/build-utils/release.sh
+++ b/build-utils/release.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 #############################
 # Build tar.gz in a container

--- a/build-utils/send-sighup.sh
+++ b/build-utils/send-sighup.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 kill -HUP $(ps aux | grep '[u]launcher' | awk '{print $2}')
 

--- a/build-utils/travis-cli-container.sh
+++ b/build-utils/travis-cli-container.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # To encrypt AUR key:
 # $ cd ulauncher

--- a/build-utils/travis-test.sh
+++ b/build-utils/travis-test.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 #####################################
 # Runs pytests and builds preferences

--- a/build-utils/watch-doc.sh
+++ b/build-utils/watch-doc.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 cd `dirname $0`/..
 

--- a/dev-clean.sh
+++ b/dev-clean.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+
+# remove icons
+rm \
+  -v \
+  "${HOME}/.local/share/icons/hicolor/48x48/apps/ulauncher.svg" \
+  "${HOME}/.local/share/icons/hicolor/48x48/apps/ulauncher-indicator.svg" \
+  "${HOME}/.local/share/icons/hicolor/scalable/apps/ulauncher.svg" \
+  "${HOME}/.local/share/icons/hicolor/scalable/apps/ulauncher-indicator.svg" \
+  "${HOME}/.local/share/icons/gnome/scalable/apps/ulauncher.svg" \
+  "${HOME}/.local/share/icons/gnome/scalable/apps/ulauncher-indicator.svg" \
+  "${HOME}/.local/share/icons/breeze/apps/48/ulauncher-indicator.svg" \
+  "${HOME}/.local/share/icons/ubuntu-mono-dark/scalable/apps/ulauncher-indicator.svg" \
+  "${HOME}/.local/share/icons/ubuntu-mono-light/scalable/apps/ulauncher-indicator.svg" \
+  "${HOME}/.local/share/icons/elementary/scalable/apps/ulauncher-indicator.svg";
+
+# remove application folder
+rm \
+  -rv \
+  "${HOME}/.local/share/ulauncher";
+
+# remove launcher
+rm \
+ -v \
+ "${HOME}/.local/share/applications/ulauncher.desktop";

--- a/dev-nkpy.sh
+++ b/dev-nkpy.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+
+find . \( -type f -name "*.pyc" -o -type f -name "*.pyo" \) -exec rm {} \;
+find . -type d -name "__pycache__" -prune -exec rm -rf {} \;

--- a/dev-run.sh
+++ b/dev-run.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 echo "installing media files to ~/.local to be able to load icons by name"
 python setup.py install_data --install-dir="$HOME/.local" || exit 1

--- a/glade
+++ b/glade
@@ -1,3 +1,3 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 GLADE_CATALOG_SEARCH_PATH=./data/ui glade $@

--- a/setup.py
+++ b/setup.py
@@ -3,14 +3,18 @@
 
 import os
 import sys
+
 from itertools import takewhile, dropwhile
 
 try:
     import DistUtilsExtra.auto
 except ImportError:
-    print >> sys.stderr, 'To build ulauncher you need https://launchpad.net/python-distutils-extra'
+    print >> sys.stderr, "To build ulauncher you need"\
+        "https://launchpad.net/python-distutils-extra"
     sys.exit(1)
-assert DistUtilsExtra.auto.__version__ >= '2.18', 'needs DistUtilsExtra.auto >= 2.18'
+
+assert DistUtilsExtra.auto.__version__ >= '2.18', \
+    'needs DistUtilsExtra.auto >= 2.18'
 
 
 def update_config(libdir, values={}):
@@ -32,9 +36,10 @@ def update_config(libdir, values={}):
         fout.close()
         fin.close()
         os.rename(fout.name, fin.name)
-    except (OSError, IOError), e:
+    except (OSError, IOError):
         print ("ERROR: Can't find %s" % filename)
         sys.exit(1)
+
     return oldvalues
 
 
@@ -44,7 +49,8 @@ def move_desktop_file(root, target_data, prefix):
     # normal data files anywhere we want, the desktop file needs to exist in
     # the main system to be found.  Only actually useful for /opt installs.
 
-    old_desktop_path = os.path.normpath(root + target_data + '/share/applications')
+    old_desktop_path = os.path.normpath(root + target_data +
+                                        '/share/applications')
     old_desktop_file = old_desktop_path + '/ulauncher.desktop'
     desktop_path = os.path.normpath(root + prefix + '/share/applications')
     desktop_file = desktop_path + '/ulauncher.desktop'
@@ -68,6 +74,9 @@ def move_desktop_file(root, target_data, prefix):
 
 def update_desktop_file(filename, target_pkgdata, target_scripts):
 
+    def is_env(p):
+        return p == 'env' or '=' in p
+
     try:
         fin = file(filename, 'r')
         fout = file(filename + '.new', 'w')
@@ -79,8 +88,8 @@ def update_desktop_file(filename, target_pkgdata, target_scripts):
                 # persist env vars
                 env_vars = ''
                 if cmd.startswith('env '):
-                    is_env = lambda p: p == 'env' or '=' in p
-                    env_vars = ' '.join(list(takewhile(is_env, cmd.split()))) + ' '
+                    env_vars = ' '.join(list(takewhile(is_env, cmd.split()))) \
+                               + ' '
                     cmd = ' '.join(list(dropwhile(is_env, cmd.split())))
 
                 cmd = cmd.split(None, 1)
@@ -93,7 +102,7 @@ def update_desktop_file(filename, target_pkgdata, target_scripts):
         fout.close()
         fin.close()
         os.rename(fout.name, fin.name)
-    except (OSError, IOError), e:
+    except (OSError, IOError):
         print ("ERROR: Can't find %s" % filename)
         sys.exit(1)
 
@@ -104,7 +113,8 @@ class InstallAndUpdateDataDirectory(DistUtilsExtra.auto.install_auto):
 
         target_data = '/' + os.path.relpath(self.install_data, self.root) + '/'
         target_pkgdata = target_data + 'share/ulauncher/'
-        target_scripts = '/' + os.path.relpath(self.install_scripts, self.root) + '/'
+        target_scripts = '/' + os.path.relpath(self.install_scripts,
+                                               self.root) + '/'
 
         values = {'__ulauncher_data_directory__': "'%s'" % (target_pkgdata),
                   '__version__': "'%s'" % self.distribution.get_version()}
@@ -117,9 +127,11 @@ class InstallAndUpdateDataDirectory(DistUtilsExtra.auto.install_auto):
 class DataFileList(list):
 
     def append(self, item):
-        # don't add node_modules to data_files that DistUtilsExtra tries to add automatically
+        # don't add node_modules to data_files that DistUtilsExtra tries to
+        # add automatically
         filename = item[1][0]
-        if 'node_modules' in filename or 'bower_components' in filename or '.tmp' in filename:
+        if 'node_modules' in filename \
+           or 'bower_components' in filename or '.tmp' in filename:
             return
         else:
             return super(DataFileList, self).append(item)
@@ -187,19 +199,38 @@ def main():
         description='Application launcher for Linux',
         url='http://ulauncher.io',
         data_files=DataFileList([
-            ('share/icons/hicolor/48x48/apps', ['data/media/icons/hicolor/ulauncher.svg']),
-            ('share/icons/hicolor/48x48/apps', ['data/media/icons/hicolor/ulauncher-indicator.svg']),
-            ('share/icons/hicolor/scalable/apps', ['data/media/icons/hicolor/ulauncher.svg']),
-            ('share/icons/hicolor/scalable/apps', ['data/media/icons/hicolor/ulauncher-indicator.svg']),
-
-            # these two are fore Fedora+gnome
-            ('share/icons/gnome/scalable/apps', ['data/media/icons/hicolor/ulauncher.svg']),
-            ('share/icons/gnome/scalable/apps', ['data/media/icons/hicolor/ulauncher-indicator.svg']),
-
-            ('share/icons/breeze/apps/48', ['data/media/icons/ubuntu-mono-light/ulauncher-indicator.svg']),
-            ('share/icons/ubuntu-mono-dark/scalable/apps', ['data/media/icons/ubuntu-mono-dark/ulauncher-indicator.svg']),
-            ('share/icons/ubuntu-mono-light/scalable/apps', ['data/media/icons/ubuntu-mono-light/ulauncher-indicator.svg']),
-            ('share/icons/elementary/scalable/apps', ['data/media/icons/elementary/ulauncher-indicator.svg']),
+            ('share/icons/hicolor/48x48/apps', [
+                'data/media/icons/hicolor/ulauncher.svg'
+            ]),
+            ('share/icons/hicolor/48x48/apps', [
+                'data/media/icons/hicolor/ulauncher-indicator.svg'
+            ]),
+            ('share/icons/hicolor/scalable/apps', [
+                'data/media/icons/hicolor/ulauncher.svg'
+            ]),
+            ('share/icons/hicolor/scalable/apps', [
+                'data/media/icons/hicolor/ulauncher-indicator.svg'
+            ]),
+            # for fedora + GNOME
+            ('share/icons/gnome/scalable/apps', [
+                'data/media/icons/hicolor/ulauncher.svg'
+            ]),
+            ('share/icons/gnome/scalable/apps', [
+                'data/media/icons/hicolor/ulauncher-indicator.svg'
+            ]),
+            # for ubuntu
+            ('share/icons/breeze/apps/48', [
+                'data/media/icons/ubuntu-mono-light/ulauncher-indicator.svg'
+            ]),
+            ('share/icons/ubuntu-mono-dark/scalable/apps', [
+                'data/media/icons/ubuntu-mono-dark/ulauncher-indicator.svg'
+            ]),
+            ('share/icons/ubuntu-mono-light/scalable/apps', [
+                'data/media/icons/ubuntu-mono-light/ulauncher-indicator.svg'
+            ]),
+            ('share/icons/elementary/scalable/apps', [
+                'data/media/icons/elementary/ulauncher-indicator.svg'
+            ]),
         ]),
         cmdclass={'install': InstallAndUpdateDataDirectory}
     )

--- a/test
+++ b/test
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Some tests will fail in Docker unless virtual frame buffer is running
 if [ -f /.dockerenv ]; then


### PR DESCRIPTION
Hi @gornostal,

This PR has changes I found helped me develop. Each category of change is broken up in individual commit in case you only like some. If you do not like any, I understand, I'll sidecar them for my own development. The changes are:

1. Change all bash sheebangs from '#!/bin/bash` to '#!/usr/bin/env bash'
 
**Rationale:** not all linux systems have /bin/bash and common practice to fix this is to use /usr/bin/env

2. Added dev-clean.sh and dev-nkpy.sh

**Rationale:**
 
dev-clean.sh removes the files installed by dev-run.sh, which means that system level working ulauncher can now be used.

dev-nkpy.sh is useful to remove pyc/pyo and __pycache__ folder. This ESPECIALLY helps when the pyc files are generated inside the docker container during the test run and end up being owned by `root:root` with permission of `rw-r-r both` in docker and on the host system which prevents their regeneration when their respective py files are changed.

3. Stop DistUtilsExtra.auto from poluting stdout with a large set of mostly useless messages about which files it does not recognize (and hence can not handle). It forces one to always scroll past them during development which can be frustrating. Message look like this
```
WARNING: the following files are not recognized by DistUtilsExtra.auto:
Dockerfile.build
Dockerfile.build-arch
Dockerfile.build-rpm
PKGBUILD.template
build-utils/aur-update.py
...
```
If you still need these messages during packaging I can add environmental variable work around which will show them when needed. **Action item: let me know if you need this**

4. I applied pep8 to setup.py (minor change if it bothers you I'll revert it)