### PR TITLE
Add ulauncher.service file to the debian package.

### DIFF
--- a/scripts/build-deb.sh
+++ b/scripts/build-deb.sh
@@ -55,6 +55,7 @@ build-deb () {
         setup.py \
         ulauncher \
         ulauncher.desktop.in \
+        ulauncher.service \
         $tmpsrc \
         --exclude-from=.gitignore
     rm -rf $tmpsrc/data/preferences/*


### PR DESCRIPTION
### Link to related issue (if applicable)


### Summary of the changes in this PR
The CI failure after merging my setup.py fixes which include the service file failed because the debian package script didn't copy over the service file. This adds that tweak.

I used the build scripts to build a debian package on a Ubuntu 16.04 VM (which appears to be the version used in the CI container) and installed it to test the fix. I also installed the generated package on Ubuntu 20.04. Note that to get the service file to work on the older Ubuntu additional configuration has to be done in order to provide ulauncher with the right environment, but works out of the box on the newer Ubuntu.

### Checklist (see more [here](https://github.com/Ulauncher/Ulauncher/wiki/Code-Contribution))
- [x] Use `dev` as the base branch
- [x] Follow the [Python Code Style Guides](https://github.com/Ulauncher/Ulauncher/wiki/Python-Code-Style-Guides)
- [x] Write unit tests for your changes when applicable
- [x] If your changes alters the behavior or introduce new functionality, please update the documentation accordingly
- [x] All tests are passing

### Tested environment (distro, desktop environment and their versions)
Ubuntu 16.04, Gnome 3.14
Ubuntu 20.04, Gnome 3.30