### PR TITLE
Caret now is used as a pow operator instead of XOR in CalcMode

### DIFF
--- a/ulauncher/search/calc/CalcMode.py
+++ b/ulauncher/search/calc/CalcMode.py
@@ -16,7 +16,7 @@ operators = {ast.Add: op.add, ast.Sub: op.sub, ast.Mult: op.mul,
 def eval_expr(expr):
     """
     >>> eval_expr('2^6')
-    4
+    64
     >>> eval_expr('2**6')
     64
     >>> eval_expr('2*6+')
@@ -24,6 +24,7 @@ def eval_expr(expr):
     >>> eval_expr('1 + 2*3**(4^5) / (6 + -7)')
     -5.0
     """
+    expr = expr.replace("^", "**")
     try:
         return _eval(ast.parse(expr, mode='eval').body)
     # pylint: disable=broad-except


### PR DESCRIPTION
<!--
Thank you for submitting a PR to Ulauncher!

You can also read more about contributing in this document:
https://github.com/Ulauncher/Ulauncher/wiki/Code-Contribution
-->
### Link to related issue (if applicable)
Solves #623 

### Summary of the changes in this PR
A very minor change, now the caret operator will be used as a pow operator instead of an XOR operator.


### Checklist (see more [here](https://github.com/Ulauncher/Ulauncher/wiki/Code-Contribution))
- [x] Use `dev` as the base branch
- [x] Follow the [Python Code Style Guides](https://github.com/Ulauncher/Ulauncher/wiki/Python-Code-Style-Guides)
- [x] Write unit tests for your changes when applicable
- [x] If your changes alters the behavior or introduce new functionality, please update the documentation accordingly
- [x] All tests are passing

### Tested environment (distro, desktop environment and their versions)
