### PR TITLE
Switch extension download link to use tar instead of zip (fixes symlinks)

### DIFF
--- a/tests/api/server/test_ExtensionDownloader.py
+++ b/tests/api/server/test_ExtensionDownloader.py
@@ -26,7 +26,7 @@ class TestExtensionDownloader:
     def gh_ext(self, mocker):
         gh_ext = mocker.patch('ulauncher.api.server.ExtensionDownloader.GithubExtension').return_value
         gh_ext.get_ext_id.return_value = 'com.github.ulauncher.ulauncher-timer'
-        gh_ext.get_download_url.return_value = 'https://github.com/Ulauncher/ulauncher-timer/archive/master.tar.gz'
+        gh_ext.get_download_url.return_value = 'https://github.com/Ulauncher/ulauncher-timer/tarball/master'
         gh_ext.get_last_commit.return_value = {
             'last_commit': '64e106c',
             'last_commit_time': '2017-05-01T07:30:39'

--- a/tests/api/server/test_GithubExtension.py
+++ b/tests/api/server/test_GithubExtension.py
@@ -98,7 +98,7 @@ class TestGithubExtension:
             GithubExtension('https://github.com/Ulauncher/ulauncher-timer/').validate_url()
 
     def test_get_download_url(self, gh_ext):
-        assert gh_ext.get_download_url() == 'https://github.com/Ulauncher/ulauncher-timer/archive/master.zip'
+        assert gh_ext.get_download_url() == 'https://github.com/Ulauncher/ulauncher-timer/archive/master.tar.gz'
 
     def test_get_commit(self, gh_ext, mocker):
         urlopen = mocker.patch('ulauncher.api.server.GithubExtension.urlopen')

--- a/tests/api/server/test_GithubExtension.py
+++ b/tests/api/server/test_GithubExtension.py
@@ -98,7 +98,7 @@ class TestGithubExtension:
             GithubExtension('https://github.com/Ulauncher/ulauncher-timer/').validate_url()
 
     def test_get_download_url(self, gh_ext):
-        assert gh_ext.get_download_url() == 'https://github.com/Ulauncher/ulauncher-timer/archive/master.tar.gz'
+        assert gh_ext.get_download_url() == 'https://github.com/Ulauncher/ulauncher-timer/tarball/master'
 
     def test_get_commit(self, gh_ext, mocker):
         urlopen = mocker.patch('ulauncher.api.server.GithubExtension.urlopen')

--- a/ulauncher/api/server/ExtensionDownloader.py
+++ b/ulauncher/api/server/ExtensionDownloader.py
@@ -1,6 +1,6 @@
 import os
 import logging
-from zipfile import ZipFile
+import tarfile
 from urllib.request import urlretrieve
 from tempfile import mktemp, mkdtemp
 from shutil import rmtree, move
@@ -52,7 +52,7 @@ class ExtensionDownloader:
         """
         1. check if ext already exists
         2. get last commit info
-        3. download & unzip
+        3. download & untar
         4. add it to the db
 
         :rtype: str
@@ -74,9 +74,9 @@ class ExtensionDownloader:
         # 2. get last commit info
         commit = gh_ext.find_compatible_version()
 
-        # 3. download & unzip
-        filename = download_zip(gh_ext.get_download_url(commit['sha']))
-        unzip(filename, ext_path)
+        # 3. download & untar
+        filename = download_tarball(gh_ext.get_download_url(commit['sha']))
+        untar(filename, ext_path)
 
         # 4. add to the db
         self.ext_db.put(ext_id, {
@@ -133,8 +133,8 @@ class ExtensionDownloader:
         ext_path = os.path.join(EXTENSIONS_DIR, ext_id)
 
         gh_ext = GithubExtension(ext['url'])
-        filename = download_zip(gh_ext.get_download_url(commit['last_commit']))
-        unzip(filename, ext_path)
+        filename = download_tarball(gh_ext.get_download_url(commit['last_commit']))
+        untar(filename, ext_path)
 
         ext['updated_at'] = datetime.now().isoformat()
         ext['last_commit'] = commit['last_commit']
@@ -170,10 +170,10 @@ class ExtensionDownloader:
         return ext
 
 
-def unzip(filename: str, ext_path: str) -> None:
+def untar(filename: str, ext_path: str) -> None:
     """
     1. Remove ext_path
-    2. Extract zip into temp dir
+    2. Extract tar into temp dir
     3. Move contents of <temp_dir>/<project_name>-master/* to ext_path
     """
     if os.path.exists(ext_path):
@@ -181,8 +181,7 @@ def unzip(filename: str, ext_path: str) -> None:
 
     temp_ext_path = mkdtemp(prefix='ulauncher_dl_')
 
-    with ZipFile(filename) as zipfile:
-        zipfile.extractall(temp_ext_path)
+    tarfile.open(filename, mode="r").extractall(temp_ext_path)
 
     for dir in os.listdir(temp_ext_path):
         move(os.path.join(temp_ext_path, dir), ext_path)
@@ -190,8 +189,8 @@ def unzip(filename: str, ext_path: str) -> None:
         return
 
 
-def download_zip(url: str) -> str:
-    dest_zip = mktemp('.zip', prefix='ulauncher_dl_')
-    filename, _ = urlretrieve(url, dest_zip)
+def download_tarball(url: str) -> str:
+    dest_tar = mktemp('.tar.gz', prefix='ulauncher_dl_')
+    filename, _ = urlretrieve(url, dest_tar)
 
     return filename

--- a/ulauncher/api/server/GithubExtension.py
+++ b/ulauncher/api/server/GithubExtension.py
@@ -139,9 +139,9 @@ class GithubExtension:
     def get_download_url(self, commit: str = DEFAULT_GITHUB_BRANCH) -> str:
         """
         >>> https://github.com/Ulauncher/ulauncher-timer
-        <<< https://github.com/Ulauncher/ulauncher-timer/archive/master.zip
+        <<< https://github.com/Ulauncher/ulauncher-timer/archive/master.tar.gz
         """
-        return '%s/archive/%s.zip' % (self.url, commit)
+        return '%s/archive/%s.tar.gz' % (self.url, commit)
 
     def get_ext_id(self) -> str:
         """

--- a/ulauncher/api/server/GithubExtension.py
+++ b/ulauncher/api/server/GithubExtension.py
@@ -139,9 +139,9 @@ class GithubExtension:
     def get_download_url(self, commit: str = DEFAULT_GITHUB_BRANCH) -> str:
         """
         >>> https://github.com/Ulauncher/ulauncher-timer
-        <<< https://github.com/Ulauncher/ulauncher-timer/archive/master.tar.gz
+        <<< https://github.com/Ulauncher/ulauncher-timer/tarball/master
         """
-        return '%s/archive/%s.tar.gz' % (self.url, commit)
+        return '%s/tarball/%s' % (self.url, commit)
 
     def get_ext_id(self) -> str:
         """


### PR DESCRIPTION
This fixed #769 in my basic tests.

Apart from the one line that actually extracts the files I just search for and replaced all occurrences of "zip" without fully understanding/checking the flow, but it worked in my tests and doesn't break the tests.

Can you verify it's working for you @tchar? I could install my fork of your extension reverted to when you had symlinks: https://github.com/friday/ulauncher-albert-calculate-anything, and the usd symlink was working. I didn't actually run your extension though.