### PR TITLE
Implement standard shell/emacs ctrl-n/ctrl-p scrolling.

### DIFF
--- a/ulauncher/ui/windows/UlauncherWindow.py
+++ b/ulauncher/ui/windows/UlauncherWindow.py
@@ -178,13 +178,14 @@ class UlauncherWindow(Gtk.Window, WindowHelper):
         keyval = event.get_keyval()
         keyname = Gdk.keyval_name(keyval[1])
         alt = event.state & Gdk.ModifierType.MOD1_MASK
+        ctrl = event.state & Gdk.ModifierType.CONTROL_MASK
         Search.get_instance().on_key_press_event(widget, event, self._get_user_query())
 
         if self.results_nav:
-            if keyname in ('Up', 'ISO_Left_Tab'):
+            if keyname in ('Up', 'ISO_Left_Tab') or (ctrl and keyname == 'p'):
                 self.results_nav.go_up()
                 return True
-            if keyname in ('Down', 'Tab'):
+            if keyname in ('Down', 'Tab') or (ctrl and keyname == 'n'):
                 self.results_nav.go_down()
                 return True
             if alt and keyname in ('Return', 'KP_Enter'):


### PR DESCRIPTION
### Link to related issue (if applicable)
#649 

### Summary of the changes in this PR
It turns out that there was no need for any settings or fancy logic. Ctrl-n and Ctrl-p have no effect in current ulauncher and so are free for use. This PR simply support the Ctrl-n & Ctrl-p option specifically because Ulauncher is responsible for intercepting and responding to keypresses to scroll through results. For other emacs editing features, the user can enable the emacs keymap in Gtk as Ulauncher is a Gtk application. With custom themes it is even possible to enable it only for Ulauncher and not for other apps. However, all of that is out of scope for what Ulauncher is in charge of. Just like it doesn't implement "backspace" in the input field, neither does it implement all the normal emacs line editing commands. 

### Checklist (see more [here](https://github.com/Ulauncher/Ulauncher/wiki/Code-Contribution))
- [x] Use `dev` as the base branch
- [x] Follow the [Python Code Style Guides](https://github.com/Ulauncher/Ulauncher/wiki/Python-Code-Style-Guides)
- [x] Write unit tests for your changes when applicable
- [x] If your changes alters the behavior or introduce new functionality, please update the documentation accordingly
- [x] All tests are passing

### Tested environment (distro, desktop environment and their versions)
Fedora 34, Gnome 40