### PR TITLE
Add option to not hide when losing focus due to the mouse

### DIFF
--- a/data/preferences/src/api/fixture.js
+++ b/data/preferences/src/api/fixture.js
@@ -14,6 +14,7 @@ export default function(url, params) {
         autostart_allowed: true,
         autostart_enabled: true,
         clear_previous_text: true,
+        grab_mouse_pointer: true,
         blacklisted_desktop_dirs: ['/var/tmp', '/tmp/var/log/bin/bash/root'].join(':'),
         available_themes: [{ text: 'Dark', value: 'dark' }, { text: 'Light', value: 'light' }],
         theme_name: 'light',
@@ -41,6 +42,9 @@ export default function(url, params) {
       setTimeout(resolve, 0)
     } else if (isMatch(url, '/set/clear-previous-query')) {
       console.log('/set/clear-previous-query', params)
+      setTimeout(resolve, 0)
+    } else if (isMatch(url, '/set/grab-mouse-pointer')) {
+      console.log('/set/grab-mouse-pointer', params)
       setTimeout(resolve, 0)
     } else if (isMatch(url, '/set/blacklisted-desktop-dirs')) {
       console.log('/set/blacklisted-desktop-dirs', params)

--- a/data/preferences/src/components/pages/Preferences.vue
+++ b/data/preferences/src/components/pages/Preferences.vue
@@ -97,6 +97,15 @@
           ></b-form-select>
         </td>
       </tr>
+
+      <tr>
+        <td>
+          <label for="grab_mouse_pointer">Don't hide after losing mouse focus</label>
+        </td>
+        <td>
+          <b-form-checkbox id="grab_mouse_pointer" v-model="grab_mouse_pointer"></b-form-checkbox>
+        </td>
+      </tr>
     </table>
 
     <h1>Advanced</h1>
@@ -250,6 +259,18 @@ export default {
       set(value) {
         return jsonp('prefs://set/clear-previous-query', { value: value }).then(
           () => this.setPrefs({ clear_previous_query: value }),
+          err => bus.$emit('error', err)
+        )
+      }
+    },
+
+    grab_mouse_pointer: {
+      get() {
+        return this.prefs.grab_mouse_pointer
+      },
+      set(value) {
+        return jsonp('prefs://set/grab-mouse-pointer', { value: value }).then(
+          () => this.setPrefs({ grab_mouse_pointer: value }),
           err => bus.$emit('error', err)
         )
       }

--- a/scripts/common.sh
+++ b/scripts/common.sh
@@ -51,7 +51,7 @@ note() {
 }
 
 warn-if-not-in-docker () {
-    if [ ! -f /.dockerenv ]; then
+    if [ ! -f /.dockerenv -a ! -f /run/.containerenv ]; then
         echo
         echo "${yellow}WARNING: It's recommended to run tests in a docker container to be sure they will also pass in CI${normal}"
         echo

--- a/scripts/dev-container.sh
+++ b/scripts/dev-container.sh
@@ -12,11 +12,21 @@ dev-container () {
     *) image=$BUILD_IMAGE ;;
   esac
 
+  # If SELinux is enabled, the volumes mounted into the container
+  # need to have the right labels. This is accomplished by appending
+  # ":z" to the volume option.
+  if command -v selinuxenabled && selinuxenabled
+  then
+      vol_suffix=":z"
+  else
+      vol_suffix=""
+  fi
+
   exec docker run \
     --rm \
     -it \
-    -v $(pwd):/root/ulauncher \
-    -v $HOME/.bash_history:/root/.bash_history \
+    -v $(pwd):/root/ulauncher${vol_suffix} \
+    -v $HOME/.bash_history:/root/.bash_history${vol_suffix} \
     -p 3002:3002 \
     --name ulauncher \
     $image \

--- a/scripts/tests.sh
+++ b/scripts/tests.sh
@@ -22,7 +22,7 @@ test-pytest () {
     set +e
     echo '[ test: pytest ]'
     # Some tests will fail in Docker unless virtual frame buffer is running
-    if [ -f /.dockerenv ]; then
+    if [ -f /.dockerenv -o -f /run/.containerenv ]; then
         export DISPLAY=:1
         ps cax | grep Xvfb > /dev/null
         if [ $? -eq 0 ]; then

--- a/tests/ui/windows/test_PreferencesUlauncherDialog.py
+++ b/tests/ui/windows/test_PreferencesUlauncherDialog.py
@@ -85,6 +85,11 @@ class TestPreferencesUlauncherDialog:
         dialog.prefs_showhotkey_dialog.original(dialog, {'query': {'name': 'hotkey-name'}})
         hotkey_dialog.present.assert_called_with()
 
+    def test_prefs_set_grab_mouse_pointer(self, dialog, settings):
+        dialog.prefs_set_grab_mouse_pointer({'query': {'value': 'true'}})
+        settings.set_property.assert_called_with('grab-mouse-pointer', True)
+        settings.save_to_file.assert_called_with()
+
     @pytest.mark.with_display
     def test_get_app_hotkey(self, dialog, settings):
         settings.get_property.return_value = '<Primary>B'

--- a/ulauncher/ui/windows/PreferencesUlauncherDialog.py
+++ b/ulauncher/ui/windows/PreferencesUlauncherDialog.py
@@ -246,6 +246,7 @@ class PreferencesUlauncherDialog(Gtk.Dialog, WindowHelper):
             'render_on_screen': self.settings.get_property('render-on-screen'),
             'is_wayland': is_wayland(),
             'terminal_command': self.settings.get_property('terminal-command'),
+            'grab_mouse_pointer': self.settings.get_property('grab-mouse-pointer'),
             'env': {
                 'version': get_version(),
                 'api_version': api_version,
@@ -329,6 +330,13 @@ class PreferencesUlauncherDialog(Gtk.Dialog, WindowHelper):
         is_on = self._get_bool(url_params['query']['value'])
         logger.info('Set clear-previous-query to %s', is_on)
         self.settings.set_property('clear-previous-query', is_on)
+        self.settings.save_to_file()
+
+    @rt.route('/set/grab-mouse-pointer')
+    def prefs_set_grab_mouse_pointer(self, url_params):
+        is_on = self._get_bool(url_params['query']['value'])
+        logger.info('Set grab-mouse-pointer to %s', is_on)
+        self.settings.set_property('grab-mouse-pointer', is_on)
         self.settings.save_to_file()
 
     @rt.route('/set/blacklisted-desktop-dirs')

--- a/ulauncher/ui/windows/UlauncherWindow.py
+++ b/ulauncher/ui/windows/UlauncherWindow.py
@@ -154,6 +154,17 @@ class UlauncherWindow(Gtk.Window, WindowHelper):
         t.start()
 
     def on_focus_in_event(self, *args):
+        if self.settings.get_property('grab-mouse-pointer'):
+            ptr_dev = self.get_pointer_device()
+            result = ptr_dev.grab(
+                self.window.get_window(),
+                Gdk.GrabOwnership.NONE,
+                True,
+                Gdk.EventMask.ALL_EVENTS_MASK,
+                None,
+                0
+            )
+            logger.debug("Focus in event, grabbing pointer: %s", result)
         self.is_focused = True
 
     def on_input_changed(self, entry):
@@ -318,6 +329,17 @@ class UlauncherWindow(Gtk.Window, WindowHelper):
         if not self.results_nav.enter(self._get_user_query(), index, alt=alt):
             # hide the window if it has to be closed on enter
             self.hide_and_clear_input()
+
+    def hide(self, *args, **kwargs):
+        """Override the hide method to ensure the pointer grab is released."""
+        if self.settings.get_property('grab-mouse-pointer'):
+            self.get_pointer_device().ungrab(0)
+        super(UlauncherWindow, self).hide(*args, **kwargs)
+
+    def get_pointer_device(self):
+        return (self
+                .window.get_window()
+                .get_display().get_device_manager().get_client_pointer())
 
     def hide_and_clear_input(self):
         self.input.set_text('')

--- a/ulauncher/ui/windows/UlauncherWindow.py
+++ b/ulauncher/ui/windows/UlauncherWindow.py
@@ -338,8 +338,11 @@ class UlauncherWindow(Gtk.Window, WindowHelper):
 
     def get_pointer_device(self):
         return (self
-                .window.get_window()
-                .get_display().get_device_manager().get_client_pointer())
+                .window
+                .get_window()
+                .get_display()
+                .get_device_manager()
+                .get_client_pointer())
 
     def hide_and_clear_input(self):
         self.input.set_text('')

--- a/ulauncher/utils/Settings.py
+++ b/ulauncher/utils/Settings.py
@@ -58,6 +58,11 @@ GPROPERTIES = {
                          None,
                          "",
                          GObject.PARAM_READWRITE),
+    "grab-mouse-pointer": (bool,
+                           "Grab mouse while open (prevents losing focus)",
+                           None,
+                           False,
+                           GObject.ParamFlags.READWRITE),
 }
 
 


### PR DESCRIPTION
### Link to related issue (if applicable)

Addresses #337.
Also address #638.

### Summary of the changes in this PR

This add a user preference option which will prevent ULauncher from closing when focus is lost because of the mouse. This makes ULauncher compatible with focus follows mouse and sloppy focus modes.

The issue talked about making this option as a CLI command. However, that makes it more challenging to set the preference for the user if they are using a system installed ULauncher. In that case they would have to modify the desktop file to add the shortcut, and the modification would likely get overridden on the next update. I was able to make this a user preference so that the customization is stored in the preferences file.

I tried to make the UI element short and meaningful about what it did and not how it was implemented. Internally the option is grab-mouse-pointer since that is the actual implementation, but the effect of grabbing the mouse pointer is probably not obvious to the general user. I am most certainly interested in feedback on the naming.

I also included a couple of small tweaks which allowed me to use the container infrastructure with podman (via podman's docker compatibility wrapper). I opened issue #638 for this and I can split it out into a separate PR if desired, or remove it entirely if you aren't interested in supporting it.

Lastly I couldn't find any documentation to update with the new option. I'd be happy to do so if you give me a pointer of where to look.

### Checklist (see more [here](https://github.com/Ulauncher/Ulauncher/wiki/Code-Contribution))
- [x] Use `dev` as the base branch
- [x] Follow the [Python Code Style Guides](https://github.com/Ulauncher/Ulauncher/wiki/Python-Code-Style-Guides)
- [x] Write unit tests for your changes when applicable
- [ ] If your changes alters the behavior or introduce new functionality, please update the documentation accordingly
- [x] All tests are passing

### Tested environment (distro, desktop environment and their versions)

Distro: Fedora 32
Desktop: Gnome 3.36
