### PR TITLE
Suggest `ulauncher-toggle` when `ulauncher` is already running

### DIFF
--- a/ulauncher/main.py
+++ b/ulauncher/main.py
@@ -104,6 +104,10 @@ def main():
     instance = bus.request_name(DBUS_SERVICE)
 
     if instance != dbus.bus.REQUEST_NAME_REPLY_PRIMARY_OWNER:
+        print(
+            "DBus name already taken. Ulauncher is probably backgrounded. Did you mean `ulauncher-toggle`?",
+            file=sys.stderr
+        )
         toggle_window = dbus.SessionBus().get_object(DBUS_SERVICE, DBUS_PATH).get_dbus_method("toggle_window")
         toggle_window()
         return


### PR DESCRIPTION
### Summary of the changes in this PR
This adds a log when executing `ulauncher` with existing process already running that suggests user to use the `ulauncher-toggle` script instead of the full `ulauncher` which is about 250ms slower. This is especially useful for people using Wayland compositors who do their keybindings in compositor settings and can easily be mistaken to put `ulauncher` as the executable for menu keybind instead of the faster `ulauncher-toggle`.

### Checklist (see more [here](https://github.com/Ulauncher/Ulauncher/wiki/Code-Contribution))
- [ ] Use `dev` as the base branch
- [ ] Follow the [Python Code Style Guides](https://github.com/Ulauncher/Ulauncher/wiki/Python-Code-Style-Guides)
- [ ] Write unit tests for your changes when applicable
- [ ] If your changes alters the behavior or introduce new functionality, please update the documentation accordingly
- [ ] All tests are passing

### Tested environment (distro, desktop environment and their versions)
