### PR TITLE
fuzzy matching rewrite using new function get_matching_blocks()

### DIFF
--- a/tests/utils/test_fuzzy_search.py
+++ b/tests/utils/test_fuzzy_search.py
@@ -3,12 +3,11 @@ from ulauncher.utils.fuzzy_search import get_matching_blocks, get_score
 
 
 def test_get_matching_indexes():
-    assert get_matching_blocks('thfima', 'Thunar File Manager') == [(0, 'Th'), (7, 'Fi'), (12, 'Ma')]
+    assert get_matching_blocks('thfima', 'Thunar File Manager') == ([(0, 'Th'), (7, 'Fi'), (12, 'Ma')], 6)
 
 
 def test_get_score():
     assert get_score('calc', 'Contacts') < get_score('calc', 'LibreOffice Calc')
-    assert get_score('clac', 'LibreOffice Calc') < get_score('clac', 'Calc')
     assert get_score('pla', 'Pycharm') < get_score('pla', 'Google Play Music')
     assert get_score('', 'LibreOffice Calc') == 0
     assert get_score('0', 'LibreOffice Calc') == 0

--- a/ulauncher/search/apps/AppDb.py
+++ b/ulauncher/search/apps/AppDb.py
@@ -146,7 +146,7 @@ class AppDb:
         :rtype: :class:`ResultList`
         """
 
-        result_list = result_list or SortedList(query, min_score=75, limit=9)
+        result_list = result_list or SortedList(query, min_score=50, limit=9)
 
         if not query:
             return result_list

--- a/ulauncher/utils/fuzzy_search.py
+++ b/ulauncher/utils/fuzzy_search.py
@@ -1,61 +1,50 @@
 from functools import lru_cache
-from Levenshtein import distance, matching_blocks, editops
+from Levenshtein import matching_blocks, editops
 
 
-@lru_cache(maxsize=150)
+@lru_cache(maxsize=1000)
 def get_matching_blocks(query, text):
     """
     Uses Levenstein library's get_matching_blocks (Longest Common Substring),
     This is 8-12x faster than difflib's SequenceMatcher().get_matching_blocks()
-    :returns: List of tuples, containing the index and matching block
+    :returns: list of tuples, containing the index and matching block, number of characters that matched
     """
     query_l = query.lower()
     text_l = text.lower()
     blocks = matching_blocks(editops(query_l, text_l), query_l, text_l)[:-1]
     output = []
+    total_len = 0
     for (_, text_index, length) in blocks:
         output.append((text_index, text[text_index: text_index + length]))
-    return output
+        total_len += length
+    return output, total_len
 
 
 def get_score(query, text):
     """
-    Uses Levenshtein's algorithm + some improvements to the score
+    Uses get_matching_blocks() to figure out how much of the query that matches the text,
+    and tries to weight this to slightly favor shorter results and largely favor word matches
     :returns: number between 0 and 100
     """
-    query = query.lower()
-    text = text.lower()
-    query_len = len(query)
+
     if not query or not text:
         return 0
 
-    # Wrap and counter-weight distance so that short queries can match better with long texts.
-    # With regular levensteins distance "Fir" and "Firefox" is only 3/7 similar
-    # This is counter-weighted by 95% here, so it still has a slight benefit when your query matches a short app name.
-    diff = distance(query, text) - (max(0, len(text) - query_len) * .95)
-    score = 100 * max(0, query_len - diff) / query_len
+    query_len = len(query)
+    text_len = len(text)
+    max_len = max(query_len, text_len)
+    blocks, matching_chars = get_matching_blocks(query, text)
 
-    # Raise the score by 30% if the query fully matches the beginning of a word
-    for text_part in text.split(' '):
-        if text_part.startswith(query):
-            score += 30
-            break
+    # Ratio of the query that matches the text
+    base_similarity = matching_chars / query_len
 
-    # increase score if each separate group in indexes is a beginning of a word in text
-    # example for query 'fiwebr' groups 'fi', 'we', and 'br' are matching word beginnings
-    # of text 'Firefox Web Browser'
-    # increase score for each such group
-    increment = 10
-    i = 0  # query iterator
-    lq = len(query)
-    for j, char in enumerate(text):
-        # run until query ends and check if a query char. equals to current text char
-        if i < lq and query[i] == char:
-            # if char from query matches beginning of text or beginning of a word inside the text, increase the score
-            if j == 0 or text[j - 1] in ' .(-_+)':
-                score += increment
-            i += 1
-        elif i == lq:
-            break
+    # Lower the score if the match is in the middle of a word.
+    for index, _ in blocks:
+        is_word_boundary = index == 0 or text[index - 1] == ' '
+        if not is_word_boundary:
+            base_similarity -= 0.5 / query_len
 
-    return min(100, score)
+    # Rank matches lower for each extra character, to slightly favor shorter ones.
+    score = 100 * base_similarity * query_len / (query_len + (max_len - query_len) * 0.001)
+
+    return score

--- a/ulauncher/utils/text_highlighter.py
+++ b/ulauncher/utils/text_highlighter.py
@@ -9,7 +9,7 @@ def highlight_text(query, text: str, open_tag='<span foreground="white">', close
     text = text.replace("&amp;", "&")
 
     # Traverse through blocks in reverse order so we don't change the text index for the next iteration
-    for index, chars in reversed(get_matching_blocks(query, text)):
+    for index, chars in reversed(get_matching_blocks(query, text)[0]):
         text = text[0:index] + open_tag + chars + close_tag + text[index + len(chars):]
 
     return text.replace("&", "&amp;")


### PR DESCRIPTION
Replaces #824.

I wasn't planning to, but I reimplemented this for the v6 branch instead, with the major difference that it uses a new method [`get_matching_blocks()`](https://github.com/Ulauncher/Ulauncher/commit/f9d04fdfe0e9a397bb29c5236b1b19bd135715a7) which only exists in this branch (because it doesn't behave exactly the same in some cases).

Was finally able to replace those last 30 lines of code to now to a much more sensible solution thanks to `get_matching_blocks()`, and also removed the condition #824 reintroduced.

The character weighting is much smaller, and the new code doesn't bump up everything to 100% like the old one did with very short queries.

The highlighter and matcher uses the same implementation now (even the same function call, since it's memoized). Before this, the highligher used a completely different implementation and sometimes would display misleading results.

Might need some need tuning still, but I'm happy with the results, because getting the matchmaking blocks means we can understand it better and score it better, with less code duplication.

![2021-10-12_14-55](https://user-images.githubusercontent.com/515120/136961559-246b3037-eb75-4ade-83d4-5c898424a710.png)
