### PR TITLE
Fall back to GenericName field if Comment field is missing

### DIFF
--- a/ulauncher/search/apps/AppDb.py
+++ b/ulauncher/search/apps/AppDb.py
@@ -70,10 +70,13 @@ class AppDb:
         """
         name = app.get_string('X-GNOME-FullName') or app.get_name()
         exec_name = app.get_string('Exec') or ''
+        description = app.get_description() or ''
+        if not description and (app.get_generic_name() != name):
+            description = app.get_generic_name() or ''
         record = {
             "desktop_file": app.get_filename(),
             "desktop_file_short": os.path.basename(app.get_filename()),
-            "description": app.get_description() or '',
+            "description": description,
             "name": name,
             "search_name": search_name(name, exec_name)
         }


### PR DESCRIPTION
<!--
Thank you for submitting a PR to Ulauncher!

You can also read more about contributing in this document:
https://github.com/Ulauncher/Ulauncher/wiki/Code-Contribution
-->
### Link to related issue (if applicable)

This pull request resolves #510.

<!--
This is not required, but for your own sake you may want to ensure before putting a lot of time on a PR, that the change is something we want to add and support. If there isn't an issue for it, you're welcome to create one.
-->

### Summary of the changes in this PR

If a .desktop file doesn't have the `Comment` field, the `GenericName` field's value will be used to set description for an application record, unless it's the same as the `Name` field's value.

### Checklist (see more [here](https://github.com/Ulauncher/Ulauncher/wiki/Code-Contribution))
- [x] Use `dev` as the base branch
- [x] Follow the [Python Code Style Guides](https://github.com/Ulauncher/Ulauncher/wiki/Python-Code-Style-Guides)
- [ ] Write unit tests for your changes when applicable
- [ ] If your changes alters the behavior or introduce new functionality, please update the documentation accordingly
- [x] All tests are passing

### Tested environment (distro, desktop environment and their versions)

Kubuntu 19.10
KDE Plasma 5.17.5