### PR TITLE
Fuzzy improvements

### DIFF
--- a/tests/search/apps/test_AppDb.py
+++ b/tests/search/apps/test_AppDb.py
@@ -172,12 +172,12 @@ class TestAppDb:
 
 
 def test_search_name():
-    assert search_name('GNU Image Manipulation Program', r'gimp-2.8 %U') == 'GNU Image Manipulation Program gimp-2.8'
-    assert search_name('Content Hub Clipboard', r'content-hub-clipboard %U') == 'Content Hub Clipboard'
-    assert search_name('Scopes', r'/usr/bin/unity8-dash') == 'Scopes unity8-dash'
-    assert search_name('Mouse & Touchpad', r'unity-control-center mouse') == 'Mouse & Touchpad unity-control-center'
-    assert search_name('Back Up', r'deja-dup --backup') == 'Back Up deja-dup'
-    assert search_name('Calendar', r'gnome-calendar') == 'Calendar'
-    assert search_name('Amazon', r'unity-webapps-runner --amazon --app-id=ubuntu-amazon-default') == \
+    assert search_name('GNU Image Manipulation Program', 'gimp-2.8 %U') == 'GNU Image Manipulation Program gimp-2.8'
+    assert search_name('Content Hub Clipboard', 'content-hub-clipboard %U') == 'Content Hub Clipboard'
+    assert search_name('Scopes', '/usr/bin/unity8-dash') == 'Scopes unity8-dash'
+    assert search_name('Mouse & Touchpad', 'unity-control-center mouse') == 'Mouse & Touchpad unity-control-center'
+    assert search_name('Back Up', 'deja-dup --backup') == 'Back Up deja-dup'
+    assert search_name('Calendar', 'gnome-calendar') == 'Calendar'
+    assert search_name('Amazon', 'unity-webapps-runner --amazon --app-id=ubuntu-amazon-default') == \
         'Amazon unity-webapps-runner'
-    assert search_name('Back Up', r'env VAR1=VAL1 VAR2=VAL2 deja-dup --backup') == 'Back Up deja-dup'
+    assert search_name('Back Up', 'env VAR1=VAL1 VAR2=VAL2 deja-dup --backup') == 'Back Up deja-dup'

--- a/tests/search/apps/test_AppDb.py
+++ b/tests/search/apps/test_AppDb.py
@@ -129,7 +129,7 @@ class TestAppDb:
             'desktop_file_short': 'file_name_test1',
             'name': 'name_test1',
             'description': 'description_test1',
-            'search_name': 'name_test1',
+            'search_name': 'name_test1\n',
             'icon': app_icon_cache.get_pixbuf.return_value
         }
 
@@ -182,6 +182,6 @@ def test_get_exec_name():
 
 
 def test_search_name():
-    assert search_name('Mouse & Touchpad', 'unity-control-center') == 'Mouse & Touchpad unity-control-center'
-    assert search_name('Back Up', 'deja-dup') == 'Back Up deja-dup'
-    assert search_name('Calendar', 'gnome-calendar') == 'Calendar'
+    assert search_name('Mouse & Touchpad', 'unity-control-center') == 'Mouse & Touchpad\nunity-control-center'
+    assert search_name('Back Up', 'deja-dup') == 'Back Up\ndeja-dup'
+    assert search_name('Calendar', 'gnome-calendar') == 'Calendar\ngnome-calendar'

--- a/tests/search/apps/test_AppDb.py
+++ b/tests/search/apps/test_AppDb.py
@@ -1,7 +1,7 @@
 from collections.abc import Iterable
 import pytest
 import mock
-from ulauncher.search.apps.AppDb import AppDb, search_name
+from ulauncher.search.apps.AppDb import AppDb, search_name, get_exec_name
 from ulauncher.search.apps.AppIconCache import AppIconCache
 
 
@@ -171,13 +171,17 @@ class TestAppDb:
         }
 
 
+def test_get_exec_name():
+    assert get_exec_name('gnome-system-monitor') == 'gnome-system-monitor'
+    assert get_exec_name('gimp-2.10 %U') == 'gimp-2.10'
+    assert get_exec_name('nautilus --new-window %U') == 'nautilus'
+    assert get_exec_name('gnome-control-center applications') == 'gnome-control-center'
+    assert get_exec_name('/opt/sublime_text/sublime_text %F') == 'sublime_text'
+    assert get_exec_name('thunar --bulk-rename %F') == 'thunar'
+    assert get_exec_name('env VAR1=VAL1 /usr/bin/asdf --arg') == 'asdf'
+
+
 def test_search_name():
