### PR TITLE
Implemented RenderAppchooserAction

### DIFF
--- a/data/ui/UlauncherWindow.ui
+++ b/data/ui/UlauncherWindow.ui
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!-- Generated with glade 3.18.3 -->
+<!-- Generated with glade 3.22.1 -->
 <interface>
   <requires lib="gtk+" version="3.8"/>
   <requires lib="ulauncher_window" version="1.0"/>
@@ -17,6 +17,9 @@
     <property name="urgency_hint">True</property>
     <property name="decorated">False</property>
     <property name="deletable">False</property>
+    <child>
+      <placeholder/>
+    </child>
     <child>
       <object class="GtkBox" id="body">
         <property name="visible">True</property>
@@ -57,10 +60,11 @@
             <child>
               <object class="GtkButton" id="prefs_btn">
                 <property name="name">prefs_btn</property>
-                <property name="height_request">24</property>
                 <property name="width_request">24</property>
+                <property name="height_request">24</property>
                 <property name="visible">True</property>
                 <property name="can_focus">False</property>
+                <property name="receives_default">False</property>
                 <property name="halign">center</property>
                 <property name="valign">center</property>
                 <property name="margin_right">15</property>
@@ -104,6 +108,9 @@
             <property name="fill">True</property>
             <property name="position">1</property>
           </packing>
+        </child>
+        <child>
+          <placeholder/>
         </child>
         <style>
           <class name="app"/>

--- a/ulauncher/api/shared/action/RenderAppchooserAction.py
+++ b/ulauncher/api/shared/action/RenderAppchooserAction.py
@@ -1,0 +1,24 @@
+from gi.repository import GLib
+from .BaseAction import BaseAction
+
+
+class RenderAppchooserAction(BaseAction):
+    """
+    Renders list of result items
+
+    :param list result_list: list of :class:`~ulauncher.api.shared.item.ResultItem.ResultItem` objects
+    """
+
+    def __init__(self, path):
+        self.path = path
+
+    def keep_app_open(self):
+        return True
+
+    def run(self):
+        from ulauncher.ui.windows.UlauncherWindow import UlauncherWindow
+
+        window = UlauncherWindow.get_instance()
+        if window.is_visible():
+            # update UI in the main thread to avoid race conditions
+            GLib.idle_add(window.show_appchooser, self.path)

--- a/ulauncher/ui/windows/UlauncherWindow.py
+++ b/ulauncher/ui/windows/UlauncherWindow.py
@@ -13,7 +13,7 @@ gi.require_version('Gdk', '3.0')
 gi.require_version('GLib', '2.0')
 gi.require_version('Keybinder', '3.0')
 
-from gi.repository import Gtk, Gdk, GLib, Gio, Keybinder
+from gi.repository import Gtk, Gdk, GLib, Keybinder
 
 # these imports are needed for Gtk to find widget classes
 from ulauncher.ui.ResultItemWidget import ResultItemWidget
@@ -83,8 +83,6 @@ class UlauncherWindow(Gtk.Window, WindowHelper):
         self.input = self.ui['input']
         self.prefs_btn = self.ui['prefs_btn']
         self.result_box = self.ui["result_box"]
-
-        self.result_box_parent = self.result_box.get_parent()
 
         self.result_box_parent = self.result_box.get_parent()
 


### PR DESCRIPTION
### Link to related issue (if applicable)
<!--
This is not required, but for your own sake you may want to ensure before putting a lot of time on a PR, that the change is something we want to add and support. If there isn't an issue for it, you're welcome to create one.
-->

### Summary of the changes in this PR
This functionality is implemented in the (development version of the) [Tracker/docfetcher/locate plugin](https://github.com/dalanicolai/gnome-tracker-extension/tree/devel). First search for a file, then choose 'Open with OTHER application'

I changed the .ui file so that the Gtk.box with id=body can hold three number of item. In this way the appchooserwidget can be added and removed from the body (without destroying the result_box), in a similar way as the item_widgets are added and destroyed in the result_box.

Then I more or less copied and adapted the RenderResultListAction file, to run the show_appchooser method from the new RenderAppchooserAction file.

Finally I added a Try-Exec to test for existence of the appchooser, otherwise the launcher will hang on its first start. If the appchooser exists than it is first removed before the result list is created/rendered.

Finally, the show_apchooser method first removes the item_widgets and subsequently creates and the appshooser widget, which takes a filepath as argument, and launches the file with the chosen application and hides again the UlauncherWindow.


### Checklist (see more [here](https://github.com/Ulauncher/Ulauncher/wiki/Code-Contribution))
- [ ] Use `dev` as the base branch
- [ ] Follow the [Python Code Style Guides](https://github.com/Ulauncher/Ulauncher/wiki/Python-Code-Style-Guides)
- [ ] Write unit tests for your changes when applicable.
- [ ] If your changes alters the behavior or introduce new functionality, please update the documentation accordingly.
- [ ] All tests are passing

### Tested environment (distro, desktop environment and their versions)
