### PR TITLE
Allow overriding extension icon at the keyword level.

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -13,5 +13,10 @@
     "python.linting.pylintEnabled": true,
     "python.linting.flake8Enabled": true,
     "python.linting.mypyEnabled": true,
-    "restructuredtext.confPath": "${workspaceFolder}/docs"
+    "restructuredtext.confPath": "${workspaceFolder}/docs",
+    "python.testing.pytestArgs": [
+        "tests"
+    ],
+    "python.testing.unittestEnabled": false,
+    "python.testing.pytestEnabled": true
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -13,10 +13,5 @@
     "python.linting.pylintEnabled": true,
     "python.linting.flake8Enabled": true,
     "python.linting.mypyEnabled": true,
-    "restructuredtext.confPath": "${workspaceFolder}/docs",
-    "python.testing.pytestArgs": [
-        "tests"
-    ],
-    "python.testing.unittestEnabled": false,
-    "python.testing.pytestEnabled": true
+    "restructuredtext.confPath": "${workspaceFolder}/docs"
 }

--- a/docs/extensions/tutorial.rst
+++ b/docs/extensions/tutorial.rst
@@ -140,6 +140,9 @@ The values of the preferences are forwarded to the ``on_event`` method of the ``
 ``description``
   Optional description
 
+``icon``
+  Optional per-keyword icon path. If not specificed it will use the extension icon
+
 ``options``
   Required for type "select". Must be a list of strings or objects like: ``{"value": "...", "text": "..."}``
 

--- a/tests/api/server/test_ExtensionManifest.py
+++ b/tests/api/server/test_ExtensionManifest.py
@@ -109,12 +109,24 @@ class TestExtensionManifest:
     def test_get_preference(self, ext_dir):
         manifest_dict = {
             'preferences': [
-                {'id': 'myid', 'type': 'keyword', 'default_value': 'mi', 'name': "Mimimi"},
+                {'id': 'myid', 'type': 'keyword', 'default_value': 'mi', 'name': "Mimimi", 'icon': 'images/icon.png'},
                 {'id': 'newid', 'type': 'input', 'default_value': 'ni'}
             ]
         }
         manifest = ExtensionManifest('test_extension', manifest_dict, ext_dir)