-    assert search_name('GNU Image Manipulation Program', 'gimp-2.8 %U') == 'GNU Image Manipulation Program gimp-2.8'
-    assert search_name('Content Hub Clipboard', 'content-hub-clipboard %U') == 'Content Hub Clipboard'
-    assert search_name('Scopes', '/usr/bin/unity8-dash') == 'Scopes unity8-dash'
-    assert search_name('Mouse & Touchpad', 'unity-control-center mouse') == 'Mouse & Touchpad unity-control-center'
-    assert search_name('Back Up', 'deja-dup --backup') == 'Back Up deja-dup'
+    assert search_name('Mouse & Touchpad', 'unity-control-center') == 'Mouse & Touchpad unity-control-center'
+    assert search_name('Back Up', 'deja-dup') == 'Back Up deja-dup'
     assert search_name('Calendar', 'gnome-calendar') == 'Calendar'
-    assert search_name('Amazon', 'unity-webapps-runner --amazon --app-id=ubuntu-amazon-default') == \
-        'Amazon unity-webapps-runner'
-    assert search_name('Back Up', 'env VAR1=VAL1 VAR2=VAL2 deja-dup --backup') == 'Back Up deja-dup'

--- a/tests/search/test_SortedList.py
+++ b/tests/search/test_SortedList.py
@@ -27,14 +27,12 @@ class TestSortedList:
         get_score.return_value = 41
         res_list.append(ri1)
         assert ri1 in res_list
-        get_score.assert_called_with('bro', ri1.get_search_name.return_value)
 
         ri2 = self.result_item()
         ri2.get_search_name.return_value = None
         get_score.return_value = 12
         res_list.append(ri2)
         assert ri2 not in res_list
-        get_score.assert_called_with('bro', ri2.get_search_name.return_value)
 
     def test_append_maintains_limit(self, res_list, get_score):
         get_score.return_value = 50

--- a/tests/utils/test_fuzzy_search.py
+++ b/tests/utils/test_fuzzy_search.py
@@ -7,9 +7,6 @@ def test_get_matching_indexes():
 
 
 def test_get_score():
-    assert get_score('fiwebro', 'Firefox Web Browser') > get_score('fiwebro', 'Firefox Web SBrowser')
-    assert get_score('j', 'johnny') < get_score('j', 'john')
-    assert get_score('calc', 'LibreOffice Calc') < get_score('calc', 'Calc')
     assert get_score('calc', 'Contacts') < get_score('calc', 'LibreOffice Calc')
     assert get_score('pla', 'Pycharm') < get_score('pla', 'Google Play Music')
     assert get_score('', 'LibreOffice Calc') == 0

--- a/ulauncher/search/SortedList.py
+++ b/ulauncher/search/SortedList.py
@@ -49,7 +49,7 @@ class SortedList:
         name, exec_name, *_ = f'{search_fields}\n'.split('\n')
         score = max(
             get_score(self._query, name),
-            get_score(self._query, exec_name)
+            get_score(self._query, exec_name) * .8
         )
 
         if score >= self._min_score:

--- a/ulauncher/search/SortedList.py
+++ b/ulauncher/search/SortedList.py
@@ -43,7 +43,15 @@ class SortedList:
             self.append(item)
 
     def append(self, result_item):
-        score = get_score(self._query, result_item.get_search_name())
+        # get_search_name() returns a string with the app display name, but it may contain a
+        # second line in which case that line is the name of the executable
+        search_fields = result_item.get_search_name()
+        name, exec_name, *_ = f'{search_fields}\n'.split('\n')
+        score = max(
+            get_score(self._query, name),
+            get_score(self._query, exec_name)
+        )
+
         if score >= self._min_score:
             result_item.score = -score  # use negative to sort by score in desc. order
             self._items.insert(result_item)

--- a/ulauncher/search/apps/AppDb.py
+++ b/ulauncher/search/apps/AppDb.py
@@ -169,11 +169,4 @@ def search_name(name, exec_name):
     Returns string that will be used for search
     We want to make sure app can be searchable by its exec_line
     """
-    exec_name_split = set(exec_name.split('-'))
-    name_split = set(name.lower().split(' '))
-    common_words = exec_name_split & name_split
-
-    if common_words or not exec_name:
-        return name
-
-    return '%s %s' % (name, exec_name)
+    return f'{name}\n{exec_name}'

--- a/ulauncher/search/apps/AppDb.py
+++ b/ulauncher/search/apps/AppDb.py
@@ -144,7 +144,7 @@ class AppDb:
         :rtype: :class:`ResultList`
         """
 
