### PR TITLE
Naive solution to pkexec issues (for Python 3.8 or higher)

### DIFF
--- a/ulauncher/api/shared/action/LaunchAppAction.py
+++ b/ulauncher/api/shared/action/LaunchAppAction.py
@@ -1,6 +1,7 @@
 import logging
 import pipes
 import subprocess
+import shlex
 
 from ulauncher.utils.desktop.reader import read_desktop_file
 from ulauncher.utils.Settings import Settings
@@ -26,6 +27,7 @@ class LaunchAppAction(BaseAction):
     def run(self):
         app = read_desktop_file(self.filename)
         command = app.get_string('Exec')
+        
         terminal_exec = settings.get_property('terminal-command')
         if app.get_boolean('Terminal') and terminal_exec and command:
             logger.info('Run command %s (%s) in preferred terminal (%s)', command, self.filename, terminal_exec)
@@ -33,6 +35,14 @@ class LaunchAppAction(BaseAction):
         else:
             logger.info('Run application %s (%s)', app.get_name(), self.filename)
             try:
-                app.launch()
+                if (command.startswith("pkexec")):
+                    subprocess.Popen(
+                        args=shlex.split('sh -c "'+command+'"'),
+                        stdout=subprocess.PIPE,
+                        stderr=subprocess.PIPE,
+                        start_new_session=True
+                    )
+                else:
+                    app.launch()
             except Exception as e:
                 logger.error('%s: %s', type(e).__name__, e)


### PR DESCRIPTION
It's not a great solution but here's a jumping off point to support pkexec in Ulauncher.

Part of the fix requires a Pexec flag only present in Python 3.8 or later, though this is only to prevent the application from closing when Ulauncher's main process does. As far as I know this won't stop the application or fix working in older versions.

Sadly I couldn't find a solution to prevent redirecting part of the application std output to the terminal, but if anyone can modify this then please go ahead.

This was tested as working under Linux Mint 20.1 using driver-manager and timeshift.