### PR TITLE
Add ulauncher systemd unit file

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,15 @@ Check out [docs.ulauncher.io](http://docs.ulauncher.io/) to find out how.
 As of Ulauncher v4, you can create your own color themes
 Check out [docs.ulauncher.io](http://docs.ulauncher.io/en/latest/themes/themes.html) to find out how.
 
+[Systemd users](https://www.freedesktop.org/wiki/Software/systemd/)
+==============================================================
+
+If your distribution packages [ulauncher.service](contrib/systemd/ulauncher.service) properly, then you can run `ulauncher` on startup by running:
+
+```
+systemctl --user enable ulauncher.service
+```
+
 
 Known Issues
 ============

--- a/contrib/systemd/ulauncher.service
+++ b/contrib/systemd/ulauncher.service
@@ -1,0 +1,13 @@
+[Unit]
+Description=Linux Application Launcher
+Documentation=https://ulauncher.io/
+After=display-manager.service
+
+[Service]
+Type=simple
+Restart=always
+RestartSec=1
+ExecStart=/usr/bin/ulauncher --hide-window
+
+[Install]
+WantedBy=graphical.target


### PR DESCRIPTION
This is useful for users who have systemd and want to run `ulauncher` that way.

Documentation was updated accordingly.

For users running `systemd` it's a lot cleaner to run `ulauncher` from a dedicated unit file (logging, restarting, stopping, ...) than through a raw binary.

<!--
Thank you for submitting a PR to Ulauncher!

You can also read more about contributing in this document:
https://github.com/Ulauncher/Ulauncher/wiki/Code-Contribution
-->

### Summary of the changes in this PR

### Checklist (see more [here](https://github.com/Ulauncher/Ulauncher/wiki/Code-Contribution))
- [x] Use `dev` as the base branch
- [x] Follow the [Python Code Style Guides](https://github.com/Ulauncher/Ulauncher/wiki/Python-Code-Style-Guides)
- [x] Write unit tests for your changes when applicable
- [x] If your changes alters the behavior or introduce new functionality, please update the documentation accordingly
- [x] All tests are passing

### Tested environment (distro, desktop environment and their versions)

This is for package maintainers mostly. If this gets merged, I can help make the proper changes in [PKGBUILD](https://aur.archlinux.org/cgit/aur.git/tree/PKGBUILD?h=ulauncher) on Arch for example.
