### PR TITLE
Remove pyxdg dependency and switch to store state files in XDG_STATE_HOME

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,7 +25,6 @@ RUN apt-get update && \
         gir1.2-notify-0.7 \
         python3-all \
         python3-gi \
-        python3-xdg \
         python3-dbus \
         python3-levenshtein \
         python3-paramiko \

--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ You need the the following:
   sudo apt-get update && sudo apt-get install \
     yarnpkg gobject-introspection libgtk-3-0 libkeybinder-3.0-0 \
     gir1.2-{gtk-3.0,keybinder-3.0,webkit2-4.0,glib-2.0,gdkpixbuf-2.0,notify-0.7,ayatanaappindicator3-0.1} \
-    python3-{setuptools,all,gi,xdg,dbus,levenshtein}
+    python3-{setuptools,all,gi,dbus,levenshtein}
   ```
 
 </details>

--- a/debian/control
+++ b/debian/control
@@ -27,8 +27,7 @@ Depends: ${misc:Depends},
  python3-gi,
  python3-gi-cairo,
  python3-dbus,
- python3-levenshtein,
- python3-xdg
+ python3-levenshtein
 Recommends: gir1.2-ayatanaappindicator3-0.1
 Description: Application launcher for Linux
  See https://ulauncher.io for more information

--- a/docs/extensions/libs.rst
+++ b/docs/extensions/libs.rst
@@ -31,6 +31,3 @@ In future we'll make it possible to support ``requirements.txt`` for extensions.
 
 `python-dbus <https://github.com/LEW21/pydbus>`_
   Python DBus library.
-
-`python-xdg <https://pyxdg.readthedocs.io/en/latest/index.html>`_
-  Python library supporting various freedesktop standards.

--- a/setup.cfg
+++ b/setup.cfg
@@ -40,7 +40,6 @@ install_requires =
 	pycairo
 	PyGObject
 	python-Levenshtein
-	pyxdg
 
 [flake8]
 exclude = docs,data,scripts
@@ -68,6 +67,5 @@ requires = gobject-introspection
 	python3-dbus
 	python3-cairo
 	python3-gobject
-	python3-pyxdg
 	python3-Levenshtein
 

--- a/ulauncher/api/shared/socket_path.py
+++ b/ulauncher/api/shared/socket_path.py
@@ -1,11 +1,7 @@
-import os.path
-from xdg.BaseDirectory import get_runtime_dir
+import os
 
 
 def get_socket_path():
     """Gets the path to the Ulauncher control unix socket."""
-    try:
-        rundir = get_runtime_dir()
-    except KeyError:
-        rundir = "/tmp"
+    rundir = os.environ.get("XDG_RUNTIME_DIR") or "/tmp"
     return os.path.join(rundir, "ulauncher_control")

--- a/ulauncher/config.py
+++ b/ulauncher/config.py
@@ -11,10 +11,12 @@ from gettext import gettext
 from ulauncher import __version__, __data_directory__
 
 _HOME = os.path.expanduser('~')
+_XDG_STATE_HOME = os.environ.get('XDG_STATE_HOME') or os.path.join(_HOME, '.local', 'state')
 _XDG_DATA_HOME = os.environ.get('XDG_DATA_HOME') or os.path.join(_HOME, '.local', 'share')
 _XDG_CONFIG_HOME = os.environ.get('XDG_CONFIG_HOME') or os.path.join(_HOME, '.config')
 _XDG_CACHE_HOME = os.environ.get('XDG_CACHE_HOME') or os.path.join(_HOME, '.cache')
 
+STATE_DIR = os.path.join(_XDG_STATE_HOME, 'ulauncher')
 DATA_DIR = os.path.join(_XDG_DATA_HOME, 'ulauncher')
 # Use ulauncher_cache dir because of the WebKit bug
 # https://bugs.webkit.org/show_bug.cgi?id=151646
@@ -32,6 +34,9 @@ if not os.path.exists(CONFIG_DIR):
     # If there is no config dir, assume it's the first run
     FIRST_RUN = True
     os.makedirs(CONFIG_DIR)
+
+if not os.path.exists(STATE_DIR):
+    os.makedirs(STATE_DIR)
 
 if not os.path.exists(DATA_DIR):
     os.makedirs(DATA_DIR)

--- a/ulauncher/config.py
+++ b/ulauncher/config.py
@@ -8,15 +8,18 @@ from uuid import uuid4
 from time import time
 from functools import lru_cache
 from gettext import gettext
-from xdg.BaseDirectory import xdg_config_home, xdg_cache_home, xdg_data_home
 from ulauncher import __version__, __data_directory__
 
+_HOME = os.path.expanduser('~')
+_XDG_DATA_HOME = os.environ.get('XDG_DATA_HOME') or os.path.join(_HOME, '.local', 'share')
+_XDG_CONFIG_HOME = os.environ.get('XDG_CONFIG_HOME') or os.path.join(_HOME, '.config')
+_XDG_CACHE_HOME = os.environ.get('XDG_CACHE_HOME') or os.path.join(_HOME, '.cache')
 
