### PR TITLE
Fix ampersand breaking highlighting

### DIFF
--- a/tests/utils/test_text_highlighter.py
+++ b/tests/utils/test_text_highlighter.py
@@ -9,4 +9,5 @@ def test_highlight_text():
     assert hl('hell wo', 'hello world') == '<i>hell</i>o<i> wo</i>rld'
     assert hl('ttesti', 'testik_ls-ttestk') == '<i>testi</i>k_ls-ttestk'
     assert hl('dome', 'Documents') == '<i>Do</i>cu<i>me</i>nts'
-    assert hl('e tom', 'São tomé & príncipe') == 'São<i> tom</i>é & príncip<i>e</i>'
+    assert hl('e tom', 'São tomé & príncipe') == 'São<i> tom</i>é &amp; príncip<i>e</i>'
+    assert hl('date', 'Date &amp; Time') == '<i>Date</i> &amp; Time'

--- a/ulauncher/utils/text_highlighter.py
+++ b/ulauncher/utils/text_highlighter.py
@@ -6,6 +6,8 @@ def highlight_text(query, text: str, open_tag='<span foreground="white">', close
     Highlights words from query in a given text string
     :returns: string with Pango markup
     """
+    text = text.replace("&amp;", "&")
+
     positions = get_matching_indexes(query, text)
 
     # use positions to highlight text with tags
@@ -25,4 +27,4 @@ def highlight_text(query, text: str, open_tag='<span foreground="white">', close
         # don't forget to close tag if it is opened
         hlted.append(close_tag)
 
-    return ''.join(hlted)
+    return ''.join(hlted).replace("&", "&amp;")


### PR DESCRIPTION
This should fix #587 which was broken by fixing #477, which imo is a less important use case to support

Before:
![before](https://user-images.githubusercontent.com/515120/129115733-42fed0cf-79d2-4d90-9e28-843df3b6c13a.png)

`Failed to set text '<span foreground="#fff">Date &</span>amp; Time Settings' from markup due to error parsing markup: Error on line 1: Entity did not end with a semicolon; most likely you used an ampersand character without intending to start an entity — escape ampersand as &amp;`

As can be seen, the issue is that the highlighter splits up the `&amp;` entity with a html tag. By replacing `&amp;` to `&` and then back again after highlighting this is fixed. In addition this escapes unescaped `&`.

After:
![2021-08-12_01-40](https://user-images.githubusercontent.com/515120/129117220-36442913-5f1c-4489-bcdf-aa989c66a5ce.png)

It breaks #477 again for https://github.com/dhelmr/ulauncher-duckduckgo-bangs, but not for my extension. I think I originally [disabled hightlighting like this](https://github.com/friday/ulauncher-clipboard/blob/master/main.py#L25) to solve that, but then didn't even need to do that when switching to the small result view. I think this is a reasonable workaround/limitation for the rare exceptions of extensions out there that want to display special characters.

![2021-08-12_01-27](https://user-images.githubusercontent.com/515120/129116416-7bb6e4b2-04d4-42e2-8f85-7d94ea00292d.png)
