### PR TITLE
Restore extension logging

### DIFF
--- a/tests/api/server/test_ProcessErrorExtractor.py
+++ b/tests/api/server/test_ProcessErrorExtractor.py
@@ -1,14 +1,7 @@
-import io
-
 from ulauncher.api.server.ProcessErrorExtractor import ProcessErrorExtractor
 
 
 class TestProcessErrorExtractor:
-
-    def test_extract_from_file_object(self):
-        string = "line 1\nline2\nModuleNotFoundError: No module named 'mymodule'"
-        e = ProcessErrorExtractor.extract_from_file_object(io.StringIO(string))
-        assert e.error == "ModuleNotFoundError: No module named 'mymodule'"
 
     def test_is_import_error__true(self):
         e = ProcessErrorExtractor("ModuleNotFoundError: No module named 'mymodule'")

--- a/ulauncher/api/server/ProcessErrorExtractor.py
+++ b/ulauncher/api/server/ProcessErrorExtractor.py
@@ -1,21 +1,9 @@
 import re
-import io
-from itertools import takewhile
 
 from ulauncher.api.shared.errors import UlauncherAPIError
 
 
 class ProcessErrorExtractor:
-
-    @classmethod
-    def extract_from_file_object(cls, file: io.BytesIO) -> 'ProcessErrorExtractor':
-        error = b''
-        for line in takewhile(bool, iter(file.readline, b'')):
-            if line:
-                error = line
-
-        return cls(error.decode('utf-8') if isinstance(error, bytes) else error)
-
     def __init__(self, error: str):
         """
         expecting an error like this:


### PR DESCRIPTION
Extension logging was disabled when adding the extension error messages in Preferences. That stopped them from outputting to stderr (which is what's being used for logging, although I don't know why), disabling any logging from inside the extensions.

It should also be possible to change the logger to use stdout, but that code is in the extensions, and big part of why this is important imo is printing extension errors so devs can test them and see why it's not working.