### PR TITLE
Don't install conftest.py

### DIFF
--- a/scripts/help.sh
+++ b/scripts/help.sh
@@ -6,7 +6,7 @@ help () {
   ${bold}./ul init-dev-env
     ${dim}Installs Ulauncher data (icons, static files for preferences, etc.) to '~/.local/share/ulauncher/'${normal}
 
-  ${bold}./ul cleanup-dev-evn
+  ${bold}./ul cleanup-dev-env
     ${dim}Removes files installed by './ul init-dev-env'. Also removes cache files, but not configs${normal}
 
   ${bold}./ul run

--- a/setup.py
+++ b/setup.py
@@ -187,6 +187,7 @@ def main():
         "test",
         "ulauncher.desktop.dev",
         "requirements.txt",
+        "conftest.py"
     ])
 
     DistUtilsExtra.auto.setup(


### PR DESCRIPTION
### Link to related issue (if applicable)
none

### Summary of the changes in this PR
This makes setup.py ignore the conftest.py which is now at the top-level. Otherwise, it installs it to `*/python*/site-packages/conftest.py` which is definitely not what we want. 

This breaks the Fedora build, and even if someone installed from the source tarball, there would be an extraneous file which shouldn't be there.

### Checklist (see more [here](https://github.com/Ulauncher/Ulauncher/wiki/Code-Contribution))
- [x] Use `dev` as the base branch
- [x] Follow the [Python Code Style Guides](https://github.com/Ulauncher/Ulauncher/wiki/Python-Code-Style-Guides)
- [x] Write unit tests for your changes when applicable
- [x] If your changes alters the behavior or introduce new functionality, please update the documentation accordingly
- [x] All tests are passing

### Tested environment (distro, desktop environment and their versions)
Feodra 34, Gnome 40