### PR TITLE
Add packaging status in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,10 @@ You must have the following things installed:
 
 Check out output of `./ul` to find more useful commands.
 
+### Packaging status
+
+[Fedora](https://src.fedoraproject.org/rpms/ulauncher): `sudo dnf install ulauncher`
+
 
 License
 =======


### PR DESCRIPTION
Hello. Ulauncher packaged and available in official Fedora repos now. Now [on QA](https://bodhi.fedoraproject.org/updates/FEDORA-2020-fd95acc030). Can we mention this in README? Thank you for you app.

### Tested environment (distro, desktop environment and their versions)

- Fedora 32
- GNOME 3.36; GNOME Flashback 3.36; i3wm; icewm