### PR TITLE
Open file in background when using file browser

### DIFF
--- a/ulauncher/api/shared/action/OpenAction.py
+++ b/ulauncher/api/shared/action/OpenAction.py
@@ -19,8 +19,8 @@ class OpenAction(BaseAction):
 
     def run(self):
         if sys.platform.startswith('darwin'):
-            subprocess.call(('open', self.path))
+            subprocess.Popen(['open', self.path])
         elif os.name == 'nt':
             os.startfile(self.path)
         elif os.name == 'posix':
-            subprocess.call(('xdg-open', self.path))
+            subprocess.Popen(['xdg-open', self.path])


### PR DESCRIPTION
Fixes issue #355 

### Summary of the changes in this PR
Change from `subprocess.call` to `subprocess.Popen`:

- `call` waits for the child process to end
- `Popen` runs the child process in background

### Tested environment
ArchLinux, i3wm 4.46.1
