### PR TITLE
V6 - Load the version from setup.cfg

### DIFF
--- a/ulauncher/__init__.py
+++ b/ulauncher/__init__.py
@@ -1,17 +1,13 @@
+from configparser import ConfigParser
 from pathlib import Path
-from subprocess import check_output, CalledProcessError
 
 # This file is overwritten by the build_wrapper script in setup.py
 # IF YOU EDIT THIS FILE make sure your changes are reflected there
 
-
-def _exec_get_(*args):
-    try:
-        return check_output(list(args)).decode('utf-8').rstrip()
-    except (FileNotFoundError, CalledProcessError):
-        return ""
+config = ConfigParser()
+config.read('setup.cfg')
 
 
 __data_directory__ = f'{Path(__file__).resolve().parent.parent}/data'
 __is_dev__ = True
-__version__ = _exec_get_("git", "describe", "--tags") or "DEV"
+__version__ = config['metadata']['version']


### PR DESCRIPTION
This loads the version from setup.cfg (only). It's comparable to the "VERSION" file used in my fork before, but without the file.

The script `tag-release.sh` (although it's kind of primitive still) bumps this version in setup.cfg if you create the release this way, so it should be the same as the tag.

The reason `git describe` was used before was to get the pre-release commit hash also if there were commits since the latest tag, however it seems like it created more problems than it solved In addition to not working with git worktrees, tags are not pulled by default, so there's a risk of git describe showing an invalid version.