### PR TITLE
Allow apps to launch with default GDK_BACKEND

### DIFF
--- a/ulauncher/config.py
+++ b/ulauncher/config.py
@@ -69,7 +69,7 @@ def is_wayland_compatibility_on():
     In this mode user won't be able to set app hotkey via preferences
     Set hotkey in OS Settings > Devices > Keyboard > Add Hotkey > Command: ulauncher-toggle
     """
-    return is_wayland() and gdk_backend().lower() == 'wayland'
+    return is_wayland() and (gdk_backend().lower() == 'wayland' or gdk_backend() == '')
 
 
 def gdk_backend():

--- a/ulauncher/main.py
+++ b/ulauncher/main.py
@@ -14,7 +14,7 @@ gi.require_version('Gtk', '3.0')
 
 # pylint: disable=wrong-import-position
 from ulauncher.config import (get_version, get_options, is_wayland, is_wayland_compatibility_on,
-                              gdk_backend, CACHE_DIR, CONFIG_DIR)
+                              CACHE_DIR, CONFIG_DIR)
 from ulauncher.utils.decorator.run_async import run_async
 from ulauncher.ui.windows.UlauncherWindow import UlauncherWindow
 from ulauncher.ui.AppIndicator import AppIndicator
@@ -80,18 +80,6 @@ def main():
     """
     Main function that starts everything
     """
-    if is_wayland() and gdk_backend().lower() != 'x11' and not is_wayland_compatibility_on():
-        warn = """
-                    [!]
-        Looks like you are in Wayland session
-        Please run Ulauncher with env var
-        GDK_BACKEND set to 'x11' like this:
-
-        GDK_BACKEND=x11 ulauncher
-        """
-        print(warn, file=sys.stderr)
-        sys.exit(1)
-
     # start DBus loop
     DBusGMainLoop(set_as_default=True)
     bus = dbus.SessionBus()


### PR DESCRIPTION
### Link to related issue

Fixes https://github.com/Ulauncher/Ulauncher/issues/363

### Summary of the changes in this PR

Removes requirement to explicity set GDK_BACKEND under wayland

~~This allows both wayland and X11 apps to be launched side by side, and removes the need for wayland users to set an additional env var.~~ **Edit:** This will result in apps being launched in X11 mode rather than using wayland.

This is an alternative approach to setting and then unsetting it as taken in https://github.com/Ulauncher/Ulauncher/compare/issue-363-unset-gdk-backend, and probably a simpler solution long term.

To solve the centering problem mentioned in https://github.com/Ulauncher/Ulauncher/issues/183#issuecomment-358937630 and https://github.com/Ulauncher/Ulauncher/issues/363#issuecomment-484353470 we may wish to more explicitly check for the incompatible wayland implementation or find a longer term fix.

### Checklist (see more [here](https://github.com/Ulauncher/Ulauncher/wiki/Code-Contribution))
- [x] Use `dev` as the base branch
- [x] Follow the [Python Code Style Guides](https://github.com/Ulauncher/Ulauncher/wiki/Python-Code-Style-Guides)
- [ ] Write unit tests for your changes when applicable
- [ ] If your changes alters the behavior or introduce new functionality, please update the documentation accordingly
- [x] All tests are passing

### Tested environment (distro, desktop environment and their versions)

SwayWM under Ubuntu.

```
uname -a
Linux 9694cd126e43 4.18.0-17-generic #18~18.04.1-Ubuntu SMP Fri Mar 15 15:27:12 UTC 2019 x86_64 x86_64 x86_64 GNU/Linux
```

```
sway|master» git --no-pager log HEAD --no-walk          
commit fc3253cc35b123ae5d21db3379ad0acf43ad0c20 (HEAD -> master, origin/master, origin/HEAD)
Date:   Wed Jun 19 01:34:07 2019 -0400
```