### PR TITLE
Move gi.require_version() to the proper place

### DIFF
--- a/ulauncher/main.py
+++ b/ulauncher/main.py
@@ -5,14 +5,13 @@ import logging
 import time
 from threading import Event
 import gi
+gi.require_version('Gtk', '3.0')
+# pylint: disable=wrong-import-position
 from gi.repository import Gtk
 import dbus
 import dbus.service
 from dbus.mainloop.glib import DBusGMainLoop
 
-gi.require_version('Gtk', '3.0')
-
-# pylint: disable=wrong-import-position
 from ulauncher.config import (get_version, get_options, is_wayland, is_wayland_compatibility_on,
                               gdk_backend, CACHE_DIR, CONFIG_DIR, DATA_DIR)
 from ulauncher.utils.decorator.run_async import run_async


### PR DESCRIPTION
<!--
Thank you for submitting a PR to Ulauncher!

You can also read more about contributing in this document:
https://github.com/Ulauncher/Ulauncher/wiki/Code-Contribution
-->

### Summary of the changes in this PR
When `from gi.repository import Gtk` is called before `gi.require_version('Gtk', '3.0')`, the latter has no effect and Gtk version is not ensured, as evidenced by the message
```
/usr/lib/python3/dist-packages/ulauncher/main.py:8: PyGIWarning: Gtk was imported without specifying a version first. Use gi.require_version('Gtk', '3.0') before import to ensure that the right version gets loaded.
  from gi.repository import Gtk
```
This tiny PR fixes that.

### Checklist (see more [here](https://github.com/Ulauncher/Ulauncher/wiki/Code-Contribution))
- [x] Use `dev` as the base branch
- [x] Follow the [Python Code Style Guides](https://github.com/Ulauncher/Ulauncher/wiki/Python-Code-Style-Guides)
- [x] Write unit tests for your changes when applicable
- [x] If your changes alters the behavior or introduce new functionality, please update the documentation accordingly
- [x] All tests are passing

### Tested environment (distro, desktop environment and their versions)
This doesn't really matter, but it's
```
Distributor ID:	elementary
Description:	elementary OS 5.0 Juno
Release:	5.0
Codename:	juno
```
