### PR TITLE
Ensure correct theme file permissions

### DIFF
--- a/ulauncher/utils/Theme.py
+++ b/ulauncher/utils/Theme.py
@@ -138,7 +138,7 @@ class Theme:
         rmtree(new_theme_dir)
         copytree(self.path, new_theme_dir)
 
-        # change file permissions (because Nix store is read-only)
+        # ensure correct file permissions
         os.chmod(new_theme_dir, 0o755)
 
         return os.path.join(new_theme_dir, 'generated.css')

--- a/ulauncher/utils/Theme.py
+++ b/ulauncher/utils/Theme.py
@@ -138,6 +138,9 @@ class Theme:
         rmtree(new_theme_dir)
         copytree(self.path, new_theme_dir)
 
+        # change file permissions (because Nix store is read-only)
+        os.chmod(new_theme_dir, 0o755)
+
         return os.path.join(new_theme_dir, 'generated.css')
 
 


### PR DESCRIPTION
<!--
Thank you for submitting a PR to Ulauncher!

You can also read more about contributing in this document:
https://github.com/Ulauncher/Ulauncher/wiki/Code-Contribution
-->
### Link to related issue (if applicable)
<!--
This is not required, but for your own sake you may want to ensure before putting a lot of time on a PR, that the change is something we want to add and support. If there isn't an issue for it, you're welcome to create one.
-->

### Summary of the changes in this PR

I added one line of code to ensure that themes copied to ~/.cache/ulauncher_cache/themes have the correct file permissions. This fixes issues with package managers with read-only stores such as NixOS (https://github.com/NixOS/nixpkgs/pull/81207).

### Checklist (see more [here](https://github.com/Ulauncher/Ulauncher/wiki/Code-Contribution))
- [x] Use `dev` as the base branch
- [x] Follow the [Python Code Style Guides](https://github.com/Ulauncher/Ulauncher/wiki/Python-Code-Style-Guides)
- [ ] Write unit tests for your changes when applicable
- [ ] If your changes alters the behavior or introduce new functionality, please update the documentation accordingly
- [ ] All tests are passing

### Tested environment (distro, desktop environment and their versions)
NixOS, i3 with no desktop environment.
