### PR TITLE
Fix json files corruptions

### DIFF
--- a/ulauncher/utils/db/KeyValueJsonDb.py
+++ b/ulauncher/utils/db/KeyValueJsonDb.py
@@ -17,8 +17,12 @@ class KeyValueJsonDb(KeyValueDb[Key, Value]):
             if not os.path.isfile(self._name):
                 raise IOError("%s exists and is not a file" % self._name)
 
-            with open(self._name, 'r') as _in:
-                self.set_records(json.load(_in))
+            try:
+                with open(self._name, 'r') as _in:
+                    self.set_records(json.load(_in))
+            except json.JSONDecodeError:
+                # file corrupted, reset it.
+                self.commit()
         else:
             # make sure path exists
             mkpath(os.path.dirname(self._name))


### PR DESCRIPTION
### Link to related issue (if applicable)
One json file got corrupted and the application is no more working... Happening mainly with `shortcuts.json`

https://github.com/Ulauncher/Ulauncher/issues/592
https://github.com/Ulauncher/Ulauncher/issues/621
https://github.com/Ulauncher/Ulauncher/issues/592

### Summary of the changes in this PR
If the file is not a valid json, write default records `{}`.

### Checklist (see more [here](https://github.com/Ulauncher/Ulauncher/wiki/Code-Contribution))
- [x] Use `dev` as the base branch
- [x] Follow the [Python Code Style Guides](https://github.com/Ulauncher/Ulauncher/wiki/Python-Code-Style-Guides)
- [x] Write unit tests for your changes when applicable
- [x] If your changes alters the behavior or introduce new functionality, please update the documentation accordingly
- [x] All tests are passing

### Tested environment (distro, desktop environment and their versions)
Ubuntu, gnome, last version