-        assert manifest.get_preference('newid') == {'id': 'newid', 'type': 'input', 'default_value': 'ni'}
+        assert manifest.get_preference('newid') == {
+            'id': 'newid',
+            'type': 'input',
+            'default_value': 'ni',
+        }
+
+        assert manifest.get_preference('myid') == {
+            'id': 'myid',
+            'type': 'keyword',
+            'default_value': 'mi',
+            'name': 'Mimimi',
+            'icon': 'images/icon.png'
+        }
 
     def test_get_option__option_exists__value_returned(self, ext_dir):
         manifest_dict = {

--- a/ulauncher/api/server/ExtensionManifest.py
+++ b/ulauncher/api/server/ExtensionManifest.py
@@ -22,14 +22,16 @@ OptionItems = List[OptionItem]
 Options = TypedDict('Options', {
     'query_debounce': float
 })
-ManifestPreferenceItem = TypedDict('ManifestPreferenceItem', {
-    'id': str,
-    'type': str,
-    'name': str,
-    'description': str,
-    'default_value': str,
-    'options': OptionItems
-})
+ManifestPreferenceItem = TypedDict(
+    'ManifestPreferenceItem', {
+        'id': str,
+        'type': str,
+        'name': str,
+        'description': str,
+        'default_value': str,
+        'options': OptionItems,
+        'icon': str,
+    })
 ManifestJson = TypedDict('ManifestJson', {
     'required_api_version': str,
     'name': str,
@@ -73,6 +75,10 @@ class ExtensionManifest:
 
     def load_icon(self, size):
         return load_image(self.get_icon_path(), size)
+
+    def load_icon_from_path(self, path, size):
+        abs_path = os.path.join(self.extensions_dir, self.extension_id, path)
+        return load_image(abs_path, size)
 
     def get_required_api_version(self) -> str:
         return self.manifest['required_api_version']

--- a/ulauncher/api/server/ExtensionManifest.py
+++ b/ulauncher/api/server/ExtensionManifest.py
@@ -73,11 +73,8 @@ class ExtensionManifest:
     def get_icon_path(self) -> str:
         return os.path.join(self.extensions_dir, self.extension_id, self.get_icon())
 
-    def load_icon(self, size):
-        return load_image(self.get_icon_path(), size)
-
-    def load_icon_from_path(self, path, size):
-        abs_path = os.path.join(self.extensions_dir, self.extension_id, path)
+    def load_icon(self, size, path=None):
+        abs_path = os.path.join(self.extensions_dir, self.extension_id, path) if path else self.get_icon_path()
         return load_image(abs_path, size)
 
     def get_required_api_version(self) -> str:

--- a/ulauncher/api/server/ExtensionPreferences.py
+++ b/ulauncher/api/server/ExtensionPreferences.py
@@ -18,6 +18,7 @@ PreferenceItem = TypedDict('PreferenceItem', {
     'default_value': str,
     'user_value': str,
     'value': str,
+    'icon': Optional[str]
 })
 PreferenceItems = List[PreferenceItem]
 
@@ -61,7 +62,8 @@ class ExtensionPreferences:
                 'options': p.get('options', []),
                 'default_value': default_value,
                 'user_value': self.db.find(p['id']) or '',
-                'value': self.db.find(p['id']) or default_value
+                'value': self.db.find(p['id']) or default_value,
+                'icon': p.get('icon', None)
             })
 
         return items

--- a/ulauncher/api/server/ExtensionSearchMode.py
+++ b/ulauncher/api/server/ExtensionSearchMode.py
@@ -55,12 +55,7 @@ class ExtensionSearchMode(BaseSearchMode):
                 if not pref['value']:
                     continue
 
-                if pref['icon'] is not None:
-                    icon = c.manifest.load_icon_from_path(pref['icon'], ExtensionKeywordResultItem.get_icon_size())
-                else:
-                    icon = c.manifest.load_icon(
-                        ExtensionKeywordResultItem.get_icon_size())
-
+                icon = c.manifest.load_icon(ExtensionKeywordResultItem.get_icon_size(), path=pref['icon'])
                 items.append(ExtensionKeywordResultItem(name=html.escape(pref['name']),
                                                         description=html.escape(pref['description']),
                                                         keyword=pref['value'],

--- a/ulauncher/api/server/ExtensionSearchMode.py
+++ b/ulauncher/api/server/ExtensionSearchMode.py
@@ -55,7 +55,12 @@ class ExtensionSearchMode(BaseSearchMode):
                 if not pref['value']:
                     continue
 
-                icon = c.manifest.load_icon(ExtensionKeywordResultItem.get_icon_size())
+                if pref['icon'] is not None:
+                    icon = c.manifest.load_icon_from_path(pref['icon'], ExtensionKeywordResultItem.get_icon_size())
+                else:
+                    icon = c.manifest.load_icon(
+                        ExtensionKeywordResultItem.get_icon_size())
+
                 items.append(ExtensionKeywordResultItem(name=html.escape(pref['name']),
                                                         description=html.escape(pref['description']),
                                                         keyword=pref['value'],


### PR DESCRIPTION
I was just experimenting with this and manage to implement the feature in 1h or so, that´s why I didn´t open an issue before.

This PR allows specifying an icon, associated with a keyword, that will override the global the extension icon defined in the extension manifest when the extension is triggered using that keyword.

The main use case for this feature, is for extensions that implement multiple keywords, with different goals, where the developer might want to use a distinctive icon for each.

For example, on my [docsearch](https://github.com/brpaz/ulauncher-docsearch) extension, which allows users to search on documentation sites that implement [Algolia Docsearch](https://docsearch.algolia.com/), the user can access, for example, the  Vue documentation, using  `docsearch vue <query>` but also I want to have direct keywords for each documentation site like  `vue <query>`. In the latter, I would like to display the specific documentation icon instead of the extension icon.

With the changes in this PR, the only thing I need to do is on the on the `manifest.json` of my extension, define an "icon" property in the keyword preference object like so:

```json
 {
    "id": "kw_vue",
    "type": "keyword",
    "name": "Vue Documentation",
    "default_value": "vuedocs",
    "icon": "images/docs/vue.png"
},
```

When matching the input keyword with the extension preferences, Ulauncher will check if the "icon" property is defined and if yes, use that instead of the extension icon.

The new field is completely optional and should not break anything.

**Notes**

- The VS code configuration change was necessary so I can run unit tests directly from the editor. I can remove it from the commit but since Ulauncher already includes a `.vscode/settings.json` I think it might make sense to be versioned.
- I will update the documentation if you are ok with this feature.

### Checklist
- [x] Verify that the test command `./ul test` is passing (the CI server will check this if you don't)
- [ ] Update the documentation according to your changes (when applicable)
- [x] Write unit tests for your changes (when applicable)
