### PR TITLE
Explicitly import GdkX11 3.0 in tests.

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,4 +1,7 @@
 from functools import reduce
+import gi
+gi.require_version('GdkX11', '3.0')
+# pylint: disable=wrong-import-position
 from gi.repository import GdkX11
 
 import pytest


### PR DESCRIPTION
This fixes the tests when running with GTK4.

Before this PR they all say says `gi.RepositoryError: Requiring namespace 'Gdk' version '3.0', but '4.0' is already loaded`

Credit to @troycurtisjr 