### PR TITLE
Search parameters include application description

### DIFF
--- a/tests/search/test_SortedList.py
+++ b/tests/search/test_SortedList.py
@@ -75,15 +75,3 @@ class TestSortedList:
         assert ri6 in res_list
 
         assert res_list[0] == ri5  # ri5 stays first, because it has the highest score (100)
-
-
-class TestSortedListOrder:
-    def test_order_if_name_and_description_match(self):
-        r1 = ResultItem(name='Problem Reporting', description='An application to report problems')
-        r2 = ResultItem(name='VS Code', description='Code editing, redefined')
-
-        sorted_list_instance = SortedList(query='re', min_score=50)
-        sorted_list_instance.append(r1)
-        sorted_list_instance.append(r2)
-        assert sorted_list_instance[0].get_name() == 'Problem Reporting'
-        assert sorted_list_instance[1].get_name() == 'VS Code'

--- a/tests/search/test_SortedList.py
+++ b/tests/search/test_SortedList.py
@@ -75,3 +75,15 @@ class TestSortedList:
         assert ri6 in res_list
 
         assert res_list[0] == ri5  # ri5 stays first, because it has the highest score (100)
+
+
+class TestSortedListOrder:
+    def test_order_if_name_and_description_match(self):
+        r1 = ResultItem(name='Problem Reporting', description='An application to report problems')
+        r2 = ResultItem(name='VS Code', description='Code editing, redefined')
+
+        sorted_list_instance = SortedList(query='re', min_score=50)
+        sorted_list_instance.append(r1)
+        sorted_list_instance.append(r2)
+        assert sorted_list_instance[0].get_name() == 'Problem Reporting'
+        assert sorted_list_instance[1].get_name() == 'VS Code'

--- a/tests/search/test_SortedListOrder.py
+++ b/tests/search/test_SortedListOrder.py
@@ -1,0 +1,19 @@
+from ulauncher.api.shared.item.ResultItem import ResultItem
+from ulauncher.search.SortedList import SortedList
+
+
+class TestSortedListOrder:
+    def test_order_if_name_and_description_match(self):
+        app_name_1 = 'Problem Reporting'
+        app_name_2 = 'VS Code'
+        r1 = ResultItem(name=app_name_1, description='An application to report problems')
+        r2 = ResultItem(name=app_name_2, description='Code editing, redefined')
+
+        sorted_list_instance = SortedList(query='re', min_score=50, limit=10)
+        sorted_list_instance.append(r1)
+        sorted_list_instance.append(r2)
+        assert sorted_list_instance[0].get_name() == app_name_1
+
+        # TODO: Need to investigate why the sorted list instance is 1, even after appending two items
+        assert len(sorted_list_instance) == 2
+        assert sorted_list_instance[1].get_name() == app_name_2

--- a/tests/search/test_SortedListOrder.py
+++ b/tests/search/test_SortedListOrder.py
@@ -14,6 +14,5 @@ class TestSortedListOrder:
         sorted_list_instance.append(r2)
         assert sorted_list_instance[0].get_name() == app_name_1
 
-        # TODO: Need to investigate why the sorted list instance is 1, even after appending two items
         assert len(sorted_list_instance) == 2
         assert sorted_list_instance[1].get_name() == app_name_2

--- a/ulauncher/search/SortedList.py
+++ b/ulauncher/search/SortedList.py
@@ -1,6 +1,7 @@
+from ulauncher.api.shared.item.ResultItem import ResultItem
+
 from ulauncher.search.Query import Query
 
-from ulauncher.search.apps.AppResultItem import AppResultItem
 
 from ulauncher.utils.SortedCollection import SortedCollection
 from ulauncher.utils.fuzzy_search import get_score
@@ -46,7 +47,7 @@ class SortedList:
         for item in items:
             self.append(item)
 
-    def append(self, result_item: AppResultItem):
+    def append(self, result_item: ResultItem):
         score_from_name = get_score(self._query, result_item.get_search_name())
         score_from_description = get_score(
             self._query,
@@ -57,7 +58,7 @@ class SortedList:
         if score_from_name >= self._min_score:
             result_item.score = -score_from_name
         elif score_from_description >= self._min_score:
-            # Halving the score so that it will rank below items which match with the name
+            # Halving so that it will rank below items which match with the name
             result_item.score = -(score_from_description / 2)
         else:
             return

--- a/ulauncher/search/SortedList.py
+++ b/ulauncher/search/SortedList.py
@@ -48,11 +48,11 @@ class SortedList:
             self.append(item)
 
     def append(self, result_item: ResultItem):
-        score_from_name = get_score(self._query, result_item.get_search_name())
         score_from_description = get_score(
             self._query,
             result_item.get_description(Query(self._query))
         )
+        score_from_name = get_score(self._query, result_item.get_search_name())
 
         # use negative to sort by score in desc. order
         if score_from_name >= self._min_score:


### PR DESCRIPTION
<!--
Thank you for submitting a PR to Ulauncher!

You can also read more about contributing in this document:
https://github.com/Ulauncher/Ulauncher/wiki/Code-Contribution
-->
### Link to related issue (if applicable)
<!--
This is not required, but for your own sake you may want to ensure before putting a lot of time on a PR, that the change is something we want to add and support. If there isn't an issue for it, you're welcome to create one.
-->
Partly solves #270 . Also closes #613 

### Summary of the changes in this PR
Currently the search uses the name, although description is present in the AppDB. With this change we also consider the description in the search. 
If the match score of description is greater than min_score (which is 50 for app search) then the score is halved and sent back as a result item, just to make sure it always ranks below entries which match with the name.
One thing I would like your opinion on is that - now the get_score fn returns ResultItems which have a score less than the min_score provided. This seems weird to me, but I could not think of any other elegant way. Let me know your thoughts :smile: 

### Checklist (see more [here](https://github.com/Ulauncher/Ulauncher/wiki/Code-Contribution))
- [x] Use `dev` as the base branch
- [x] Follow the [Python Code Style Guides](https://github.com/Ulauncher/Ulauncher/wiki/Python-Code-Style-Guides)
- [x] Write unit tests for your changes when applicable
- [x] If your changes alters the behavior or introduce new functionality, please update the documentation accordingly
- [x] All tests are passing

### Tested environment (distro, desktop environment and their versions)
distro: Fedora 33
desktop environment: GNOME on XOrg
version: running from the dev branch, version