### PR TITLE
Add support for GDK_BACKEND=wayland,x11

### DIFF
--- a/ulauncher/config.py
+++ b/ulauncher/config.py
@@ -71,7 +71,10 @@ def is_wayland_compatibility_on():
     Set hotkey in OS Settings > Devices > Keyboard > Add Hotkey > Command: ulauncher-toggle
     GDK_BACKEND is typically unset in Wayland sessions to allow GTK apps to self-select
     """
-    return is_wayland() and gdk_backend().lower() in ('wayland', '')
+    return is_wayland() and (
+        gdk_backend() == '' 
+        or gdk_backend().lower().startswith('wayland')
+    )
 
 
 def gdk_backend():


### PR DESCRIPTION
closes #775 

In Wayland environments it's common to have `GDK_BACKEND=wayland,x11` which forces all applications linking to a version of GDK that supports wayland to use it and fallback to x11 in case of a older version (Older electron applications are a good example of applications that need the `,x11` in GDK_BACKEND).

This PR changes it so that Ulauncher does not abort with this configuration and proceeds with using Wayland as GDK backend.

<!--
Thank you for submitting a PR to Ulauncher!

You can also read more about contributing in this document:
https://github.com/Ulauncher/Ulauncher/wiki/Code-Contribution
-->
### Link to related issue (if applicable)
<!--
This is not required, but for your own sake you may want to ensure before putting a lot of time on a PR, that the change is something we want to add and support. If there isn't an issue for it, you're welcome to create one.
-->

### Summary of the changes in this PR

### Checklist (see more [here](https://github.com/Ulauncher/Ulauncher/wiki/Code-Contribution))
- [ ] Use `dev` as the base branch
- [ ] Follow the [Python Code Style Guides](https://github.com/Ulauncher/Ulauncher/wiki/Python-Code-Style-Guides)
- [ ] Write unit tests for your changes when applicable
- [ ] If your changes alters the behavior or introduce new functionality, please update the documentation accordingly
- [ ] All tests are passing

### Tested environment (distro, desktop environment and their versions)
