### PR TITLE
added support for more variants of github extension url

### DIFF
--- a/tests/api/server/test_GithubExtension.py
+++ b/tests/api/server/test_GithubExtension.py
@@ -95,7 +95,7 @@ class TestGithubExtension:
             GithubExtension('http://github.com/Ulauncher/ulauncher-timer').validate_url()
 
         with pytest.raises(GithubExtensionError):
-            GithubExtension('https://github.com/Ulauncher/ulauncher-timer/').validate_url()
+            GithubExtension('git@github.com/Ulauncher/ulauncher-timer/').validate_url()
 
     def test_get_download_url(self, gh_ext):
         assert gh_ext.get_download_url() == 'https://github.com/Ulauncher/ulauncher-timer/tarball/master'

--- a/ulauncher/api/server/GithubExtension.py
+++ b/ulauncher/api/server/GithubExtension.py
@@ -49,7 +49,7 @@ class GithubExtensionError(UlauncherAPIError):
 
 class GithubExtension:
 
-    url_match_pattern = r'^https:\/\/github.com\/([\w-]+\/[\w-]+)$'
+    url_match_pattern = r'^(https:\/\/github.com\/|git@github.com:)(([\w-]+\/[\w-]+))\/?(.git|tree\/master\/?)?$'
     url_file_template = 'https://raw.githubusercontent.com/{project_path}/{branch}/{file_path}'
     url_commit_template = 'https://api.github.com/repos/{project_path}/commits/{commit}'
 
@@ -138,10 +138,10 @@ class GithubExtension:
 
     def get_download_url(self, commit: str = DEFAULT_GITHUB_BRANCH) -> str:
         """
-        >>> https://github.com/Ulauncher/ulauncher-timer
+        >>> Ulauncher/ulauncher-timer
         <<< https://github.com/Ulauncher/ulauncher-timer/tarball/master
         """
-        return '%s/tarball/%s' % (self.url, commit)
+        return 'https://github.com/%s/tarball/%s' % (self._get_project_path(), commit)
 
     def get_ext_id(self) -> str:
         """
@@ -159,4 +159,4 @@ class GithubExtension:
         if not match:
             raise GithubExtensionError('Invalid GithubUrl: %s' % self.url, ErrorName.InvalidGithubUrl)
 
-        return match.group(1)
+        return match.group(2)


### PR DESCRIPTION
<!--
Thank you for submitting a PR to Ulauncher!

Please read our contribution instructions if you haven't:
https://github.com/Ulauncher/Ulauncher#code-contribution

Explain the changes in this PR and link to related issue(s) if applicable
-->
Fixes #807 

This PR adds support for more versions of github urls when installing an extension
Previously, you could only add by using the following url format : https://github.com/Ulauncher/ulauncher-kill
Now, these variants are also supported

 https://github.com/Ulauncher/ulauncher-kill/
https://github.com/Ulauncher/ulauncher-kill/tree/master
https://github.com/Ulauncher/ulauncher-kill/tree/master/
https://github.com/Ulauncher/ulauncher-kill.git
git@github.com:Ulauncher/ulauncher-kill.git

### Checklist
- [x] Verify that the test command `./ul test` is passing (the CI server will check this if you don't)
- [x] Update the documentation according to your changes (when applicable)
- [x] Write unit tests for your changes (when applicable)
