### PR TITLE
Treat both comma and dot as decimal separators for calc mode

### DIFF
--- a/tests/modes/calc/test_CalcMode.py
+++ b/tests/modes/calc/test_CalcMode.py
@@ -34,6 +34,11 @@ class TestCalcMode:
         assert eval_expr('110 / 3') == Decimal('36.66666666666666666666666667')
         assert eval_expr('1.1 + 2.2') == Decimal('3.3')
 
+    def test_eval_expr_syntax_variation(self):
+        assert eval_expr('5.5 * 10') == Decimal('55')
+        assert eval_expr('12 / 1,5') == eval_expr('12 / 1.5') == Decimal('8')
+        assert eval_expr('3 ** 2') == eval_expr('3^2') == Decimal('9')
+
     def test_handle_query(self, mode, RenderResultListAction, CalcResultItem):
         assert mode.handle_query('3+2') == RenderResultListAction.return_value
         assert mode.handle_query('3+2*') == RenderResultListAction.return_value

--- a/ulauncher/modes/calc/CalcMode.py
+++ b/ulauncher/modes/calc/CalcMode.py
@@ -25,7 +25,7 @@ def eval_expr(expr):
     >>> eval_expr('1 + 2*3**(4^5) / (6 + -7)')
     -5.0
     """
-    expr = expr.replace("^", "**")
+    expr = expr.replace("^", "**").replace(",", ".")
     try:
         return _eval(ast.parse(expr, mode='eval').body)
     # pylint: disable=broad-except
@@ -46,7 +46,7 @@ def _eval(node):
 
 
 class CalcMode(BaseMode):
-    RE_CALC = re.compile(r'^[\d\-\(\.][\d\*+\/\-\.e\(\)\^ ]*$', flags=re.IGNORECASE)
+    RE_CALC = re.compile(r'^[\d\-\(\.,][\d\*+\/\-\.,e\(\)\^ ]*$', flags=re.IGNORECASE)
 
     def is_enabled(self, query):
         return bool(re.match(self.RE_CALC, query))


### PR DESCRIPTION
Adding comma as a synonym for dot, for math expressions. This fixes #575, but means we can't accept comma or dot as thousand separators in the input (probably reasonable for our use anyway).

![2021-12-05_12-05](https://user-images.githubusercontent.com/515120/144743987-75f5ecad-8f62-4e68-8970-645a44d7eb12.png)


### Checklist
- [x] Verify that the test command `./ul test` is passing (the CI server will check this if you don't)
- [ ] Update the documentation according to your changes (when applicable)
- [x] Write unit tests for your changes (when applicable)