-DATA_DIR = os.path.join(xdg_data_home, 'ulauncher')
+DATA_DIR = os.path.join(_XDG_DATA_HOME, 'ulauncher')
 # Use ulauncher_cache dir because of the WebKit bug
 # https://bugs.webkit.org/show_bug.cgi?id=151646
-CACHE_DIR = os.path.join(xdg_cache_home, 'ulauncher_cache')
-CONFIG_DIR = os.path.join(xdg_config_home, 'ulauncher')
+CACHE_DIR = os.path.join(_XDG_CACHE_HOME, 'ulauncher_cache')
+CONFIG_DIR = os.path.join(_XDG_CONFIG_HOME, 'ulauncher')
 SETTINGS_FILE_PATH = os.path.join(CONFIG_DIR, 'settings.json')
 # spec: https://specifications.freedesktop.org/menu-spec/latest/ar01s02.html
 EXTENSIONS_DIR = os.path.join(DATA_DIR, 'extensions')

--- a/ulauncher/search/QueryHistoryDb.py
+++ b/ulauncher/search/QueryHistoryDb.py
@@ -1,5 +1,5 @@
 import os
-from ulauncher.config import DATA_DIR
+from ulauncher.config import STATE_DIR
 from ulauncher.utils.db.KeyValueDb import KeyValueDb
 from ulauncher.utils.decorator.singleton import singleton
 
@@ -9,7 +9,7 @@ class QueryHistoryDb(KeyValueDb):
     @classmethod
     @singleton
     def get_instance(cls):
-        db = cls(os.path.join(DATA_DIR, 'query_history.db'))
+        db = cls(os.path.join(STATE_DIR, 'query_history.db'))
         db.open()
         return db
 

--- a/ulauncher/search/apps/AppResultItem.py
+++ b/ulauncher/search/apps/AppResultItem.py
@@ -3,7 +3,7 @@ import gi
 gi.require_version('Gio', '2.0')
 # pylint: disable=wrong-import-position
 from gi.repository import Gio
-from ulauncher.config import DATA_DIR
+from ulauncher.config import STATE_DIR
 from ulauncher.utils.db.KeyValueDb import KeyValueDb
 from ulauncher.utils.Settings import Settings
 from ulauncher.utils.fuzzy_search import get_score
@@ -13,7 +13,7 @@ from ulauncher.search.QueryHistoryDb import QueryHistoryDb
 from ulauncher.utils.image_loader import get_app_icon_pixbuf
 
 settings = Settings.get_instance()
-_app_stat_db = KeyValueDb(join(DATA_DIR, 'app_stat_v3.db')).open()
+_app_stat_db = KeyValueDb(join(STATE_DIR, 'app_stat_v3.db')).open()
 
 
 class AppResultItem(ResultItem):

--- a/ulauncher/search/file_browser/FileQueries.py
+++ b/ulauncher/search/file_browser/FileQueries.py
@@ -1,7 +1,7 @@
 import os
 from time import time, sleep
 from typing import Optional
-from ulauncher.config import CACHE_DIR
+from ulauncher.config import STATE_DIR
 from ulauncher.utils.db.KeyValueDb import KeyValueDb
 from ulauncher.utils.decorator.run_async import run_async
 from ulauncher.utils.decorator.singleton import singleton
@@ -14,7 +14,7 @@ class FileQueries(KeyValueDb[str, float]):
     @classmethod
     @singleton
     def get_instance(cls) -> 'FileQueries':
-        browser_cache = os.path.join(CACHE_DIR, 'file_browser_queries_v2.db')
+        browser_cache = os.path.join(STATE_DIR, 'file_browser_queries_v2.db')
         db = cls(browser_cache)
         db.open()
         return db

--- a/ulauncher/utils/setup_logging.py
+++ b/ulauncher/utils/setup_logging.py
@@ -1,7 +1,7 @@
 import os
 import logging
 from copy import copy
-from ulauncher.config import DATA_DIR
+from ulauncher.config import STATE_DIR
 
 
 # The background is set with 40 plus the number of the color, and the foreground with 30
@@ -47,7 +47,7 @@ def setup_logging(opts):
     root.addHandler(stream_handler)
 
     # set up login to a file
-    log_file = os.path.join(DATA_DIR, 'last.log')
+    log_file = os.path.join(STATE_DIR, 'last.log')
     if os.path.exists(log_file):
         os.remove(log_file)
 


### PR DESCRIPTION
Implements #843

It's changing the location of all the state files and the log to XDG_STATE_HOME. Note that XDG_STATE_HOME is very new, and it's likely that Ulauncher will be the first app to use it on users systems (it was for me), but this isn't a problem :). XDG_DATA_HOME is now only used to store extensions, and XDG_CACHE_HOME is only used to store css files generated for themes that extends other themes. I'm not sure if this is something we can work around, so we don't use XDG_CACHE_HOME at all.

Planning on doing more work with how the state files are stored, and making them less backward compatible, by switching to json. Otherwise I wouldn't have moved them.