### PR TITLE
Add Ubuntu groovy (20.10) ppa build

### DIFF
--- a/scripts/make-release.sh
+++ b/scripts/make-release.sh
@@ -92,6 +92,7 @@ launchpad_upload() {
     bionic="PPA=$PPA RELEASE=bionic ./ul build-deb $VERSION --upload"
     eoan="PPA=$PPA RELEASE=eoan ./ul build-deb $VERSION --upload"
     focal="PPA=$PPA RELEASE=focal ./ul build-deb $VERSION --upload"
+    groovy="PPA=$PPA RELEASE=groovy ./ul build-deb $VERSION --upload"
 
     # extracts ~/.shh for uploading package to ppa.launchpad.net via sftp
     # then uploads each realease
@@ -101,6 +102,6 @@ launchpad_upload() {
         --rm \
         -v $(pwd):/root/ulauncher \
         $BUILD_IMAGE \
-        bash -c "tar -xvf scripts/launchpad.ssh.tar -C / && $xenial && $bionic && $eoan && $focal"
+        bash -c "tar -xvf scripts/launchpad.ssh.tar -C / && $xenial && $bionic && $eoan && $focal && $groovy"
     set +x
 }


### PR DESCRIPTION
### Link to related issue (if applicable)
n/a

### Summary of the changes in this PR
Add build for upcoming Ubuntu Groovy (20.10)

### Checklist (see more [here](https://github.com/Ulauncher/Ulauncher/wiki/Code-Contribution))
- [x] Use `dev` as the base branch
- [x] Follow the [Python Code Style Guides](https://github.com/Ulauncher/Ulauncher/wiki/Python-Code-Style-Guides)
- [x] Write unit tests for your changes when applicable
- [x] If your changes alters the behavior or introduce new functionality, please update the documentation accordingly
- [x] All tests are passing

### Tested environment (distro, desktop environment and their versions)
Tested new build via repo'sdocker image
```
~ docker run --rm -it ulauncher-build bash

root@f9f5031f9124:/workdir# RELEASE=groovy ./ul build-deb 5.8.2-a1 --deb

Building DEB package for Ulauncher 5.8.2-a1...
➜ Checking that current version is not in debian/changelog
➜ Building Preferences UI
✔ Preferences are already built. Skipping.
➜ Copying src to a temp dir
➜ Building deb package
dpkg-buildpackage: info: source package ulauncher
dpkg-buildpackage: info: source version 5.8.2-a1
dpkg-buildpackage: info: source distribution xenial
dpkg-buildpackage: info: source changed by Aleksandr Gornostal <ulauncher.app@gmail.com>
dpkg-buildpackage: info: host architecture amd64

[...]

dpkg-buildpackage: info: full upload; Debian-native package (full source is included)
✔ ulauncher_5.8.2-a1_all.deb saved to /tmp
root@f9f5031f9124:/workdir# mv /tmp/ulauncher_5.8.2-a1_all.deb .
root@f9f5031f9124:/workdir# exit
(venv) ~/P/c/Ulauncher - [ubuntu-groovy] sudo dpkg -i ulauncher_5.8.2-a1_all.deb     
(Reading database ... 442523 files and directories currently installed.)
Preparing to unpack ulauncher_5.8.2-a1_all.deb ...
Unpacking ulauncher (5.8.2-a1) over (5.8.0-0ubuntu1ppa1~focal) ...
Setting up ulauncher (5.8.2-a1) ...
Processing triggers for bamfdaemon (0.5.3+18.04.20180207.2-0ubuntu2) ...
Rebuilding /usr/share/applications/bamf-2.index...
Processing triggers for desktop-file-utils (0.24-1ubuntu4) ...
Processing triggers for gnome-menus (3.36.0-1ubuntu1) ...
Processing triggers for mime-support (3.64ubuntu1) ...
Processing triggers for gnome-icon-theme (3.12.0-3) ...
Processing triggers for hicolor-icon-theme (0.17-2) ...
```
Ulauncher works normally in Ubuntu groovy afterwards.




