### PR TITLE
Add default terminal setting for desktop entries

### DIFF
--- a/data/preferences/src/components/pages/Preferences.vue
+++ b/data/preferences/src/components/pages/Preferences.vue
@@ -87,7 +87,7 @@
     <table>
       <tr>
         <td>
-          <label for="terminal-exec">Terminal launch command</label>
+          <label for="terminal-exec">Terminal Launch Command</label>
         </td>
         <td>
           <b-form-input

--- a/data/preferences/src/components/pages/Preferences.vue
+++ b/data/preferences/src/components/pages/Preferences.vue
@@ -86,6 +86,17 @@
 
     <table>
       <tr>
+        <td>
+          <label for="terminal-exec">Terminal launch command</label>
+        </td>
+        <td>
+          <b-form-input
+            style="width:250px"
+            id="terminal-exec"
+            v-model="terminal_exec"></b-form-input>
+        </td>
+      </tr>
+      <tr>
         <td class="pull-top">
           <label>Blacklisted App Dirs</label>
           <small>
@@ -176,6 +187,18 @@ export default {
       set(value) {
         return jsonp('prefs://set/show-recent-apps', { value: value }).then(
           () => this.setPrefs({ show_recent_apps: value }),
+          err => bus.$emit('error', err)
+        )
+      }
+    },
+
+    terminal_exec: {
+      get() {
+        return this.prefs.terminal_exec
+      },
+      set(value) {
+        return jsonp('prefs://set/terminal-exec', { value: value }).then(
+          () => this.setPrefs({ terminal_exec: value }),
           err => bus.$emit('error', err)
         )
       }

--- a/ulauncher/api/shared/action/LaunchAppAction.py
+++ b/ulauncher/api/shared/action/LaunchAppAction.py
@@ -1,10 +1,14 @@
 import logging
+import pipes
+import subprocess
 
 from ulauncher.util.desktop.reader import read_desktop_file
 from ulauncher.util.string import force_unicode
+from ulauncher.util.Settings import Settings
 from .BaseAction import BaseAction
 
 logger = logging.getLogger(__name__)
+settings = Settings.get_instance()
 
 
 class LaunchAppAction(BaseAction):
@@ -22,5 +26,11 @@ class LaunchAppAction(BaseAction):
 
     def run(self):
         app = read_desktop_file(self.filename)
-        logger.info('Run application %s (%s)' % (force_unicode(app.get_name()), self.filename))
-        app.launch()
+        command = app.get_string('Exec')
+        terminal_exec = settings.get_property('terminal-exec')
+        if app.get_boolean('Terminal') and terminal_exec and command:
+            logger.info('Run command %s (%s) in preferred terminal (%s)' % (command, self.filename, terminal_exec))
+            subprocess.Popen(terminal_exec.split() + [pipes.quote(command)])
+        else:
+            logger.info('Run application %s (%s)' % (force_unicode(app.get_name()), self.filename))
+            app.launch()

--- a/ulauncher/ui/windows/PreferencesUlauncherDialog.py
+++ b/ulauncher/ui/windows/PreferencesUlauncherDialog.py
@@ -194,6 +194,7 @@ class PreferencesUlauncherDialog(Gtk.Dialog, WindowHelper):
             'available_themes': self._get_available_themes(),
             'theme_name': Theme.get_current().get_name(),
             'is_wayland': is_wayland(),
+            'terminal_exec': self.settings.get_property('terminal-exec'),
             'env': {
                 'version': get_version(),
                 'user_home': os.path.expanduser('~')
@@ -253,6 +254,13 @@ class PreferencesUlauncherDialog(Gtk.Dialog, WindowHelper):
         from ulauncher.ui.windows.UlauncherWindow import UlauncherWindow
         ulauncher_window = UlauncherWindow.get_instance()
         ulauncher_window.init_theme()
+
+    @rt.route('/set/terminal-exec')
+    def prefs_set_terminal_exec(self, url_params):
+        terminal_exec = url_params['query']['value']
+        logger.info('Set terminal launch command to %s' % terminal_exec)
+        self.settings.set_property('terminal-exec', terminal_exec)
+        self.settings.save_to_file()
 
     @rt.route('/show/hotkey-dialog')
     @glib_idle_add

--- a/ulauncher/util/Settings.py
+++ b/ulauncher/util/Settings.py
@@ -48,6 +48,11 @@ GPROPERTIES = {
                                  None,
                                  ':'.join(DEFAULT_BLACKLISTED_DIRS),
                                  GObject.PARAM_READWRITE),
+    "terminal-exec": (str,
+                   "Terminal command",
+                   None,
+                   "",
+                   GObject.PARAM_READWRITE),
 }
 
 


### PR DESCRIPTION
See #295 

@goodwillcoding suggested auto-detecting *could* be possible. I don't think it is, but I may have missed something. The `TERM`-variable is not for this and the dconf entries are deprecated. So even if I could use them I think that would be making matters worse.

Either way, I made it into a setting "terminal-exec", which is added to the advanced section of the preferences window as "Terminal Launch Command" (not thrilled about the name but I needed to fine one that implied that the exec argument should be included).

It updates with the "change"-event, so when the focus is lost after having changed, rather than when it actually changes.

![screenshot from 2018-09-30 23-38-15](https://user-images.githubusercontent.com/515120/46263047-3f786600-c50a-11e8-858e-3aa91e3faaaf.png)

The exec flag is usually `-e` or `-x` it seems (with somewhat different meanings). For gnome-terminal it's `--` though.