### PR TITLE
Fix: GDK_BACKEND is not a reliable indicator of a wayland session

### DIFF
--- a/ulauncher/config.py
+++ b/ulauncher/config.py
@@ -69,8 +69,9 @@ def is_wayland_compatibility_on():
     """
     In this mode user won't be able to set app hotkey via preferences
     Set hotkey in OS Settings > Devices > Keyboard > Add Hotkey > Command: ulauncher-toggle
+    GDK_BACKEND is typically unset in Wayland sessions to allow GTK apps to self-select
     """
-    return is_wayland() and gdk_backend().lower() == 'wayland'
+    return is_wayland() and gdk_backend().lower() in ('wayland', '')
 
 
 def gdk_backend():


### PR DESCRIPTION
### Link to related issue (if applicable)
n/a

### Summary of the changes in this PR
Wayland sessions typically do not set `GDK_BACKEND` to anything - not even gnome. The reason for this is that it forces GDK apps to use wayland, but also any other GDK apps launched from it which might break in unexpected ways. GTK auto selects the right backend instead. This is why firefox recommends using `MOZ_ENABLE_WAYLAND` for instance.

Tweak the wayland detector accordingly.


### Checklist (see more [here](https://github.com/Ulauncher/Ulauncher/wiki/Code-Contribution))
- [x] Use `dev` as the base branch
- [x] Follow the [Python Code Style Guides](https://github.com/Ulauncher/Ulauncher/wiki/Python-Code-Style-Guides)
- [ ] Write unit tests for your changes when applicable
- [x] If your changes alters the behavior or introduce new functionality, please update the documentation accordingly
- [x] All tests are passing

### Tested environment (distro, desktop environment and their versions)
Ubuntu 19.10, Gnome (wayland / x11), Sway 1.4, Mate 1.22 (x11)
