### PR TITLE
Treat some data as persistent and save them in XDG_DATA_HOME

### DIFF
--- a/docs/extensions/tutorial.rst
+++ b/docs/extensions/tutorial.rst
@@ -4,7 +4,7 @@ Development Tutorial
 Creating a Project
 ------------------
 
-Ulauncher runs all extensions from ``~/.cache/ulauncher_cache/extensions/``.
+Ulauncher runs all extensions from ``~/.local/share/ulauncher/extensions/``.
 
 Create a new directory there (name it as you wish) with the following structure::
 

--- a/ulauncher/config.py
+++ b/ulauncher/config.py
@@ -14,8 +14,9 @@ from time import time
 from functools import lru_cache
 
 from gettext import gettext
-from xdg.BaseDirectory import xdg_config_home, xdg_cache_home, xdg_data_dirs
+from xdg.BaseDirectory import xdg_config_home, xdg_cache_home, xdg_data_dirs, xdg_data_home
 
+DATA_DIR = os.path.join(xdg_data_home, 'ulauncher')
 # Use ulauncher_cache dir because of the WebKit bug
 # https://bugs.webkit.org/show_bug.cgi?id=151646
 CACHE_DIR = os.path.join(xdg_cache_home, 'ulauncher_cache')
@@ -23,7 +24,7 @@ CONFIG_DIR = os.path.join(xdg_config_home, 'ulauncher')
 SETTINGS_FILE_PATH = os.path.join(CONFIG_DIR, 'settings.json')
 # spec: https://specifications.freedesktop.org/menu-spec/latest/ar01s02.html
 DESKTOP_DIRS = list(filter(os.path.exists, [os.path.join(dir, "applications") for dir in xdg_data_dirs]))
-EXTENSIONS_DIR = os.path.join(CACHE_DIR, 'extensions')
+EXTENSIONS_DIR = os.path.join(DATA_DIR, 'extensions')
 EXT_PREFERENCES_DIR = os.path.join(CONFIG_DIR, 'ext_preferences')
 ULAUNCHER_APP_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), '..'))
 

--- a/ulauncher/main.py
+++ b/ulauncher/main.py
@@ -14,7 +14,7 @@ gi.require_version('Gtk', '3.0')
 
 # pylint: disable=wrong-import-position
 from ulauncher.config import (get_version, get_options, is_wayland, is_wayland_compatibility_on,
-                              gdk_backend, CACHE_DIR, CONFIG_DIR)
+                              gdk_backend, CACHE_DIR, CONFIG_DIR, DATA_DIR)
 from ulauncher.utils.decorator.run_async import run_async
 from ulauncher.ui.windows.UlauncherWindow import UlauncherWindow
 from ulauncher.ui.AppIndicator import AppIndicator
@@ -30,6 +30,9 @@ DBUS_PATH = '/net/launchpad/ulauncher'
 def _create_dirs():
     if not os.path.exists(CONFIG_DIR):
         os.makedirs(CONFIG_DIR)
+
+    if not os.path.exists(DATA_DIR):
+        os.makedirs(DATA_DIR)
 
     # make sure ~/.cache/ulauncher exists
     if not os.path.exists(CACHE_DIR):

--- a/ulauncher/search/QueryHistoryDb.py
+++ b/ulauncher/search/QueryHistoryDb.py
@@ -1,5 +1,5 @@
 import os
-from ulauncher.config import CACHE_DIR
+from ulauncher.config import DATA_DIR
 from ulauncher.utils.db.KeyValueDb import KeyValueDb
 from ulauncher.utils.decorator.singleton import singleton
 
@@ -9,7 +9,7 @@ class QueryHistoryDb(KeyValueDb):
     @classmethod
     @singleton
     def get_instance(cls):
-        db = cls(os.path.join(CACHE_DIR, 'query_history.db'))
+        db = cls(os.path.join(DATA_DIR, 'query_history.db'))
         db.open()
         return db
 

--- a/ulauncher/search/apps/AppStatDb.py
+++ b/ulauncher/search/apps/AppStatDb.py
@@ -2,7 +2,7 @@ import os
 from operator import itemgetter
 from itertools import islice
 
-from ulauncher.config import CACHE_DIR
+from ulauncher.config import DATA_DIR
 from ulauncher.utils.db.KeyValueDb import KeyValueDb
 from ulauncher.utils.decorator.singleton import singleton
 
@@ -15,7 +15,7 @@ class AppStatDb(KeyValueDb):
     @classmethod
     @singleton
     def get_instance(cls):
-        return cls(os.path.join(CACHE_DIR, 'app_stat_v2.db')).open()
+        return cls(os.path.join(DATA_DIR, 'app_stat_v2.db')).open()
 
     def inc_count(self, path):
         count = self._records.get(path, 0)

--- a/ulauncher/utils/setup_logging.py
+++ b/ulauncher/utils/setup_logging.py
@@ -1,7 +1,7 @@
 import os
 import logging
 from copy import copy
-from ulauncher.config import CACHE_DIR
+from ulauncher.config import DATA_DIR
 
 
 # The background is set with 40 plus the number of the color, and the foreground with 30
@@ -47,7 +47,7 @@ def setup_logging(opts):
     root.addHandler(stream_handler)
 
     # set up login to a file
-    log_file = os.path.join(CACHE_DIR, 'last.log')
+    log_file = os.path.join(DATA_DIR, 'last.log')
     if os.path.exists(log_file):
         os.remove(log_file)
 


### PR DESCRIPTION
### Link to related issue (if applicable)

#152, #347

### Summary of the changes in this PR

Implement #347.

> A cache [...] stores data so future requests for that data can be served faster [...]. — https://en.wikipedia.org/wiki/Cache_(computing)

These existing uses of `CACHE_DIR` record history, so they should not be considered cache:

- QueryHistoryDb
- AppStatDb
- Logging

I've also made it so that extensions are saved in `DATA_DIR` (the new variable pointing to `xdg-data-home`). While extensions can be "recomputed" (i.e. downloaded again), it takes a relatively long time to download them, and not too much space to store them persistently. This is in fact what bit me initially: I made my system clear the cache on shut down because I don't care about a cache from the previous session, but with Ulauncher extensions being treated as cache I'd have to wait an unpredictable amount of time after login before they can be used again.

### Checklist (see more [here](https://github.com/Ulauncher/Ulauncher/wiki/Code-Contribution))
- [x] Use `dev` as the base branch
- [x] Follow the [Python Code Style Guides](https://github.com/Ulauncher/Ulauncher/wiki/Python-Code-Style-Guides)
- [X] Write unit tests for your changes when applicable
- [x] If your changes alter the behavior or introduce new functionality, please update the documentation accordingly
- [X] All tests are passing

### Tested environment (distro, desktop environment and their versions)

- Arch Linux, Python 3.7.4, KDE Plasma 5.16.4