### PR TITLE
Skip adding some.desktop file in the database if it is superceded by it's counterpart in XDG_DIRS

### DIFF
--- a/ulauncher/utils/desktop/reader.py
+++ b/ulauncher/utils/desktop/reader.py
@@ -14,7 +14,7 @@ from ulauncher.utils.db.KeyValueDb import KeyValueDb
 logger = logging.getLogger(__name__)
 
 
-def find_desktop_files(dirs: List[str] = None) -> Generator[str, None, None]:
+def find_desktop_files(dirs: List[str] = None, pattern: str = "*.desktop") -> Generator[str, None, None]:
     """
     :param list dirs:
     :rtype: list
@@ -25,7 +25,7 @@ def find_desktop_files(dirs: List[str] = None) -> Generator[str, None, None]:
 
     # pylint: disable=cell-var-from-loop
     all_files = chain.from_iterable(
-        map(lambda f: os.path.join(f_path, f), find_files(f_path, '*.desktop')) for f_path in dirs)
+        map(lambda f: os.path.join(f_path, f), find_files(f_path, pattern)) for f_path in dirs)
 
     # dedup desktop file according to follow XDG data dir order
     # specifically the first file name (i.e. firefox.desktop) take precedence


### PR DESCRIPTION
### Summary of the changes in this PR
Currently when some.desktop file exists in more then one XDG_DIR and one of them is updated (for example via apt-get upgrade installing new version) the some.desktop file is added to the database. This PR prevents this by checing if the updated some.desktop is in the path in the superceded XDG directory. This avoid duplicates.

A more specific case I encountered was when I had a $HOME/.local/share/applications/some.desktop hiding a desktop entry in /usr/share/applications/some.desktop ... upon upgrade of the package containing some.desktop the hidden entry would be shown

### Checklist (see more [here](https://github.com/Ulauncher/Ulauncher/wiki/Code-Contribution))
- [x] Use `dev` as the base branch
- [x] Follow the [Python Code Style Guides](https://github.com/Ulauncher/Ulauncher/wiki/Python-Code-Style-Guides)
- [x] Write unit tests for your changes when applicable
- [x] If your changes alters the behavior or introduce new functionality, please update the documentation accordingly
- [x] All tests are passing

### Tested environment (distro, desktop environment and their versions)
Ubuntu 18.04.3