### PR TITLE
Fix #874 and floating point errors in general for CalcMode

### DIFF
--- a/tests/modes/calc/test_CalcMode.py
+++ b/tests/modes/calc/test_CalcMode.py
@@ -1,5 +1,6 @@
+from decimal import Decimal
 import pytest
-from ulauncher.modes.calc.CalcMode import CalcMode
+from ulauncher.modes.calc.CalcMode import CalcMode, eval_expr
 
 
 class TestCalcMode:
@@ -28,6 +29,10 @@ class TestCalcMode:
         assert not mode.is_enabled(')+3')
         assert not mode.is_enabled('e3')
         assert not mode.is_enabled('a+b')
+
+    def test_eval_expr_no_floating_point_errors(self):
+        assert eval_expr('110 / 3') == Decimal('36.66666666666666666666666667')
+        assert eval_expr('1.1 + 2.2') == Decimal('3.3')
 
     def test_handle_query(self, mode, RenderResultListAction, CalcResultItem):
         assert mode.handle_query('3+2') == RenderResultListAction.return_value

--- a/ulauncher/modes/calc/CalcMode.py
+++ b/ulauncher/modes/calc/CalcMode.py
@@ -1,5 +1,6 @@
 import re
 import ast
+from decimal import Decimal
 import operator as op
 
 from ulauncher.api.shared.action.RenderResultListAction import RenderResultListAction
@@ -35,7 +36,7 @@ def eval_expr(expr):
 
 def _eval(node):
     if isinstance(node, ast.Num):  # <number>
-        return node.n
+        return Decimal(str(node.n))
     if isinstance(node, ast.BinOp):  # <left> <operator> <right>
         return operators[type(node.op)](_eval(node.left), _eval(node.right))
     if isinstance(node, ast.UnaryOp):  # <operator> <operand> e.g., -1


### PR DESCRIPTION
This fixes #874 and more critical floating point errors such as `1.1 + 2.2` evaluating to `3.3000000000000003`

### Checklist
- [x] Verify that the test command `./ul test` is passing (the CI server will check this if you don't)
- [ ] Update the documentation according to your changes (when applicable)
- [x] Write unit tests for your changes (when applicable)
