### PR TITLE
Simplify preferences logic

### DIFF
--- a/preferences-src/src/App.vue
+++ b/preferences-src/src/App.vue
@@ -75,7 +75,7 @@ export default {
   },
   methods: {
     openUrlInBrowser(url) {
-      jsonp('prefs://open/web-url', { url: url })
+      jsonp('prefs:///open/web-url', { url: url })
     },
     onError(err) {
       this.error = err

--- a/preferences-src/src/api/fixture.js
+++ b/preferences-src/src/api/fixture.js
@@ -25,29 +25,12 @@ export default function(url, params) {
           is_wayland: true,
         }
       })
-    } else if (isMatch(url, '/set/show-indicator-icon')) {
-      console.log('/set/show-indicator-icon', params)
-      setTimeout(resolve, 0) // preventDefault doesn't work unless resolution is done in the next event loop
-    } else if (isMatch(url, '/set/autostart-enabled')) {
-      console.log('/set/autostart-enabled', params)
-      setTimeout(resolve, 0)
-    } else if (isMatch(url, '/set/show-recent-apps')) {
-      console.log('/set/show-recent-apps', params)
-      setTimeout(resolve, 0)
-    } else if (isMatch(url, '/set/theme-name')) {
-      console.log('/set/theme-name', params)
+      // preventDefault doesn't work unless resolution is done in the next event loop
+    } else if (isMatch(url, '/set')) {
+      console.log('/set', params)
       setTimeout(resolve, 0)
     } else if (isMatch(url, '/set/hotkey-show-app')) {
       console.log('/set/hotkey-show-app', params)
-      setTimeout(resolve, 0)
-    } else if (isMatch(url, '/set/clear-previous-query')) {
-      console.log('/set/clear-previous-query', params)
-      setTimeout(resolve, 0)
-    } else if (isMatch(url, '/set/grab-mouse-pointer')) {
-      console.log('/set/grab-mouse-pointer', params)
-      setTimeout(resolve, 0)
-    } else if (isMatch(url, '/set/disable-desktop-filters')) {
-      console.log('/set/disable-desktop-filters', params)
       setTimeout(resolve, 0)
     } else if (isMatch(url, '/open/web-url')) {
       console.log('/open/web-url', params)

--- a/preferences-src/src/api/fixture.js
+++ b/preferences-src/src/api/fixture.js
@@ -18,11 +18,11 @@ export default function(url, params) {
         disable_desktop_filters: false,
         available_themes: [{ text: 'Dark', value: 'dark' }, { text: 'Light', value: 'light' }],
         theme_name: 'light',
-        is_wayland: true,
         env: {
           version: '1.2.3',
           api_version: '2.1.0',
-          user_home: '/home/username'
+          user_home: '/home/username',
+          is_wayland: true,
         }
       })
     } else if (isMatch(url, '/set/show-indicator-icon')) {

--- a/preferences-src/src/api/jsonp.js
+++ b/preferences-src/src/api/jsonp.js
@@ -1,37 +1,27 @@
 /**
- * Author: alexbardas
+ * THIS file has been heavily modified for Ulauncher's needs
+ * We need this library due to working with very the very restricted Webkit register_uri_scheme()
+ * Original author: alexbardas
  * https://github.com/alexbardas/jsonp-promise
  * MIT license
  */
 
 // Callback index.
-var count = 0
+var count = 1
 
 /**
  * JSONP handler
  *
- * Options:
- * - prefix {String} callback prefix (defaults to `__jp`)
- * - param {String} qs parameter (defaults to `callback`)
- * - timeout {Number} how long after the request until a timeout error
- *   is emitted (defaults to `15000`)
- *
  * @param {String} url
  * @param {Object} [params]  dictionary with query parameters
- * @param {Object} [options]
  * @return {Object} Returns a response promise and a cancel handler.
  */
-export default function jsonp (url, params, options) {
-  params = params || {}
-  options = options || {}
-
+export default function jsonp (url, params = {}) {
   var script
-  var timer
-  var cancel
 
   // Generate a unique id for the request.
-  var prefix = options.prefix || '__jp'
-  var id = prefix + (count++)
+  var id = `__jp${count}`
+  count += 1
 
   function cleanup () {
     // Remove the script tag.
@@ -40,30 +30,10 @@ export default function jsonp (url, params, options) {
     }
 
     window[id] = () => {}
-
-    if (timer) {
-      clearTimeout(timer)
-    }
   }
 
-  function b64EncodeUnicode (str) {
-    // first we use encodeURIComponent to get percent-encoded UTF-8,
-    // then we convert the percent encodings into raw bytes which
-    // can be fed into btoa.
-    return btoa(encodeURIComponent(str).replace(
-      /%([0-9A-F]{2})/g,
-      (match, p1) => {
-        return String.fromCharCode('0x' + p1)
-      }
-    ))
-  }
 
-  let promise = new Promise(function (resolve, reject) {
-    let timeout = options.timeout || 15000
-    timer = setTimeout(function () {
-      cleanup()
-      reject('Request timeout')
-    }, timeout)
+  return new Promise((resolve, reject) => {
 
     window[id] = function (data, error) {
       cleanup()
@@ -75,36 +45,15 @@ export default function jsonp (url, params, options) {
     }
 
     // Add querystring component
-    let param = options.param || 'callback'
-    params[param] = id
-    let urlParams = []
-    for (let i in params) {
-      if (params[i] instanceof Object) {
-        let key = `${i}_b64json`
-        let val = b64EncodeUnicode(JSON.stringify(params[i]))
-        urlParams.push(`${key}=${val}`)
-      } else {
-        urlParams.push(i + '=' + encodeURIComponent(params[i]))
-      }
-    }
-    url += (~url.indexOf('?') ? '&' : '?') + urlParams.join('&')
-    url = url.replace('?&', '?')
+    params['callback'] = id
+    // This is a hacky, nonstandard way to send data that we resort to because of heavy
+    // limitation in the GTKWebKit APIs
+    url += `?${encodeURIComponent(JSON.stringify(params))}`
 
     // Create script.
     script = document.createElement('script')
     script.src = url
     let target = document.getElementsByTagName('script')[0] || document.head
     target.parentNode.insertBefore(script, target)
-
-    cancel = function () {
-      if (window[id]) {
-        cleanup()
-        reject('Request canceled')
-      }
-    }
   })
-
-  promise.cancel = cancel
-
-  return promise
 }

--- a/preferences-src/src/components/NavBar.vue
+++ b/preferences-src/src/components/NavBar.vue
@@ -22,7 +22,7 @@ export default {
   name: 'navbar',
   methods: {
     closeWindow () {
-      jsonp('prefs://close').then(null, (err) => bus.$emit('error', err))
+      jsonp('prefs:///close').then(null, (err) => bus.$emit('error', err))
     }
   }
 }

--- a/preferences-src/src/components/pages/EditShortcut.vue
+++ b/preferences-src/src/components/pages/EditShortcut.vue
@@ -108,7 +108,7 @@ export default {
       return path.indexOf('~') === 0 ? path.replace('~', this.prefs.env.user_home, 1) : path
     },
     selectIcon() {
-      jsonp('prefs://show/file-browser', { type: 'image', name: shortcutIconEventName }).then(null, err =>
+      jsonp('prefs:///show/file-browser', { type: 'image', name: shortcutIconEventName }).then(null, err =>
         bus.$emit('error', err)
       )
     },
@@ -131,7 +131,7 @@ export default {
         run_without_argument: this.localRunWithoutArgument
       }
       let method = shortcut.id ? 'update' : 'add'
-      jsonp('prefs://shortcut/' + method, shortcut).then(this.hide, err => bus.$emit('error', err))
+      jsonp('prefs:///shortcut/' + method, shortcut).then(this.hide, err => bus.$emit('error', err))
     },
     hide() {
       this.$router.push({ path: '/shortcuts' })

--- a/preferences-src/src/components/pages/ExtensionConfig.vue
+++ b/preferences-src/src/components/pages/ExtensionConfig.vue
@@ -253,7 +253,7 @@ export default {
         }
         updates[`pref.${pref.id}`] = value
       }
-      jsonp('prefs://extension/update-prefs', updates).then(
+      jsonp('prefs:///extension/update-prefs', updates).then(
         () => {
           this.showSavedMsg = true
           setTimeout(() => {
@@ -277,7 +277,7 @@ export default {
       }
     },
     remove() {
-      jsonp('prefs://extension/remove', { id: this.extension.id }).then(
+      jsonp('prefs:///extension/remove', { id: this.extension.id }).then(
         () => {
           this.$emit('removed', this.extension.id)
         },
@@ -291,7 +291,7 @@ export default {
       this.updateExtModal = true
       this.newVersionInfo = null
       this.updateState = 'checking-updates'
-      jsonp('prefs://extension/check-updates', { id: this.extension.id }).then(
+      jsonp('prefs:///extension/check-updates', { id: this.extension.id }).then(
         data => {
           if (data) {
             this.newVersionInfo = data
@@ -309,7 +309,7 @@ export default {
     update() {
       this.updateError = null
       this.updateState = 'updating'
-      jsonp('prefs://extension/update-ext', { id: this.extension.id }).then(
+      jsonp('prefs:///extension/update-ext', { id: this.extension.id }).then(
         () => {
           this.updateState = 'updated'
           bus.$emit('extension/get-all')
@@ -321,7 +321,7 @@ export default {
       )
     },
     openUrl(url) {
-      jsonp('prefs://open/web-url', { url })
+      jsonp('prefs:///open/web-url', { url })
     },
     handleNativeClick(e) {
       if (e.target && e.target.tagName === 'A') {

--- a/preferences-src/src/components/pages/Extensions.vue
+++ b/preferences-src/src/components/pages/Extensions.vue
@@ -151,7 +151,7 @@ export default {
   },
   methods: {
     fetchData() {
-      jsonp('prefs://extension/get-all').then(
+      jsonp('prefs:///extension/get-all').then(
         data => {
           this.extensions = data
           this.activeExt = data[0]
@@ -174,7 +174,7 @@ export default {
       this.fetchData()
     },
     openUrlInBrowser(url) {
-      jsonp('prefs://open/web-url', { url: url })
+      jsonp('prefs:///open/web-url', { url: url })
     },
     selectExtension(ext) {
       this.activeExt = ext
@@ -216,7 +216,7 @@ export default {
       this.extUrlToDownload = input.value
       this.addingExtension = true
       this.addingExtensionError = null
-      jsonp('prefs://extension/add', { url: input.value }).then(
+      jsonp('prefs:///extension/add', { url: input.value }).then(
         data => {
           this.extensions = data
           this.addingExtension = false

--- a/preferences-src/src/components/pages/Help.vue
+++ b/preferences-src/src/components/pages/Help.vue
@@ -46,7 +46,7 @@ export default {
   },
   methods: {
     openUrlInBrowser(url) {
-      jsonp('prefs://open/web-url', { url: url })
+      jsonp('prefs:///open/web-url', { url: url })
     }
   }
 }

--- a/preferences-src/src/components/pages/Preferences.vue
+++ b/preferences-src/src/components/pages/Preferences.vue
@@ -176,124 +176,33 @@ export default {
 
   computed: {
     ...mapState(['prefs']),
-
     ...mapGetters(['prefsLoaded']),
-
-    autostart_enabled: {
+    // Generate getters/setters for all preferences that are just storing to the config file
+    // Unfortunately there seems to be no way to generate these from the backend data,
+    // as we haven't recievened it yet at this point in the runtime
+    // A more reasonable approach would probably be to use a wrapper rather than directly accessing these
+    // As in v-model="prefs.show_recent_apps" instead of v-model="show_recent_apps"?
+    ...Object.fromEntries([
+      'autostart_enabled',
+      'clear_previous_query',
+      'disable_desktop_filters',
+      'grab_mouse_pointer',
+      'render_on_screen',
+      'show_indicator_icon',
+      'show_recent_apps',
+      'terminal_command',
+      'theme_name',
+    ].map(name => ([name, {
       get() {
-        return this.prefs.autostart_enabled
+        return this.prefs[name]
       },
       set(value) {
-        return jsonp('prefs:///set/autostart-enabled', { value: value }).then(
-          () => this.setPrefs({ autostart_enabled: value }),
+        return jsonp('prefs:///set', {property: name.replace('_', '-'), value}).then(
+          () => this.setPrefs({[name]: value}),
           err => bus.$emit('error', err)
         )
       }
-    },
-
-    show_indicator_icon: {
-      get() {
-        return this.prefs.show_indicator_icon
-      },
-      set(value) {
-        return jsonp('prefs:///set/show-indicator-icon', { value: value }).then(
-          () => this.setPrefs({ show_indicator_icon: value }),
-          err => bus.$emit('error', err)
-        )
-      }
-    },
-
-    show_recent_apps: {
-      get() {
-        if (this.prefs.show_recent_apps === true) {
-          return '3'
-        } else if (this.prefs.show_recent_apps === false) {
-          return '0'
-        }
-        return this.prefs.show_recent_apps
-      },
-      set(value) {
-        return jsonp('prefs:///set/show-recent-apps', { value: value }).then(
-          () => this.setPrefs({ show_recent_apps: value }),
-          err => bus.$emit('error', err)
-        )
-      }
-    },
-
-    terminal_command: {
-      get() {
-        return this.prefs.terminal_command
-      },
-      set(value) {
-        return jsonp('prefs:///set/terminal-command', { value: value }).then(
-          () => this.setPrefs({ terminal_command: value }),
-          err => bus.$emit('error', err)
-        )
-      }
-    },
-
-    theme_name: {
-      get() {
-        return this.prefs.theme_name
-      },
-      set(value) {
-        return jsonp('prefs:///set/theme-name', { value: value }).then(
-          () => this.setPrefs({ theme_name: value }),
-          err => bus.$emit('error', err)
-        )
-      }
-    },
-
-    clear_previous_query: {
-      get() {
-        return this.prefs.clear_previous_query
-      },
-      set(value) {
-        return jsonp('prefs:///set/clear-previous-query', { value: value }).then(
-          () => this.setPrefs({ clear_previous_query: value }),
-          err => bus.$emit('error', err)
-        )
-      }
-    },
-
-    grab_mouse_pointer: {
-      get() {
-        return this.prefs.grab_mouse_pointer
-      },
-      set(value) {
-        return jsonp('prefs:///set/grab-mouse-pointer', { value: value }).then(
-          () => this.setPrefs({ grab_mouse_pointer: value }),
-          err => bus.$emit('error', err)
-        )
-      }
-    },
-
-    disable_desktop_filters: {
-      get() {
-        return this.prefs.disable_desktop_filters
-      },
-      set(value) {
-        return jsonp('prefs:///set/disable-desktop-filters', { value: value }).then(
-          () => {
-            this.setPrefs({ disable_desktop_filters: value })
-            this.disableDesktopFiltersChanged = true
-          },
-          err => bus.$emit('error', err)
-        )
-      }
-    },
-
-    render_on_screen: {
-      get() {
-        return this.prefs.render_on_screen
-      },
-      set(value) {
-        return jsonp('prefs:///set/render-on-screen', { value: value }).then(
-          () => this.setPrefs({ render_on_screen: value }),
-          err => bus.$emit('error', err)
-        )
-      }
-    }
+    }]))),
   },
 
   methods: {

--- a/preferences-src/src/components/pages/Preferences.vue
+++ b/preferences-src/src/components/pages/Preferences.vue
@@ -13,7 +13,7 @@
             @focus.native="showHotkeyDialog($event)"
             :value="prefs.hotkey_show_app"
           ></b-form-input>
-          <div v-if="prefs.is_wayland" class="hotkey-warning">
+          <div v-if="prefs.env.is_wayland" class="hotkey-warning">
             <b-alert show variant="warning">
               <small>
                 It appears that your are in Wayland session.

--- a/preferences-src/src/components/pages/Preferences.vue
+++ b/preferences-src/src/components/pages/Preferences.vue
@@ -184,7 +184,7 @@ export default {
         return this.prefs.autostart_enabled
       },
       set(value) {
-        return jsonp('prefs://set/autostart-enabled', { value: value }).then(
+        return jsonp('prefs:///set/autostart-enabled', { value: value }).then(
           () => this.setPrefs({ autostart_enabled: value }),
           err => bus.$emit('error', err)
         )
@@ -196,7 +196,7 @@ export default {
         return this.prefs.show_indicator_icon
       },
       set(value) {
-        return jsonp('prefs://set/show-indicator-icon', { value: value }).then(
+        return jsonp('prefs:///set/show-indicator-icon', { value: value }).then(
           () => this.setPrefs({ show_indicator_icon: value }),
           err => bus.$emit('error', err)
         )
@@ -213,7 +213,7 @@ export default {
         return this.prefs.show_recent_apps
       },
       set(value) {
-        return jsonp('prefs://set/show-recent-apps', { value: value }).then(
+        return jsonp('prefs:///set/show-recent-apps', { value: value }).then(
           () => this.setPrefs({ show_recent_apps: value }),
           err => bus.$emit('error', err)
         )
@@ -225,7 +225,7 @@ export default {
         return this.prefs.terminal_command
       },
       set(value) {
-        return jsonp('prefs://set/terminal-command', { value: value }).then(
+        return jsonp('prefs:///set/terminal-command', { value: value }).then(
           () => this.setPrefs({ terminal_command: value }),
           err => bus.$emit('error', err)
         )
@@ -237,7 +237,7 @@ export default {
         return this.prefs.theme_name
       },
       set(value) {
-        return jsonp('prefs://set/theme-name', { value: value }).then(
+        return jsonp('prefs:///set/theme-name', { value: value }).then(
           () => this.setPrefs({ theme_name: value }),
           err => bus.$emit('error', err)
         )
@@ -249,7 +249,7 @@ export default {
         return this.prefs.clear_previous_query
       },
       set(value) {
-        return jsonp('prefs://set/clear-previous-query', { value: value }).then(
+        return jsonp('prefs:///set/clear-previous-query', { value: value }).then(
           () => this.setPrefs({ clear_previous_query: value }),
           err => bus.$emit('error', err)
         )
@@ -261,7 +261,7 @@ export default {
         return this.prefs.grab_mouse_pointer
       },
       set(value) {
-        return jsonp('prefs://set/grab-mouse-pointer', { value: value }).then(
+        return jsonp('prefs:///set/grab-mouse-pointer', { value: value }).then(
           () => this.setPrefs({ grab_mouse_pointer: value }),
           err => bus.$emit('error', err)
         )
@@ -273,7 +273,7 @@ export default {
         return this.prefs.disable_desktop_filters
       },
       set(value) {
-        return jsonp('prefs://set/disable-desktop-filters', { value: value }).then(
+        return jsonp('prefs:///set/disable-desktop-filters', { value: value }).then(
           () => {
             this.setPrefs({ disable_desktop_filters: value })
             this.disableDesktopFiltersChanged = true
@@ -288,7 +288,7 @@ export default {
         return this.prefs.render_on_screen
       },
       set(value) {
-        return jsonp('prefs://set/render-on-screen', { value: value }).then(
+        return jsonp('prefs:///set/render-on-screen', { value: value }).then(
           () => this.setPrefs({ render_on_screen: value }),
           err => bus.$emit('error', err)
         )
@@ -300,16 +300,16 @@ export default {
     ...mapMutations(['setPrefs']),
 
     openUrlInBrowser(url) {
-      jsonp('prefs://open/web-url', { url: url })
+      jsonp('prefs:///open/web-url', { url: url })
     },
 
     showHotkeyDialog(e) {
-      jsonp('prefs://show/hotkey-dialog', { name: hotkeyEventName })
+      jsonp('prefs:///show/hotkey-dialog', { name: hotkeyEventName })
       e.target.blur()
     },
 
     onHotkeySet(e) {
-      jsonp('prefs://set/hotkey-show-app', { value: e.value }).then(
+      jsonp('prefs:///set/hotkey-show-app', { value: e.value }).then(
         () => this.setPrefs({ hotkey_show_app: e.displayValue }),
         err => bus.$emit('error', err)
       )

--- a/preferences-src/src/components/pages/Shortcuts.vue
+++ b/preferences-src/src/components/pages/Shortcuts.vue
@@ -62,7 +62,7 @@ export default {
   },
   methods: {
     fetchData () {
-      jsonp('prefs://shortcut/get-all').then((data) => {
+      jsonp('prefs:///shortcut/get-all').then((data) => {
         this.items = data
       })
     },
@@ -73,7 +73,7 @@ export default {
       this.$router.push({path: 'edit-shortcut', query: item})
     },
     remove (item) {
-      jsonp('prefs://shortcut/remove', {id: item.id}).then(() => {
+      jsonp('prefs:///shortcut/remove', {id: item.id}).then(() => {
         this.items = this.items.filter((i) => item.id === i.id ? null : i)
       }, (err) => bus.$emit('error', err))
     },

--- a/preferences-src/src/components/widgets/ExtensionErrorExplanation.vue
+++ b/preferences-src/src/components/widgets/ExtensionErrorExplanation.vue
@@ -83,7 +83,7 @@ export default {
   }),
   methods: {
     openUrlInBrowser(url) {
-      jsonp('prefs://open/web-url', { url: url })
+      jsonp('prefs:///open/web-url', { url: url })
     },
     alertVariant() {
       if (this.errorName === 'UnexpectedError') {

--- a/preferences-src/src/components/widgets/ExtensionRuntimeError.vue
+++ b/preferences-src/src/components/widgets/ExtensionRuntimeError.vue
@@ -48,7 +48,7 @@ export default {
   },
   methods: {
     openUrlInBrowser(url) {
-      jsonp('prefs://open/web-url', { url: url })
+      jsonp('prefs:///open/web-url', { url: url })
     }
   }
 }

--- a/tests/ui/windows/test_PreferencesUlauncherDialog.py
+++ b/tests/ui/windows/test_PreferencesUlauncherDialog.py
@@ -59,14 +59,12 @@ class TestPreferencesUlauncherDialog:
         dialog.prefs_set_show_indicator_icon({'value': False})
         idle_add.assert_called_with(indicator.switch, False)
         settings.set_property.assert_called_with('show-indicator-icon', False)
-        settings.save_to_file.assert_called_with()
 
     def test_prefs_set_hotkey_show_app(self, dialog, ulauncherWindow, settings):
         hotkey = '<Primary>space'
         dialog.prefs_set_hotkey_show_app.original(dialog, {'value': hotkey})
         ulauncherWindow.bind_hotkey.assert_called_with(hotkey)
         settings.set_property.assert_called_with('hotkey-show-app', hotkey)
-        settings.save_to_file.assert_called_with()
 
     def test_prefs_set_autostart(self, dialog, autostart_pref):
         dialog.prefs_set_autostart({'value': True})
@@ -78,7 +76,6 @@ class TestPreferencesUlauncherDialog:
     def test_prefs_set_theme_name(self, dialog, settings, ulauncherWindow):
         dialog.prefs_set_theme_name.original(dialog, {'value': 'light'})
         settings.set_property.assert_called_with('theme-name', 'light')
-        settings.save_to_file.assert_called_with()
         ulauncherWindow.init_theme.assert_called_with()
 
     def test_prefs_showhotkey_dialog(self, dialog, hotkey_dialog):
@@ -88,7 +85,6 @@ class TestPreferencesUlauncherDialog:
     def test_prefs_set_grab_mouse_pointer(self, dialog, settings):
         dialog.prefs_set_grab_mouse_pointer({'value': True})
         settings.set_property.assert_called_with('grab-mouse-pointer', True)
-        settings.save_to_file.assert_called_with()
 
     @pytest.mark.with_display
     def test_get_app_hotkey(self, dialog, settings):

--- a/tests/ui/windows/test_PreferencesUlauncherDialog.py
+++ b/tests/ui/windows/test_PreferencesUlauncherDialog.py
@@ -52,41 +52,41 @@ class TestPreferencesUlauncherDialog:
 
     # pylint: disable=too-many-arguments
     def test_prefs_set_show_indicator_icon(self, dialog, settings, indicator, idle_add):
-        dialog.prefs_set_show_indicator_icon({'query': {'value': 'true'}})
+        dialog.prefs_set_show_indicator_icon({'value': 'true'})
         idle_add.assert_called_with(indicator.switch, True)
         settings.set_property.assert_called_with('show-indicator-icon', True)
 
-        dialog.prefs_set_show_indicator_icon({'query': {'value': '0'}})
+        dialog.prefs_set_show_indicator_icon({'value': '0'})
         idle_add.assert_called_with(indicator.switch, False)
         settings.set_property.assert_called_with('show-indicator-icon', False)
         settings.save_to_file.assert_called_with()
 
     def test_prefs_set_hotkey_show_app(self, dialog, ulauncherWindow, settings):
         hotkey = '<Primary>space'
-        dialog.prefs_set_hotkey_show_app.original(dialog, {'query': {'value': hotkey}})
+        dialog.prefs_set_hotkey_show_app.original(dialog, {'value': hotkey})
         ulauncherWindow.bind_hotkey.assert_called_with(hotkey)
         settings.set_property.assert_called_with('hotkey-show-app', hotkey)
         settings.save_to_file.assert_called_with()
 
     def test_prefs_set_autostart(self, dialog, autostart_pref):
-        dialog.prefs_set_autostart({'query': {'value': 'true'}})
+        dialog.prefs_set_autostart({'value': 'true'})
         autostart_pref.switch.assert_called_with(True)
 
-        dialog.prefs_set_autostart({'query': {'value': 'false'}})
+        dialog.prefs_set_autostart({'value': 'false'})
         autostart_pref.switch.assert_called_with(False)
 
     def test_prefs_set_theme_name(self, dialog, settings, ulauncherWindow):
-        dialog.prefs_set_theme_name.original(dialog, {'query': {'value': 'light'}})
+        dialog.prefs_set_theme_name.original(dialog, {'value': 'light'})
         settings.set_property.assert_called_with('theme-name', 'light')
         settings.save_to_file.assert_called_with()
         ulauncherWindow.init_theme.assert_called_with()
 
     def test_prefs_showhotkey_dialog(self, dialog, hotkey_dialog):
-        dialog.prefs_showhotkey_dialog.original(dialog, {'query': {'name': 'hotkey-name'}})
+        dialog.prefs_showhotkey_dialog.original(dialog, {'name': 'hotkey-name'})
         hotkey_dialog.present.assert_called_with()
 
     def test_prefs_set_grab_mouse_pointer(self, dialog, settings):
-        dialog.prefs_set_grab_mouse_pointer({'query': {'value': 'true'}})
+        dialog.prefs_set_grab_mouse_pointer({'value': 'true'})
         settings.set_property.assert_called_with('grab-mouse-pointer', True)
         settings.save_to_file.assert_called_with()
 

--- a/tests/ui/windows/test_PreferencesUlauncherDialog.py
+++ b/tests/ui/windows/test_PreferencesUlauncherDialog.py
@@ -52,11 +52,11 @@ class TestPreferencesUlauncherDialog:
 
     # pylint: disable=too-many-arguments
     def test_prefs_set_show_indicator_icon(self, dialog, settings, indicator, idle_add):
-        dialog.prefs_set_show_indicator_icon({'value': True})
+        dialog.prefs_set({'property': 'show-indicator-icon', 'value': True})
         idle_add.assert_called_with(indicator.switch, True)
         settings.set_property.assert_called_with('show-indicator-icon', True)
 
-        dialog.prefs_set_show_indicator_icon({'value': False})
+        dialog.prefs_set({'property': 'show-indicator-icon', 'value': False})
         idle_add.assert_called_with(indicator.switch, False)
         settings.set_property.assert_called_with('show-indicator-icon', False)
 
@@ -67,14 +67,14 @@ class TestPreferencesUlauncherDialog:
         settings.set_property.assert_called_with('hotkey-show-app', hotkey)
 
     def test_prefs_set_autostart(self, dialog, autostart_pref):
-        dialog.prefs_set_autostart({'value': True})
+        dialog.prefs_set_autostart(True)
         autostart_pref.switch.assert_called_with(True)
 
-        dialog.prefs_set_autostart({'value': False})
+        dialog.prefs_set_autostart(False)
         autostart_pref.switch.assert_called_with(False)
 
     def test_prefs_set_theme_name(self, dialog, settings, ulauncherWindow):
-        dialog.prefs_set_theme_name.original(dialog, {'value': 'light'})
+        dialog.prefs_set({'property': 'theme-name', 'value': 'light'})
         settings.set_property.assert_called_with('theme-name', 'light')
         ulauncherWindow.init_theme.assert_called_with()
 
@@ -83,7 +83,7 @@ class TestPreferencesUlauncherDialog:
         hotkey_dialog.present.assert_called_with()
 
     def test_prefs_set_grab_mouse_pointer(self, dialog, settings):
-        dialog.prefs_set_grab_mouse_pointer({'value': True})
+        dialog.prefs_set({'property': 'grab-mouse-pointer', 'value': True})
         settings.set_property.assert_called_with('grab-mouse-pointer', True)
 
     @pytest.mark.with_display

--- a/tests/ui/windows/test_PreferencesUlauncherDialog.py
+++ b/tests/ui/windows/test_PreferencesUlauncherDialog.py
@@ -52,11 +52,11 @@ class TestPreferencesUlauncherDialog:
 
     # pylint: disable=too-many-arguments
     def test_prefs_set_show_indicator_icon(self, dialog, settings, indicator, idle_add):
-        dialog.prefs_set_show_indicator_icon({'value': 'true'})
+        dialog.prefs_set_show_indicator_icon({'value': True})
         idle_add.assert_called_with(indicator.switch, True)
         settings.set_property.assert_called_with('show-indicator-icon', True)
 
-        dialog.prefs_set_show_indicator_icon({'value': '0'})
+        dialog.prefs_set_show_indicator_icon({'value': False})
         idle_add.assert_called_with(indicator.switch, False)
         settings.set_property.assert_called_with('show-indicator-icon', False)
         settings.save_to_file.assert_called_with()
@@ -69,10 +69,10 @@ class TestPreferencesUlauncherDialog:
         settings.save_to_file.assert_called_with()
 
     def test_prefs_set_autostart(self, dialog, autostart_pref):
-        dialog.prefs_set_autostart({'value': 'true'})
+        dialog.prefs_set_autostart({'value': True})
         autostart_pref.switch.assert_called_with(True)
 
-        dialog.prefs_set_autostart({'value': 'false'})
+        dialog.prefs_set_autostart({'value': False})
         autostart_pref.switch.assert_called_with(False)
 
     def test_prefs_set_theme_name(self, dialog, settings, ulauncherWindow):
@@ -86,7 +86,7 @@ class TestPreferencesUlauncherDialog:
         hotkey_dialog.present.assert_called_with()
 
     def test_prefs_set_grab_mouse_pointer(self, dialog, settings):
-        dialog.prefs_set_grab_mouse_pointer({'value': 'true'})
+        dialog.prefs_set_grab_mouse_pointer({'value': True})
         settings.set_property.assert_called_with('grab-mouse-pointer', True)
         settings.save_to_file.assert_called_with()
 

--- a/tests/utils/test_Router.py
+++ b/tests/utils/test_Router.py
@@ -1,25 +1,6 @@
-from urllib.parse import quote
 import mock
 import pytest
-from ulauncher.utils.Router import Router, RoutePathEmpty, RouteNotFound, get_url_params
-
-
-def test_get_url_params():
-    # Domain can be ammended completely since it's never used, but it's good to test both ways
-    p = get_url_params('settings://domain/get/all/?k1=v1&k2=&k3=%s' % quote('!(*#&^%?'))
-    assert p['scheme'] == 'settings'
-    assert p['path'] == 'get/all/'
-    assert p['query'] == {
-        'k1': 'v1',
-        'k2': '',
-        'k3': '!(*#&^%?'
-    }
-
-    p = get_url_params('settings:///get/all/?')
-    assert p['scheme'] == 'settings'
-    assert p['path'] == 'get/all/'
-    assert p['query'] is None
-
+from ulauncher.utils.Router import Router, RoutePathEmpty, RouteNotFound
 
 class TestRouter:
 
@@ -47,10 +28,6 @@ class TestRouter:
 
         assert router.dispatch(ctx, 'settings:///get/all?q=1&s=3') == 'result'
         m.assert_called_with(ctx, {
-            'scheme': 'settings',
-            'path': 'get/all',
-            'query': {
-                'q': '1',
-                's': '3'
-            }
+            'q': '1',
+            's': '3'
         })

--- a/tests/utils/test_Router.py
+++ b/tests/utils/test_Router.py
@@ -1,6 +1,9 @@
+import json
+from urllib.parse import quote
 import mock
 import pytest
 from ulauncher.utils.Router import Router, RoutePathEmpty, RouteNotFound
+
 
 class TestRouter:
 
@@ -26,8 +29,6 @@ class TestRouter:
             m(ctx, url_params)
             return 'result'
 
-        assert router.dispatch(ctx, 'settings:///get/all?q=1&s=3') == 'result'
-        m.assert_called_with(ctx, {
-            'q': '1',
-            's': '3'
-        })
+        payload = {'n': 1, 's': 'str', 'b': True}
+        assert router.dispatch(ctx, 'settings:///get/all?' + quote(json.dumps(payload))) == 'result'
+        m.assert_called_with(ctx, payload)

--- a/tests/utils/test_Router.py
+++ b/tests/utils/test_Router.py
@@ -5,7 +5,8 @@ from ulauncher.utils.Router import Router, RoutePathEmpty, RouteNotFound, get_ur
 
 
 def test_get_url_params():
-    p = get_url_params('settings://get/all/?k1=v1&k2=&k3=%s' % quote('!(*#&^%?'))
+    # Domain can be ammended completely since it's never used, but it's good to test both ways
+    p = get_url_params('settings://domain/get/all/?k1=v1&k2=&k3=%s' % quote('!(*#&^%?'))
     assert p['scheme'] == 'settings'
     assert p['path'] == 'get/all/'
     assert p['query'] == {
@@ -14,7 +15,7 @@ def test_get_url_params():
         'k3': '!(*#&^%?'
     }
 
-    p = get_url_params('settings://get/all/?')
+    p = get_url_params('settings:///get/all/?')
     assert p['scheme'] == 'settings'
     assert p['path'] == 'get/all/'
     assert p['query'] is None
@@ -32,7 +33,7 @@ class TestRouter:
 
     def test_router_dispatch_raises(self, router):
         with pytest.raises(RouteNotFound):
-            router.dispatch(None, 'settings://unknown/path')
+            router.dispatch(None, 'settings:///unknown/path')
 
     def test_router_dispatch(self, router):
         m = mock.Mock()
@@ -44,7 +45,7 @@ class TestRouter:
             m(ctx, url_params)
             return 'result'
 
-        assert router.dispatch(ctx, 'settings://get/all?q=1&s=3') == 'result'
+        assert router.dispatch(ctx, 'settings:///get/all?q=1&s=3') == 'result'
         m.assert_called_with(ctx, {
             'scheme': 'settings',
             'path': 'get/all',

--- a/ulauncher/ui/windows/PreferencesUlauncherDialog.py
+++ b/ulauncher/ui/windows/PreferencesUlauncherDialog.py
@@ -249,13 +249,13 @@ class PreferencesUlauncherDialog(Gtk.Dialog, WindowHelper):
             'available_themes': self._get_available_themes(),
             'theme_name': Theme.get_current().get_name(),
             'render_on_screen': self.settings.get_property('render-on-screen'),
-            'is_wayland': is_wayland(),
             'terminal_command': self.settings.get_property('terminal-command'),
             'grab_mouse_pointer': self.settings.get_property('grab-mouse-pointer'),
             'env': {
                 'version': get_version(),
                 'api_version': api_version,
-                'user_home': os.path.expanduser('~')
+                'user_home': os.path.expanduser('~'),
+                'is_wayland': is_wayland(),
             }
         }
 

--- a/ulauncher/ui/windows/PreferencesUlauncherDialog.py
+++ b/ulauncher/ui/windows/PreferencesUlauncherDialog.py
@@ -262,9 +262,7 @@ class PreferencesUlauncherDialog(Gtk.Dialog, WindowHelper):
     @rt.route('/set/show-indicator-icon')
     def prefs_set_show_indicator_icon(self, query):
         show_indicator = query['value']
-        logger.info('Set show-indicator-icon to %s', show_indicator)
         self.settings.set_property('show-indicator-icon', show_indicator)
-        self.settings.save_to_file()
         indicator = AppIndicator.get_instance()
         GLib.idle_add(indicator.switch, show_indicator)
 
@@ -286,31 +284,24 @@ class PreferencesUlauncherDialog(Gtk.Dialog, WindowHelper):
             recent_apps_number = int(query['value'])
         except ValueError:
             recent_apps_number = 3
-        logger.info('Set show-recent-apps to %s', recent_apps_number)
         self.settings.set_property('show-recent-apps', recent_apps_number)
-        self.settings.save_to_file()
 
     @rt.route('/set/hotkey-show-app')
     @glib_idle_add
     def prefs_set_hotkey_show_app(self, query):
         hotkey = query['value']
-        logger.info('Set hotkey-show-app to %s', hotkey)
 
         # Bind a new key
         from ulauncher.ui.windows.UlauncherWindow import UlauncherWindow
         ulauncher_window = UlauncherWindow.get_instance()
         ulauncher_window.bind_hotkey(hotkey)
         self.settings.set_property('hotkey-show-app', hotkey)
-        self.settings.save_to_file()
 
     @rt.route('/set/theme-name')
     @glib_idle_add
     def prefs_set_theme_name(self, query):
         name = query['value']
-        logger.info('Set theme-name to %s', name)
-
         self.settings.set_property('theme-name', name)
-        self.settings.save_to_file()
 
         from ulauncher.ui.windows.UlauncherWindow import UlauncherWindow
         ulauncher_window = UlauncherWindow.get_instance()
@@ -319,9 +310,7 @@ class PreferencesUlauncherDialog(Gtk.Dialog, WindowHelper):
     @rt.route('/set/terminal-command')
     def prefs_set_terminal_command(self, query):
         terminal_command = query['value']
-        logger.info('Set terminal launch command to %s', terminal_command)
         self.settings.set_property('terminal-command', terminal_command)
-        self.settings.save_to_file()
 
     @rt.route('/show/hotkey-dialog')
     @glib_idle_add
@@ -333,30 +322,22 @@ class PreferencesUlauncherDialog(Gtk.Dialog, WindowHelper):
     @rt.route('/set/clear-previous-query')
     def prefs_set_clear_previous_text(self, query):
         is_enabled = query['value']
-        logger.info('Set clear-previous-query to %s', is_enabled)
         self.settings.set_property('clear-previous-query', is_enabled)
-        self.settings.save_to_file()
 
     @rt.route('/set/grab-mouse-pointer')
     def prefs_set_grab_mouse_pointer(self, query):
         is_enabled = query['value']
-        logger.info('Set grab-mouse-pointer to %s', is_enabled)
         self.settings.set_property('grab-mouse-pointer', is_enabled)
-        self.settings.save_to_file()
 
     @rt.route('/set/disable-desktop-filters')
     def prefs_set_disable_desktop_filters(self, query):
         is_enabled = query['value']
-        logger.info('Set disable-desktop-filters to %s', is_enabled)
         self.settings.set_property('disable-desktop-filters', is_enabled)
-        self.settings.save_to_file()
 
     @rt.route('/set/render-on-screen')
     def prefs_set_render_on_screen(self, query):
         selected_option = query['value']
-        logger.info('Set render-on-screen to %s', selected_option)
         self.settings.set_property('render-on-screen', selected_option)
-        self.settings.save_to_file()
 
     @rt.route('/show/file-browser')
     @glib_idle_add

--- a/ulauncher/ui/windows/PreferencesUlauncherDialog.py
+++ b/ulauncher/ui/windows/PreferencesUlauncherDialog.py
@@ -2,7 +2,7 @@
 import os
 import logging
 import json
-from urllib.parse import unquote
+from urllib.parse import unquote, urlparse, parse_qs
 from typing import List, Optional, cast
 import traceback
 
@@ -35,7 +35,7 @@ from ulauncher.utils.mypy_extensions import TypedDict
 from ulauncher.utils.decorator.run_async import run_async
 from ulauncher.utils.wayland import is_wayland
 from ulauncher.utils.Settings import Settings
-from ulauncher.utils.Router import Router, get_url_params
+from ulauncher.utils.Router import Router
 from ulauncher.utils.AutostartPreference import AutostartPreference
 from ulauncher.ui.AppIndicator import AppIndicator
 from ulauncher.search.shortcuts.ShortcutsDb import ShortcutsDb
@@ -191,8 +191,8 @@ class PreferencesUlauncherDialog(Gtk.Dialog, WindowHelper):
 
         # pylint: disable=broad-except
         try:
-            params = get_url_params(scheme_request.get_uri())
-            callback_name = params['query']['callback']
+            params = urlparse(scheme_request.get_uri())
+            [callback_name] = parse_qs(params.query)['callback']
             assert callback_name
         except Exception as e:
             logger.exception('API call failed. %s: %s', type(e).__name__, e)
@@ -235,7 +235,7 @@ class PreferencesUlauncherDialog(Gtk.Dialog, WindowHelper):
     ######################################
 
     @rt.route('/get/all')
-    def prefs_get_all(self, url_params):
+    def prefs_get_all(self, query):
         logger.info('API call /get/all')
         return {
             'show_indicator_icon': self.settings.get_property('show-indicator-icon'),
@@ -259,8 +259,8 @@ class PreferencesUlauncherDialog(Gtk.Dialog, WindowHelper):
         }
 
     @rt.route('/set/show-indicator-icon')
-    def prefs_set_show_indicator_icon(self, url_params):
-        show_indicator = self._get_bool(url_params['query']['value'])
+    def prefs_set_show_indicator_icon(self, query):
+        show_indicator = self._get_bool(query['value'])
         logger.info('Set show-indicator-icon to %s', show_indicator)
         self.settings.set_property('show-indicator-icon', show_indicator)
         self.settings.save_to_file()
@@ -268,8 +268,8 @@ class PreferencesUlauncherDialog(Gtk.Dialog, WindowHelper):
         GLib.idle_add(indicator.switch, show_indicator)
 
     @rt.route('/set/autostart-enabled')
-    def prefs_set_autostart(self, url_params):
-        is_enabled = self._get_bool(url_params['query']['value'])
+    def prefs_set_autostart(self, query):
+        is_enabled = self._get_bool(query['value'])
         logger.info('Set autostart-enabled to %s', is_enabled)
         if is_enabled and not self.autostart_pref.is_allowed():
             raise PrefsApiError("Unable to turn on autostart preference")
@@ -280,9 +280,9 @@ class PreferencesUlauncherDialog(Gtk.Dialog, WindowHelper):
             raise PrefsApiError('Caught an error while switching "autostart": %s' % e) from e
 
     @rt.route('/set/show-recent-apps')
-    def prefs_set_show_recent_apps(self, url_params):
+    def prefs_set_show_recent_apps(self, query):
         try:
-            recent_apps_number = int(url_params['query']['value'])
+            recent_apps_number = int(query['value'])
         except ValueError:
             recent_apps_number = 3
         logger.info('Set show-recent-apps to %s', recent_apps_number)
@@ -291,8 +291,8 @@ class PreferencesUlauncherDialog(Gtk.Dialog, WindowHelper):
 
     @rt.route('/set/hotkey-show-app')
     @glib_idle_add
-    def prefs_set_hotkey_show_app(self, url_params):
-        hotkey = url_params['query']['value']
+    def prefs_set_hotkey_show_app(self, query):
+        hotkey = query['value']
         logger.info('Set hotkey-show-app to %s', hotkey)
 
         # Bind a new key
@@ -304,8 +304,8 @@ class PreferencesUlauncherDialog(Gtk.Dialog, WindowHelper):
 
     @rt.route('/set/theme-name')
     @glib_idle_add
-    def prefs_set_theme_name(self, url_params):
-        name = url_params['query']['value']
+    def prefs_set_theme_name(self, query):
+        name = query['value']
         logger.info('Set theme-name to %s', name)
 
         self.settings.set_property('theme-name', name)
@@ -316,54 +316,54 @@ class PreferencesUlauncherDialog(Gtk.Dialog, WindowHelper):
         ulauncher_window.init_theme()
 
     @rt.route('/set/terminal-command')
-    def prefs_set_terminal_command(self, url_params):
-        terminal_command = url_params['query']['value']
+    def prefs_set_terminal_command(self, query):
+        terminal_command = query['value']
         logger.info('Set terminal launch command to %s', terminal_command)
         self.settings.set_property('terminal-command', terminal_command)
         self.settings.save_to_file()
 
     @rt.route('/show/hotkey-dialog')
     @glib_idle_add
-    def prefs_showhotkey_dialog(self, url_params):
-        self._hotkey_name = url_params['query']['name']
+    def prefs_showhotkey_dialog(self, query):
+        self._hotkey_name = query['name']
         logger.info('Show hotkey-dialog for %s', self._hotkey_name)
         self.hotkey_dialog.present()
 
     @rt.route('/set/clear-previous-query')
-    def prefs_set_clear_previous_text(self, url_params):
-        is_enabled = self._get_bool(url_params['query']['value'])
+    def prefs_set_clear_previous_text(self, query):
+        is_enabled = self._get_bool(query['value'])
         logger.info('Set clear-previous-query to %s', is_enabled)
         self.settings.set_property('clear-previous-query', is_enabled)
         self.settings.save_to_file()
 
     @rt.route('/set/grab-mouse-pointer')
-    def prefs_set_grab_mouse_pointer(self, url_params):
-        is_enabled = self._get_bool(url_params['query']['value'])
+    def prefs_set_grab_mouse_pointer(self, query):
+        is_enabled = self._get_bool(query['value'])
         logger.info('Set grab-mouse-pointer to %s', is_enabled)
         self.settings.set_property('grab-mouse-pointer', is_enabled)
         self.settings.save_to_file()
 
     @rt.route('/set/disable-desktop-filters')
-    def prefs_set_disable_desktop_filters(self, url_params):
-        is_enabled = self._get_bool(url_params['query']['value'])
+    def prefs_set_disable_desktop_filters(self, query):
+        is_enabled = self._get_bool(query['value'])
         logger.info('Set disable-desktop-filters to %s', is_enabled)
         self.settings.set_property('disable-desktop-filters', is_enabled)
         self.settings.save_to_file()
 
     @rt.route('/set/render-on-screen')
-    def prefs_set_render_on_screen(self, url_params):
-        selected_option = url_params['query']['value']
+    def prefs_set_render_on_screen(self, query):
+        selected_option = query['value']
         logger.info('Set render-on-screen to %s', selected_option)
         self.settings.set_property('render-on-screen', selected_option)
         self.settings.save_to_file()
 
     @rt.route('/show/file-browser')
     @glib_idle_add
-    def prefs_show_file_browser(self, url_params):
+    def prefs_show_file_browser(self, query):
         """
         Request params: type=(image|all), name=(str)
         """
-        file_browser_name = url_params['query']['name']
+        file_browser_name = query['name']
         logger.info('Show file browser dialog for %s', file_browser_name)
         dialog = Gtk.FileChooserDialog("Please choose a file", self, Gtk.FileChooserAction.OPEN,
                                        (Gtk.STOCK_CANCEL, Gtk.ResponseType.CANCEL, Gtk.STOCK_OPEN, Gtk.ResponseType.OK))
@@ -384,54 +384,52 @@ class PreferencesUlauncherDialog(Gtk.Dialog, WindowHelper):
         dialog.destroy()
 
     @rt.route('/open/web-url')
-    def prefs_open_url(self, url_params):
-        url = unquote(url_params['query']['url'])
+    def prefs_open_url(self, query):
+        url = unquote(query['url'])
         logger.info('Open Web URL %s', url)
         OpenUrlAction(url).run()
 
     @rt.route('/close')
-    def prefs_close(self, url_params):
+    def prefs_close(self, query):
         logger.info('Close preferences')
         self.hide()
 
     @rt.route('/shortcut/get-all')
-    def prefs_shortcut_get_all(self, url_params):
+    def prefs_shortcut_get_all(self, query):
         logger.info('Handling /shortcut/get-all')
         shortcuts = ShortcutsDb.get_instance()
         return shortcuts.get_sorted_records()
 
     @rt.route('/shortcut/update')
     @rt.route('/shortcut/add')
-    def prefs_shortcut_update(self, url_params):
-        req_data = url_params['query']
-        logger.info('Add/Update shortcut: %s', json.dumps(req_data))
+    def prefs_shortcut_update(self, query):
+        logger.info('Add/Update shortcut: %s', json.dumps(query))
         shortcuts = ShortcutsDb.get_instance()
-        id = shortcuts.put_shortcut(req_data['name'],
-                                    req_data['keyword'],
-                                    req_data['cmd'],
-                                    req_data.get('icon') or None,
-                                    str_to_bool(req_data['is_default_search']),
-                                    str_to_bool(req_data['run_without_argument']),
-                                    req_data.get('id'))
+        id = shortcuts.put_shortcut(query['name'],
+                                    query['keyword'],
+                                    query['cmd'],
+                                    query.get('icon') or None,
+                                    str_to_bool(query['is_default_search']),
+                                    str_to_bool(query['run_without_argument']),
+                                    query.get('id'))
         shortcuts.commit()
         return {'id': id}
 
     @rt.route('/shortcut/remove')
-    def prefs_shortcut_remove(self, url_params):
-        req_data = url_params['query']
-        logger.info('Remove shortcut: %s', json.dumps(req_data))
+    def prefs_shortcut_remove(self, query):
+        logger.info('Remove shortcut: %s', json.dumps(query))
         shortcuts = ShortcutsDb.get_instance()
-        shortcuts.remove(req_data['id'])
+        shortcuts.remove(query['id'])
         shortcuts.commit()
 
     @rt.route('/extension/get-all')
-    def prefs_extension_get_all(self, url_params):
+    def prefs_extension_get_all(self, query):
         logger.info('Handling /extension/get-all')
         return self._get_all_extensions()
 
     @rt.route('/extension/add')
-    def prefs_extension_add(self, url_params):
-        url = url_params['query']['url']
+    def prefs_extension_add(self, query):
+        url = query['url']
         logger.info('Add extension: %s', url)
         downloader = ExtensionDownloader.get_instance()
         ext_id = downloader.download(url)
@@ -440,8 +438,7 @@ class PreferencesUlauncherDialog(Gtk.Dialog, WindowHelper):
         return self._get_all_extensions()
 
     @rt.route('/extension/update-prefs')
-    def prefs_extension_update_prefs(self, url_params):
-        query = url_params['query']
+    def prefs_extension_update_prefs(self, query):
         ext_id = query['id']
         logger.info('Update extension preferences: %s', query)
         prefix = 'pref.'
@@ -454,30 +451,27 @@ class PreferencesUlauncherDialog(Gtk.Dialog, WindowHelper):
                 controller.trigger_event(PreferencesUpdateEvent(pref_id, old_value, value))
 
     @rt.route('/extension/check-updates')
-    def prefs_extension_check_updates(self, url_params):
+    def prefs_extension_check_updates(self, query):
         logger.info('Handling /extension/check-updates')
-        ext_id = url_params['query']['id']
         try:
-            return ExtensionDownloader.get_instance().get_new_version(ext_id)
+            return ExtensionDownloader.get_instance().get_new_version(query['id'])
         except ExtensionIsUpToDateError:
             return None
 
     @rt.route('/extension/update-ext')
-    def prefs_extension_update_ext(self, url_params):
-        ext_id = url_params['query']['id']
-        logger.info('Update extension: %s', ext_id)
+    def prefs_extension_update_ext(self, query):
+        logger.info('Update extension: %s', query['id'])
         downloader = ExtensionDownloader.get_instance()
         try:
-            downloader.update(ext_id)
+            downloader.update(query['id'])
         except ExtensionManifestError as e:
             raise PrefsApiError(e)
 
     @rt.route('/extension/remove')
-    def prefs_extension_remove(self, url_params):
-        ext_id = url_params['query']['id']
-        logger.info('Remove extension: %s', ext_id)
+    def prefs_extension_remove(self, query):
+        logger.info('Remove extension: %s', query['id'])
         downloader = ExtensionDownloader.get_instance()
-        downloader.remove(ext_id)
+        downloader.remove(query['id'])
 
     ######################################
     # Helpers

--- a/ulauncher/utils/Router.py
+++ b/ulauncher/utils/Router.py
@@ -1,7 +1,7 @@
 import re
 from urllib.parse import unquote
 
-RE_URL = re.compile(r'^(?P<scheme>.*)://(?P<path>[^\?]*)(\?(?P<query>.*))?$', flags=re.IGNORECASE)
+RE_URL = re.compile(r'^(?P<scheme>.*)://(?P<domain>[^\/]*)/(?P<path>[^\?]*)(\?(?P<query>.*))?$', flags=re.IGNORECASE)
 
 
 def get_url_params(url):

--- a/ulauncher/utils/Settings.py
+++ b/ulauncher/utils/Settings.py
@@ -1,5 +1,6 @@
 import os
 import json
+import logging
 import gi
 gi.require_version('GObject', '2.0')
 # pylint: disable=wrong-import-position
@@ -7,6 +8,8 @@ from gi.repository import GObject
 
 from ulauncher.utils.decorator.singleton import singleton
 from ulauncher.config import SETTINGS_FILE_PATH
+
+logger = logging.getLogger(__name__)
 
 GPROPERTIES = {
     "hotkey-show-app": (str,  # type
@@ -118,4 +121,6 @@ class Settings(GObject.GObject):
             return GPROPERTIES[prop.name][3]
 
     def do_set_property(self, prop, value):
+        logger.info('Set %s to %s', prop.name, value)
         self._properties[prop.name] = value
+        self.save_to_file()

--- a/ulauncher/utils/Settings.py
+++ b/ulauncher/utils/Settings.py
@@ -124,3 +124,6 @@ class Settings(GObject.GObject):
         logger.info('Set %s to %s', prop.name, value)
         self._properties[prop.name] = value
         self.save_to_file()
+
+    def get_all(self):
+        return dict(list(map(lambda prop: (prop, getattr(self.props, prop)), dir(self.props))))


### PR DESCRIPTION
This gets rid of the worst code duplication described in #315, but does not fully solve the problem.
You still need to add each setting in four places:
* Settings.py (this is good)
* Preferences.vue display code (this is also good)
* Preferences.vue array to generate the computed properties  (this should not be needed, but at least you just have to add the name of the setting to the array)
* Fixture.js (this should not be needed imo - it should be able to load the defaults from Settings.py)

The big difference is that you no longer need to add the full computed properties (~15 lines of code each), and you don't need to add individual routes in PreferencesUlauncherDialog.py, not add the preferences to the /get/all-route if they are defined in Settings.py


### Checklist
- [x] Verify that the test command `./ul test` is passing (the CI server will check this if you don't)
- [ ] Update the documentation according to your changes (when applicable)
- [ ] Write unit tests for your changes (when applicable)
