### PR TITLE
Add ability to show all apps

### DIFF
--- a/data/preferences/src/api/fixture.js
+++ b/data/preferences/src/api/fixture.js
@@ -16,6 +16,7 @@ export default function(url, params) {
         clear_previous_text: true,
         grab_mouse_pointer: true,
         blacklisted_desktop_dirs: ['/var/tmp', '/tmp/var/log/bin/bash/root'].join(':'),
+        disable_desktop_filters: false,
         available_themes: [{ text: 'Dark', value: 'dark' }, { text: 'Light', value: 'light' }],
         theme_name: 'light',
         is_wayland: true,
@@ -48,6 +49,9 @@ export default function(url, params) {
       setTimeout(resolve, 0)
     } else if (isMatch(url, '/set/blacklisted-desktop-dirs')) {
       console.log('/set/blacklisted-desktop-dirs', params)
+      setTimeout(resolve, 0)
+    } else if (isMatch(url, '/set/disable-desktop-filters')) {
+      console.log('/set/disable-desktop-filters', params)
       setTimeout(resolve, 0)
     } else if (isMatch(url, '/open/web-url')) {
       console.log('/open/web-url', params)

--- a/data/preferences/src/components/pages/Preferences.vue
+++ b/data/preferences/src/components/pages/Preferences.vue
@@ -146,6 +146,22 @@
           ></editable-text-list>
         </td>
       </tr>
+      <tr>
+        <td class="pull-top">
+          <label for="disable-desktop-filters">Show All Apps</label>
+          <small>
+            <p>
+              Display all applications, even if they are configured to not show in the current desktop environment.
+            </p>
+            <p v-if="disableDesktopFiltersChanged">
+              <i class="fa fa-warning"></i> Restart Ulauncher for this to take effect
+            </p>
+          </small>
+        </td>
+        <td class="pull-top">
+          <b-form-checkbox id="disable-desktop-filters" v-model="disable_desktop_filters"></b-form-checkbox>
+        </td>
+      </tr>
     </table>
   </div>
 </template>
@@ -288,6 +304,21 @@ export default {
           () => {
             this.setPrefs({ blacklisted_desktop_dirs: value })
             this.blacklistedDirsChanged = true
+          },
+          err => bus.$emit('error', err)
+        )
+      }
+    },
+
+    disable_desktop_filters: {
+      get() {
+        return this.prefs.disable_desktop_filters
+      },
+      set(value) {
+        return jsonp('prefs://set/disable-desktop-filters', { value: value }).then(
+          () => {
+            this.setPrefs({ disable_desktop_filters: value })
+            this.disableDesktopFiltersChanged = true
           },
           err => bus.$emit('error', err)
         )

--- a/ulauncher/search/apps/app_watcher.py
+++ b/ulauncher/search/apps/app_watcher.py
@@ -8,6 +8,7 @@ import pyinotify
 
 from ulauncher.utils.decorator.run_async import run_async
 from ulauncher.utils.desktop.reader import find_desktop_files, read_desktop_file, filter_app, find_apps_cached
+from ulauncher.utils.Settings import Settings
 from ulauncher.search.apps.AppDb import AppDb
 from ulauncher.config import DESKTOP_DIRS
 
@@ -30,6 +31,9 @@ def _only_desktop_files(func):
 
 
 DeferredFiles = Dict[str, float]
+
+settings = Settings.get_instance()
+disable_desktop_filters = settings.get_property('disable-desktop-filters')
 
 
 class AppNotifyEventHandler(pyinotify.ProcessEvent):
@@ -118,7 +122,7 @@ class AppNotifyEventHandler(pyinotify.ProcessEvent):
 
         try:
             app = read_desktop_file(pathname)
-            if filter_app(app):
+            if filter_app(app, disable_desktop_filters):
                 self.__db.put_app(app)
                 logger.info('New app was added "%s" (%s)', app.get_name(), app.get_filename())
             else:
@@ -165,7 +169,7 @@ def start():
     db = AppDb.get_instance()
     t0 = time()
     logger.info('Started scanning desktop dirs')
-    for app in find_apps_cached():
+    for app in find_apps_cached(None, disable_desktop_filters):
         db.put_app(app)
     logger.info('Scanned desktop dirs in %.2f seconds', (time() - t0))
 

--- a/ulauncher/ui/windows/PreferencesUlauncherDialog.py
+++ b/ulauncher/ui/windows/PreferencesUlauncherDialog.py
@@ -244,6 +244,7 @@ class PreferencesUlauncherDialog(Gtk.Dialog, WindowHelper):
             'show_recent_apps': self.settings.get_property('show-recent-apps'),
             'clear_previous_query': self.settings.get_property('clear-previous-query'),
             'blacklisted_desktop_dirs': self.settings.get_property('blacklisted-desktop-dirs'),
+            'disable_desktop_filters': self.settings.get_property('disable-desktop-filters'),
             'available_themes': self._get_available_themes(),
             'theme_name': Theme.get_current().get_name(),
             'render_on_screen': self.settings.get_property('render-on-screen'),
@@ -347,6 +348,13 @@ class PreferencesUlauncherDialog(Gtk.Dialog, WindowHelper):
         dirs = url_params['query']['value']
         logger.info('Set blacklisted-desktop-dirs to %s', dirs)
         self.settings.set_property('blacklisted-desktop-dirs', dirs)
+        self.settings.save_to_file()
+
+    @rt.route('/set/disable-desktop-filters')
+    def prefs_set_disable_desktop_filters(self, url_params):
+        is_on = self._get_bool(url_params['query']['value'])
+        logger.info('Set disable-desktop-filters to %s', is_on)
+        self.settings.set_property('disable-desktop-filters', is_on)
         self.settings.save_to_file()
 
     @rt.route('/set/render-on-screen')

--- a/ulauncher/utils/Settings.py
+++ b/ulauncher/utils/Settings.py
@@ -65,6 +65,11 @@ GPROPERTIES = {
                            None,
                            False,
                            GObject.ParamFlags.READWRITE),
+    "disable-desktop-filters": (bool,  # type
+                                "Display all apps in environment despite OnlyShowIn/NotShowIn",  # nick name
+                                None,  # description
+                                False,  # default
+                                GObject.ParamFlags.READWRITE),  # flags
 }
 
 


### PR DESCRIPTION
This commit adds a configurable flag: `show-all-apps` to display all
apps despite the current desktop environement and the values:

- `OnlyShowIn`
- `NotShowIn`

from the `.desktop` files.

Closes #809

<!--
Thank you for submitting a PR to Ulauncher!

Please read our contribution instructions if you haven't:
https://github.com/Ulauncher/Ulauncher#code-contribution

Explain the changes in this PR and link to related issue(s) if applicable
-->

### Checklist
- [x] Verify that the test command `./ul test` is passing (the CI server will check this if you don't)
- [x] Update the documentation according to your changes (when applicable) -> Not sure if it needs to more documented than it is (in the settings).
- [x] Write unit tests for your changes (when applicable)
