### PR TITLE
Fix for ImportError: Requiring namespace 'Gdk' version '3.0', but '4.…

### DIFF
--- a/ulauncher/utils/display.py
+++ b/ulauncher/utils/display.py
@@ -1,4 +1,6 @@
 import logging
+import gi
+gi.require_version('Gdk', '3.0')
 from gi.repository import Gdk, GdkX11
 
 logger = logging.getLogger(__name__)


### PR DESCRIPTION
### Link to related issue (if applicable)
#736 

### Summary of the changes in this PR
2 lines of code has been added in `display.py` to solve problem with default loading GDK 4.0.
```python
import gi
gi.require_version('Gdk', '3.0')
````

### Checklist (see more [here](https://github.com/Ulauncher/Ulauncher/wiki/Code-Contribution))
- [x] Use `dev` as the base branch
- [x] Follow the [Python Code Style Guides](https://github.com/Ulauncher/Ulauncher/wiki/Python-Code-Style-Guides)
- [ ] Write unit tests for your changes when applicable 
- [ ] If your changes alters the behavior or introduce new functionality, please update the documentation accordingly
- [x] All tests are passing

### Tested environment (distro, desktop environment and their versions)
EndevourOs, GNOME 40.3

### Short description of resolved problem ###
In Ulauncher(5.11.0) if we are working on GNOME 40 or other environment with GDK 4.0 installed, we constantly getting error when trying to run any extension:
2021-07-31 19:22:14,279 | ERROR | ulauncher.api.server.ExtensionRunner: _run_process() | Extension "hello_world" exited instantly with code 1
2021-07-31 19:22:14,279 | ERROR | ulauncher.api.server.ExtensionRunner: _run_process() | Extension "hello_world" failed with an error: ImportError: Requiring namespace 'Gdk' version '3.0', but '4.0' is already loaded


