### PR TITLE
Improve state file error handling

### DIFF
--- a/tests/utils/test_KeyValueJsonDb.py
+++ b/tests/utils/test_KeyValueJsonDb.py
@@ -13,12 +13,6 @@ class TestKeyValueJsonDb:
     def db(self, db_name):
         return KeyValueJsonDb(db_name).open()
 
-    def test_open_raises_ioerror(self):
-        """It raises IOError if 'name' is a directory"""
-
-        with pytest.raises(IOError):
-            KeyValueJsonDb('/tmp').open()
-
     def test_commit(self, db_name):
         """It saves changes to disk"""
 

--- a/ulauncher/utils/db/KeyValueJsonDb.py
+++ b/ulauncher/utils/db/KeyValueJsonDb.py
@@ -13,38 +13,38 @@ class KeyValueJsonDb(Generic[Key, Value]):
     Use open() method to load JSON from a file and commit() to save it
     """
 
-    _name = None  # type: str
+    _path = None  # type: str
     _records = None  # type: Records
 
-    def __init__(self, basename: str):
+    def __init__(self, path: str):
         """
         :param str basename: path to db file
         """
-        self._name = basename
+        self._path = path
         self.set_records({})
 
     def open(self) -> 'KeyValueJsonDb':
         """Create a new data base or open existing one"""
-        if os.path.exists(self._name):
-            if not os.path.isfile(self._name):
-                raise IOError("%s exists and is not a file" % self._name)
+        if os.path.exists(self._path):
+            if not os.path.isfile(self._path):
+                raise IOError("%s exists and is not a file" % self._path)
 
             try:
-                with open(self._name, 'r') as _in:
+                with open(self._path, 'r') as _in:
                     self.set_records(json.load(_in))
             except json.JSONDecodeError:
                 # file corrupted, reset it.
                 self.commit()
         else:
             # make sure path exists
-            os.makedirs(os.path.dirname(self._name), exist_ok=True)
+            os.makedirs(os.path.dirname(self._path), exist_ok=True)
             self.commit()
 
         return self
 
     def commit(self) -> 'KeyValueJsonDb':
         """Write the database to a file"""
-        with open(self._name, 'w') as out:
+        with open(self._path, 'w') as out:
             json.dump(self._records, out, indent=4)
             out.close()
 

--- a/ulauncher/utils/db/KeyValueJsonDb.py
+++ b/ulauncher/utils/db/KeyValueJsonDb.py
@@ -1,10 +1,13 @@
-import os
 import json
+from pathlib import Path
 from typing import Dict, TypeVar, Generic, Optional
+from logging import getLogger
 
 Key = TypeVar('Key')
 Value = TypeVar('Value')
 Records = Dict[Key, Value]
+
+logger = getLogger(__name__)
 
 
 class KeyValueJsonDb(Generic[Key, Value]):
@@ -13,42 +16,40 @@ class KeyValueJsonDb(Generic[Key, Value]):
     Use open() method to load JSON from a file and commit() to save it
     """
 
-    _path = None  # type: str
+    _path = None  # type: Path
     _records = None  # type: Records
 
     def __init__(self, path: str):
         """
         :param str basename: path to db file
         """
-        self._path = path
+        self._path = Path(path)
         self.set_records({})
 
     def open(self) -> 'KeyValueJsonDb':
         """Create a new data base or open existing one"""
-        if os.path.exists(self._path):
-            if not os.path.isfile(self._path):
-                raise IOError("%s exists and is not a file" % self._path)
+        # Ensure parent dir
+        self._path.parent.mkdir(parents=True, exist_ok=True)
 
+        if self._path.exists():
             try:
-                with open(self._path, 'r') as _in:
-                    self.set_records(json.load(_in))
-            except json.JSONDecodeError:
-                # file corrupted, reset it.
-                self.commit()
-        else:
-            # make sure path exists
-            os.makedirs(os.path.dirname(self._path), exist_ok=True)
-            self.commit()
+                self.set_records(json.loads(self._path.read_text()))
+            except Exception as e:
+                logger.error("Error '%s' opening JSON file %s: %s", type(e).__name__, self._path, e)
+                logger.warning("Resetting invalid JSON file (%s)", self._path)
+                if not self.commit():
+                    logger.warning("Failed to reset JSON file")
 
         return self
 
-    def commit(self) -> 'KeyValueJsonDb':
+    def commit(self) -> bool:
         """Write the database to a file"""
-        with open(self._path, 'w') as out:
-            json.dump(self._records, out, indent=4)
-            out.close()
-
-        return self
+        try:
+            self._path.write_text(json.dumps(self._records, indent=4))
+            return True
+        except Exception as e:
+            logger.error("Error '%s' writing to JSON file %s: %s.", type(e).__name__, self._path, e)
+        return False
 
     def remove(self, key: Key) -> bool:
         """


### PR DESCRIPTION
KeyValueJsonDb is the class that handles state files and extension configuration files (but not the main config) in v6. This change makes it more robust, catching higher level errors and logging, so the app should never crash when it tries to save or load the file.
* The pathlib and json libraries will throw exceptions if the path exists but is not a file or if it's write protected (see #713, although that file is not covered by this class).
* If the file is corrupt or invalid JSON (this was a very common issue when we used Pickle: #111, #260, #290, #412, #443 #464, #469, #474, #699) it will throw too,

These exceptions will be caught and logged, but not treated as fatal. It will fall back to using an empty record and if it can't save it will just keep running anyway. It's not the end of the world to lose this data compared to Ulauncher crashing, but with extensions it may be best to handle not being able to save preferences (it will be possible to handle, since `commit()` will return `False`)

### Checklist
- [x] Verify that the test command `./ul test` is passing (the CI server will check this if you don't)
- [ ] Update the documentation according to your changes (when applicable)
- [x] Write unit tests for your changes (when applicable)
