### PR TITLE
Make window visible before requesting move.

### DIFF
--- a/ulauncher/ui/windows/UlauncherWindow.py
+++ b/ulauncher/ui/windows/UlauncherWindow.py
@@ -247,9 +247,9 @@ class UlauncherWindow(Gtk.Window, WindowHelper):
 
     def show_window(self):
         # works only when the following methods are called in that exact order
-        self.position_window()
         self.window.set_sensitive(True)
         self.window.present()
+        self.position_window()
         if not is_wayland_compatibility_on():
             self.present_with_time(Keybinder.get_current_event_time())
 


### PR DESCRIPTION
<!--
Thank you for submitting a PR to Ulauncher!

You can also read more about contributing in this document:
https://github.com/Ulauncher/Ulauncher/wiki/Code-Contribution
-->
### Link to related issue (if applicable)

#349 #205
<!--
This is not required, but for your own sake you may want to ensure before putting a lot of time on a PR, that the change is something we want to add and support. If there isn't an issue for it, you're welcome to create one.
-->

### Summary of the changes in this PR

On LXDE Ubuntu 18.04 with i3-gaps, I was consistently having an issue with the window jumping all over the place.   The location would be correct on a fresh launch, then wrong every time after that.

I traced the issue to [the Python gtk.Window docs](https://developer.gnome.org/pygtk/stable/class-gtkwindow.html#move)

> The move() method asks the window manager to move the window to the position specified by x and y. Window managers are free to ignore this. In fact, most window managers ignore requests for initial window positions (instead using a user-defined placement algorithm) and honor requests after the window has already been shown.

As far as I can tell, my window manager (and most of them) are ignoring the request for initial position before the window is presented. I made this change and the launcher shows up at the right location every time now.

### Checklist (see more [here](https://github.com/Ulauncher/Ulauncher/wiki/Code-Contribution))
- [x] Use `dev` as the base branch
- [x] Follow the [Python Code Style Guides](https://github.com/Ulauncher/Ulauncher/wiki/Python-Code-Style-Guides)
- [ ] Write unit tests for your changes when applicable (NA)
- [ ] If your changes alters the behavior or introduce new functionality, please update the documentation accordingly (NA)
- [x] All tests are passing

### Tested environment (distro, desktop environment and their versions)

* LXDE
* Ubuntu 18.04
* i3-gaps
