### PR TITLE
HiDPI support

### DIFF
--- a/data/ui/result_item.ui
+++ b/data/ui/result_item.ui
@@ -1,31 +1,31 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!-- Generated with glade 3.22.1 -->
+<!-- Generated with glade 3.38.2 -->
 <interface>
-  <requires lib="gtk+" version="3.8"/>
+  <requires lib="gtk+" version="3.16"/>
   <requires lib="result_item" version="1.0"/>
   <!-- interface-local-resource-path ../media -->
   <object class="ResultItemWidget" id="item-frame">
     <property name="name">item_frame</property>
     <property name="visible">True</property>
-    <property name="can_focus">False</property>
+    <property name="can-focus">False</property>
     <child>
       <object class="GtkEventBox" id="item-box">
         <property name="visible">True</property>
-        <property name="can_focus">False</property>
+        <property name="can-focus">False</property>
         <child>
           <object class="GtkBox" id="item-container">
             <property name="visible">True</property>
-            <property name="can_focus">False</property>
-            <property name="margin_left">20</property>
-            <property name="margin_right">20</property>
-            <property name="margin_top">3</property>
-            <property name="margin_bottom">3</property>
+            <property name="can-focus">False</property>
+            <property name="margin-left">20</property>
+            <property name="margin-right">20</property>
+            <property name="margin-top">3</property>
+            <property name="margin-bottom">3</property>
             <child>
               <object class="GtkImage" id="item-icon">
-                <property name="width_request">50</property>
-                <property name="height_request">50</property>
+                <property name="width-request">50</property>
+                <property name="height-request">50</property>
                 <property name="visible">True</property>
-                <property name="can_focus">False</property>
+                <property name="can-focus">False</property>
                 <property name="stock">gtk-missing-image</property>
                 <style>
                   <class name="item-icon"/>
@@ -40,17 +40,17 @@
             <child>
               <object class="GtkFixed" id="name_wrapper">
                 <property name="visible">True</property>
-                <property name="can_focus">False</property>
-                <property name="margin_left">5</property>
+                <property name="can-focus">False</property>
+                <property name="margin-left">5</property>
                 <property name="hexpand">True</property>
                 <property name="vexpand">False</property>
                 <child>
                   <object class="GtkLabel" id="item-name">
-                    <property name="width_request">410</property>
+                    <property name="width-request">410</property>
                     <property name="visible">True</property>
-                    <property name="can_focus">False</property>
+                    <property name="can-focus">False</property>
                     <property name="ellipsize">middle</property>
-                    <property name="max_width_chars">1</property>
+                    <property name="max-width-chars">1</property>
                     <property name="xalign">0</property>
                     <style>
                       <class name="item-name"/>
@@ -63,11 +63,11 @@
                 </child>
                 <child>
                   <object class="GtkLabel" id="item-descr">
-                    <property name="width_request">410</property>
+                    <property name="width-request">410</property>
                     <property name="visible">True</property>
-                    <property name="can_focus">False</property>
+                    <property name="can-focus">False</property>
                     <property name="ellipsize">middle</property>
-                    <property name="max_width_chars">1</property>
+                    <property name="max-width-chars">1</property>
                     <property name="xalign">0</property>
                     <style>
                       <class name="item-descr"/>
@@ -88,10 +88,10 @@
             <child>
               <object class="GtkLabel" id="item-shortcut">
                 <property name="name">item-shortcut</property>
-                <property name="width_request">44</property>
+                <property name="width-request">44</property>
                 <property name="visible">True</property>
-                <property name="can_focus">False</property>
-                <property name="margin_left">15</property>
+                <property name="can-focus">False</property>
+                <property name="margin-left">15</property>
                 <property name="label">Alt+1</property>
                 <property name="justify">right</property>
                 <style>

--- a/data/ui/result_item.ui
+++ b/data/ui/result_item.ui
@@ -38,17 +38,20 @@
               </packing>
             </child>
             <child>
-              <object class="GtkFixed" id="name_wrapper">
+              <object class="GtkBox" id="name_wrapper">
+                <property name="width-request">410</property>
                 <property name="visible">True</property>
                 <property name="can-focus">False</property>
                 <property name="margin-left">5</property>
-                <property name="hexpand">True</property>
-                <property name="vexpand">False</property>
+                <property name="hexpand">False</property>
+                <property name="vexpand">True</property>
+                <property name="orientation">vertical</property>
                 <child>
                   <object class="GtkLabel" id="item-name">
-                    <property name="width-request">410</property>
                     <property name="visible">True</property>
                     <property name="can-focus">False</property>
+                    <property name="margin-top">5</property>
+                    <property name="hexpand">True</property>
                     <property name="ellipsize">middle</property>
                     <property name="max-width-chars">1</property>
                     <property name="xalign">0</property>
@@ -58,14 +61,16 @@
                     </style>
                   </object>
                   <packing>
-                    <property name="y">5</property>
+                    <property name="expand">False</property>
+                    <property name="fill">True</property>
+                    <property name="position">0</property>
                   </packing>
                 </child>
                 <child>
                   <object class="GtkLabel" id="item-descr">
-                    <property name="width-request">410</property>
                     <property name="visible">True</property>
                     <property name="can-focus">False</property>
+                    <property name="hexpand">True</property>
                     <property name="ellipsize">middle</property>
                     <property name="max-width-chars">1</property>
                     <property name="xalign">0</property>
@@ -75,7 +80,9 @@
                     </style>
                   </object>
                   <packing>
-                    <property name="y">28</property>
+                    <property name="expand">False</property>
+                    <property name="fill">True</property>
+                    <property name="position">1</property>
                   </packing>
                 </child>
               </object>


### PR DESCRIPTION
Fixes #322 for the main ulauncher widget (not Preferences)

This PR switches from `GtkFixed` container to `GTKBox` so the layout won't break with large fonts. It also moves the width from the children to the parent so there's only one place to change if we need to override.

1x:
![2021-09-04_20-52](https://user-images.githubusercontent.com/515120/132105164-0d1e021f-cdbd-4705-97f9-f4cd64b89d31.png)

1.33x:
![2021-09-04_20-51](https://user-images.githubusercontent.com/515120/132105114-88bb38e8-a982-49ce-bf6e-88f59ce2c60a.png)

2x:
![2021-09-04_20-48](https://user-images.githubusercontent.com/515120/132105080-bc3b3080-6019-4bdf-bedb-4148fa7374b6.png)


### Checklist (see more [here](https://github.com/Ulauncher/Ulauncher/wiki/Code-Contribution))
- [x] Use `dev` as the base branch
- [ ] Write unit tests for your changes when applicable
- [ ] If your changes alters the behavior or introduce new functionality, please update the documentation accordingly
- [x] All tests are passing

### Tested environment (distro, desktop environment and their versions)