-        result_list = result_list or SortedList(query, min_score=50, limit=9)
+        result_list = result_list or SortedList(query, min_score=75, limit=9)
 
         if not query:
             return result_list

--- a/ulauncher/search/apps/AppDb.py
+++ b/ulauncher/search/apps/AppDb.py
@@ -69,7 +69,7 @@ class AppDb:
         :param Gio.DesktopAppInfo app:
         """
         name = app.get_string('X-GNOME-FullName') or app.get_name()
-        exec_name = app.get_string('Exec') or ''
+        exec_name = get_exec_name(app.get_string('Exec') or '')
         description = app.get_description() or ''
         if not description and (app.get_generic_name() != name):
             description = app.get_generic_name() or ''
@@ -155,28 +155,25 @@ class AppDb:
         return result_list
 
 
+def get_exec_name(exec):
+    """
+    Returns name of the executable file without the full path, env keyword and environment vars
+    Similar to Gio.DesktopAppInfo.get_executable(), except that will not drop env keyword and vars
+    """
+    match = re.match(r'^(env\s+)?([^\s=]+=[^\s=]+\s+)*([^\s=]+\/)*(?P<bin>[^\s=]*)', exec, re.I)
+    return match.group('bin') if match else ""
+
+
 def search_name(name, exec_name):
     """
     Returns string that will be used for search
-    We want to make sure app can be searchable by its exec_name
+    We want to make sure app can be searchable by its exec_line
     """
-    if not exec_name:
-        return name
-
-    # drop env vars
-    exec_name = ' '.join([p for p in exec_name.split(' ') if p != 'env' and '=' not in p])
-
-    # drop "/usr/bin/"
-    match = re.match(r'^(\/.+\/)?([-\w\.]+)([^\w\/]|$)', exec_name.lower(), re.I)
-    if not match:
-        return name
-
-    exec_name = match.group(2)
     exec_name_split = set(exec_name.split('-'))
     name_split = set(name.lower().split(' '))
     common_words = exec_name_split & name_split
 
-    if common_words:
+    if common_words or not exec_name:
         return name
 
     return '%s %s' % (name, exec_name)


### PR DESCRIPTION
This changes the behavior of fuzzy matching

Levenstein distance is the amount of changes needed between one string of text to become the second one. The previous implementation didn't use it in that way, leading to low scores for what I would consider to be positive matches like "wif" for "Wi-Fi", because it was actually checking how many letters to change in "wif" to become "Wi-Fi gnome-control center" (which is most of them), and hence giving it a low score.

1. Instead of concatenating "Wi-Fi gnome-control center" or "Files nautilus" and running the query on that, it runs separately on "Wi-Fi" and "gnome-control center", and picks the one with the best score.
2. #558 Make a custom method for matching queries with results that counter-weights the "how many letters to change to become" part so that short queries can match with long results (also removed tests that expect short queries to favor short results)
3. Change the weighting so that app names are considered slightly more important than executable names, which are sometimes the same across several applications in the same suit (like "Thunar Bulk Rename" in #700).
4. Set a much higher threshold for what's considered a match (it needed to be low before, but now because of 1. and 2. those low scores are just noise). #324

Will probably need to tune this later, but it's a heck of an improvement already. The code is not super pretty, because it's overloading `search_name` and `get_search_name()`. This is a hard problem to solve, since the class they're in is used both for apps and the file browse mode, and only the former really needs this method and the name of the executable.

In my fork I also added the description (and tags, but not properly implemented), and "normalized" both the results and queries, so that only letters and numbers were kept. So for example "Add/Remove Software" and "Wi-Fi" stripped the slash and dash, both in the query and the results used for matching, but I think of these are more controversial changes that can wait.

### Checklist
- [x] Use `dev` as the base branch
- [x] Follow the [Python Code Style Guides](https://github.com/Ulauncher/Ulauncher/wiki/Python-Code-Style-Guides)
- [x] Write unit tests for your changes when applicable
- [x] If your changes alters the behavior or introduce new functionality, please update the documentation accordingly
- [x] All tests are passing
