### PR TITLE
Add fallback solution for searching if Levenshtein is missing or outdated

### DIFF
--- a/ulauncher/utils/fuzzy_search.py
+++ b/ulauncher/utils/fuzzy_search.py
@@ -5,6 +5,10 @@ from difflib import SequenceMatcher
 logger = getLogger(__name__)
 
 
+def _get_matching_blocks_native(query, text):
+    return SequenceMatcher(None, query, text).get_matching_blocks()
+
+
 # Using Levenshtein is ~10x faster, but some older distro releases might not package Levenshtein
 # with these methods. So we fall back on difflib.SequenceMatcher (native Python library) to be sure.
 try:
@@ -14,9 +18,7 @@ try:
         return matching_blocks(editops(query, text), query, text)
 except (ModuleNotFoundError, ImportError):
     logger.warning("Levenshtein is missing or outdated. Falling back to slower fuzzy-finding method.")
-
-    def _get_matching_blocks(query, text):
-        return SequenceMatcher(None, query, text).get_matching_blocks()
+    _get_matching_blocks = _get_matching_blocks_native
 
 
 @lru_cache(maxsize=1000)


### PR DESCRIPTION
This PR adds a fallback for Levenshtein if it's missing or outdated. I added it because I knew about the other method (it's how I originally implemented `get_matching_blocks()`), and it doesn't add a lot of code.

I don't think we strictly need this PR now, but we would need it for Xenial support (which we are pulling anyway with 6.0.0, and we stopped making Xenial releases for 5.14.1 also). I do think it's good to have in though, as the Levenshtein library has been in a sorry state for many years, and I'm not sure if it will continue to be packaged for distros.

Not sure this means we should:
* Make the tests run for both implementations?
* Remove the [CI server pypi package installation](https://github.com/Ulauncher/Ulauncher/pull/822/commits/6dfd4bc1e131a28a9b09fb6ab47409c388c543cf)
* Mark the Levenstein library as an optional dependency?