### PR TITLE
Set argument to ' ' if no string is set for argument --> When hitting…

### DIFF
--- a/ulauncher/search/shortcuts/ShortcutResultItem.py
+++ b/ulauncher/search/shortcuts/ShortcutResultItem.py
@@ -73,7 +73,7 @@ class ShortcutResultItem(ResultItem):
         elif self.is_default_search:
             argument = query
         else:
-            argument = None
+            argument = ' '
 
         if self.run_without_argument:
             if self._is_url():


### PR DESCRIPTION
… ENTER, a search with no content is performed, which shall always lead to the main-page of the keyword-search-engine

<!--
Thank you for submitting a PR to Ulauncher!

You can also read more about contributing in this document:
https://github.com/Ulauncher/Ulauncher/wiki/Code-Contribution
-->
### Link to related issue (if applicable)
<!--
This is not required, but for your own sake you may want to ensure before putting a lot of time on a PR, that the change is something we want to add and support. If there isn't an issue for it, you're welcome to create one.
-->
Feature request [https://github.com/Ulauncher/Ulauncher/issues/654](https://github.com/Ulauncher/Ulauncher/issues/654)

### Summary of the changes in this PR
Very minor change in using "argument" varialbe for shortcuts
If shortcut is "activated" but no search term is inserted, the url is opened anyway --> Normally leads to main-page of configured-search-engine

SORRY im an absolute Beginner and sure that i made mistakes in forking/branching and my skills are not high enough to provide all the testing needed

### Checklist (see more [here](https://github.com/Ulauncher/Ulauncher/wiki/Code-Contribution))
- [x] Use `dev` as the base branch
- [x] Follow the [Python Code Style Guides](https://github.com/Ulauncher/Ulauncher/wiki/Python-Code-Style-Guides)
- [ ] Write unit tests for your changes when applicable
- [ ] If your changes alters the behavior or introduce new functionality, please update the documentation accordingly
- [x] All tests are passing

### Tested environment (distro, desktop environment and their versions)

System:    Kernel: 5.4.0-56-generic x86_64 bits: 64 compiler: gcc v: 9.3.0 
           Desktop: Cinnamon 4.6.7 wm: muffin 4.6.3 dm: LightDM 1.30.0 
           Distro: Linux Mint 20 Ulyana base: Ubuntu 20.04 focal 
