### PR TITLE
Allow $ as a keyword

### DIFF
--- a/ulauncher/search/file_browser/FileBrowserMode.py
+++ b/ulauncher/search/file_browser/FileBrowserMode.py
@@ -27,7 +27,7 @@ class FileBrowserMode(BaseSearchMode):
         /usr/bin/foo
         """
         try:
-            return query.lstrip()[0] in ('~', '/', '$')
+            return (query.lstrip()[0] in ('~', '/', '$')) and (len(query) > 1)
         except IndexError:
             return False
 

--- a/ulauncher/search/file_browser/FileBrowserMode.py
+++ b/ulauncher/search/file_browser/FileBrowserMode.py
@@ -27,7 +27,7 @@ class FileBrowserMode(BaseSearchMode):
         /usr/bin/foo
         """
         try:
-            return (query.lstrip()[0] in ('~', '/', '$')) and (len(query) > 1)
+            return (query.lstrip()[0] in ('~', '/', '$')) and (len(query) > 1 and query != '~')
         except IndexError:
             return False
 

--- a/ulauncher/search/file_browser/FileBrowserMode.py
+++ b/ulauncher/search/file_browser/FileBrowserMode.py
@@ -23,11 +23,10 @@ class FileBrowserMode(BaseSearchMode):
         """
         Enabled for queries like:
         ~/Downloads
-        $USER/Downloads
         /usr/bin/foo
         """
         try:
-            return (query.lstrip()[0] in ('~', '/', '$')) and (len(query) > 1 and query != '~')
+            return query.lstrip()[0] in ('~', '/')
         except IndexError:
             return False
 


### PR DESCRIPTION
<!--
Thank you for submitting a PR to Ulauncher!

You can also read more about contributing in this document:
https://github.com/Ulauncher/Ulauncher/wiki/Code-Contribution
-->
### Link to related issue (if applicable)
<!--
This is not required, but for your own sake you may want to ensure before putting a lot of time on a PR, that the change is something we want to add and support. If there isn't an issue for it, you're welcome to create one.
-->

### Summary of the changes in this PR

Allow $ as a keyword, removing it from the list of chars for FileBrowserMode to activate. Already supports ~ which is exactly the same.

### Checklist (see more [here](https://github.com/Ulauncher/Ulauncher/wiki/Code-Contribution))
- [x] Use `dev` as the base branch
- [x] Follow the [Python Code Style Guides](https://github.com/Ulauncher/Ulauncher/wiki/Python-Code-Style-Guides)
- [x] Write unit tests for your changes when applicable
- [x] If your changes alters the behavior or introduce new functionality, please update the documentation accordingly
- [x] All tests are passing

### Tested environment (distro, desktop environment and their versions)
