### PR TITLE
Try fixing the ulauncher-toggle crash

### DIFF
--- a/bin/ulauncher-toggle
+++ b/bin/ulauncher-toggle
@@ -1,4 +1,4 @@
-#!/usr/bin/sh
+#!/usr/bin/env sh
 
 dbus-send \
     --session \


### PR DESCRIPTION
<!--
Thank you for submitting a PR to Ulauncher!

You can also read more about contributing in this document:
https://github.com/Ulauncher/Ulauncher/wiki/Code-Contribution
-->
### Link to related issue (if applicable) #642 
<!--
This is not required, but for your own sake you may want to ensure before putting a lot of time on a PR, that the change is something we want to add and support. If there isn't an issue for it, you're welcome to create one.
-->

### Summary of the changes in this PR

Just the path of `sh` in shebang of `ulauncher-toggle` is changed

### Checklist (see more [here](https://github.com/Ulauncher/Ulauncher/wiki/Code-Contribution))
- [x] Use `dev` as the base branch
- [ ] Follow the [Python Code Style Guides](https://github.com/Ulauncher/Ulauncher/wiki/Python-Code-Style-Guides)
- [ ] Write unit tests for your changes when applicable
- [ ] If your changes alters the behavior or introduce new functionality, please update the documentation accordingly
- [ ] All tests are passing

### Tested environment (distro, desktop environment, and their versions)
Distro: elementray OS 5.1.7 (Ubuntu 18.04)
DE: pantheon