### PR TITLE
Make systemd service file able to auto-start more consistently and include in the source tarball.

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Check out [docs.ulauncher.io](http://docs.ulauncher.io/en/latest/themes/themes.h
 [Systemd users](https://www.freedesktop.org/wiki/Software/systemd/)
 ==============================================================
 
-If your distribution packages [ulauncher.service](contrib/systemd/ulauncher.service) properly, then you can run `ulauncher` on startup by running:
+If your distribution packages [ulauncher.service](ulauncher.service) properly, then you can run `ulauncher` on startup by running:
 
 ```
 systemctl --user enable ulauncher.service

--- a/scripts/build-targz.sh
+++ b/scripts/build-targz.sh
@@ -30,6 +30,7 @@ build-targz () {
         setup.py \
         ulauncher \
         ulauncher.desktop.in \
+        ulauncher.service \
         $tmpdir \
         --exclude-from=.gitignore
 

--- a/ulauncher.service
+++ b/ulauncher.service
@@ -1,7 +1,6 @@
 [Unit]
 Description=Linux Application Launcher
 Documentation=https://ulauncher.io/
-After=display-manager.service
 
 [Service]
 Type=simple
@@ -10,4 +9,4 @@ RestartSec=1
 ExecStart=/usr/bin/ulauncher --hide-window
 
 [Install]
-WantedBy=graphical.target
+WantedBy=graphical-session.target


### PR DESCRIPTION
Make systemd service file able to auto-start more consistently and include in the source tarball.

Currently the arch, deb, and rpms builds do not automatically include this file, but I'll work on that in a followup PR. I wanted to get this in for the 5.12 release if possible.

### Link to related issue (if applicable)
https://github.com/Ulauncher/Ulauncher/issues/764

### Summary of the changes in this PR
Drops the "After" which has no effect when launched as a user service and point to graphical-session.target instead of graphical.target so that things work more consistently. 

### Checklist (see more [here](https://github.com/Ulauncher/Ulauncher/wiki/Code-Contribution))
- [x] Use `dev` as the base branch
- [x] Follow the [Python Code Style Guides](https://github.com/Ulauncher/Ulauncher/wiki/Python-Code-Style-Guides)
- [x] Write unit tests for your changes when applicable
- [x] If your changes alters the behavior or introduce new functionality, please update the documentation accordingly
- [x] All tests are passing

### Tested environment (distro, desktop environment and their versions)
Fedora 34, Gnome