### PR TITLE
Ensure child processes are reaped.

### DIFF
--- a/ulauncher/api/shared/action/LaunchAppAction.py
+++ b/ulauncher/api/shared/action/LaunchAppAction.py
@@ -7,12 +7,18 @@ import shutil
 from pathlib import Path
 
 from ulauncher.utils.desktop.reader import read_desktop_file
+from ulauncher.utils.decorator.run_async import run_async
 from ulauncher.utils.Settings import Settings
 from ulauncher.api.shared.action.BaseAction import BaseAction
 
 logger = logging.getLogger(__name__)
 settings = Settings.get_instance()
 hasSystemdRun = bool(shutil.which("systemd-run"))
+
+
+@run_async
+def wait_for_pid(pid):
+    os.waitpid(pid, 0)
 
 
 class LaunchAppAction(BaseAction):
@@ -67,6 +73,7 @@ class LaunchAppAction(BaseAction):
             try:
                 logger.info('Run application %s (%s) Exec %s', app.get_name(), self.filename, exec)
                 # Start_new_session is only needed if systemd-run is missing
-                subprocess.Popen(sanitized_exec, env=env, start_new_session=True)
+                pid = subprocess.Popen(sanitized_exec, env=env, start_new_session=True).pid
+                wait_for_pid(pid)
             except Exception as e:
                 logger.error('%s: %s', type(e).__name__, e)


### PR DESCRIPTION
Fixes #811.

I did replicate the issue described in #811. Interestingly there was only ever one defunct process, but it would stick around, sometime even chewing up 5% or so CPU until the next process was launched & terminated.  I'm not *super* happy with this solution, as I tend to try to reduce threads typically. However, I didn't come up with a great alternative. Some ideas I thought of:

- A single thread that would wait on any child (`waitpid(0,0)`) in a loop until there were none. Then some kind of singleton control to restart the thread again if needed with the next child. However, we don't want this to reap the extension children, so that doesn't work.
- Using the asyncio lib's subprocess support. Internally this uses an event loop implementation, and isn't something we are using elsewhere. It seems like there was a lot more nuance to get right there, especially with the fact we have the Gtk event loop already running
-  Gio.Subprocess: I strongly considered this implementation, and is fact something I've implemented in my test branch where I've implemented unix sockets (namely to git rid of the thread-per-extension in an effort to help trim down resources). However, that would mean changing to a new launching mechanism and all the change/testing that would entail, and I didn't think it was worth the potentially risky change.

### Checklist
- [X] Verify that the test command `./ul test` is passing (the CI server will check this if you don't)
- [X] Update the documentation according to your changes (when applicable)
- [X] Write unit tests for your changes (when applicable)
