### PR TITLE
Wayland fix

### DIFF
--- a/ulauncher.service
+++ b/ulauncher.service
@@ -6,7 +6,7 @@ Documentation=https://ulauncher.io/
 Type=simple
 Restart=always
 RestartSec=1
-ExecStart=/usr/bin/ulauncher --hide-window
+ExecStart=env GDK_BACKEND=x11 /usr/bin/ulauncher --hide-window
 
 [Install]
 WantedBy=graphical-session.target

--- a/ulauncher/api/shared/action/LaunchAppAction.py
+++ b/ulauncher/api/shared/action/LaunchAppAction.py
@@ -1,4 +1,5 @@
 import logging
+import os
 import subprocess
 import re
 import shlex
@@ -57,9 +58,15 @@ class LaunchAppAction(BaseAction):
                     '--scope',
                     '--slice=app-{}'.format(sanitized_app)
                 ] + sanitized_exec
+
+            env = dict(os.environ.items())
+            # Make sure GDK apps aren't forced to use x11 on wayland due to ulauncher's need to run
+            # under X11 for proper centering.
+            env.pop("GDK_BACKEND", None)
+
             try:
                 logger.info('Run application %s (%s) Exec %s', app.get_name(), self.filename, exec)
                 # Start_new_session is only needed if systemd-run is missing
-                subprocess.Popen(sanitized_exec, start_new_session=True)
+                subprocess.Popen(sanitized_exec, env=env, start_new_session=True)
             except Exception as e:
                 logger.error('%s: %s', type(e).__name__, e)


### PR DESCRIPTION
### Link to related issue (if applicable)

### Summary of the changes in this PR
This fixes ulauncher on wayland when started from systemd. It also makes sure GDK applications launched by ulauncher don't get forced into using Xwayland unnecessarily.

### Checklist (see more [here](https://github.com/Ulauncher/Ulauncher/wiki/Code-Contribution))
- [x] Use `dev` as the base branch
- [x] Follow the [Python Code Style Guides](https://github.com/Ulauncher/Ulauncher/wiki/Python-Code-Style-Guides)
- [x] Write unit tests for your changes when applicable
- [x] If your changes alters the behavior or introduce new functionality, please update the documentation accordingly
- [x] All tests are passing

### Tested environment (distro, desktop environment and their versions)
Fedora 34, Gnome 40