### PR TITLE
Merge icon loading methods

### DIFF
--- a/docs/extensions/tutorial.rst
+++ b/docs/extensions/tutorial.rst
@@ -96,7 +96,7 @@ Create :file:`manifest.json` using the following template::
 
 * ``required_api_version`` - the version(s) of the Ulauncher Extension API (not the main app version) that the extension requires. See above for more information.
 * ``name``, ``description``, ``developer_name`` can be anything you like but not an empty string
-* ``icon`` - relative path to an extension icon
+* ``icon`` - relative path to an extension icon, or the name of a `themed icon <https://specifications.freedesktop.org/icon-naming-spec/icon-naming-spec-latest.html#names>`_, for example "edit-paste".
 * ``options`` - dictionary of optional parameters. See available options below
 * ``preferences`` - list of preferences available for users to override.
   They are rendered in Ulauncher preferences in the same order they are listed in manifest.
@@ -148,7 +148,7 @@ The values of the preferences are forwarded to the ``on_event`` method of the ``
   Optional description
 
 ``icon``
-  Optional per-keyword icon path. If not specificed it will use the extension icon
+  Optional per-keyword icon (path or themed icon). If not specificed it will use the extension icon
 
 ``options``
   Required for type "select". Must be a list of strings or objects like: ``{"value": "...", "text": "..."}``

--- a/docs/source/ulauncher.utils.rst
+++ b/docs/source/ulauncher.utils.rst
@@ -96,7 +96,7 @@ ulauncher.utils.fuzzy\_search module
 ulauncher.utils.image\_loader module
 ------------------------------------
 
-.. automodule:: ulauncher.utils.image_loader
+.. automodule:: ulauncher.utils.icon
     :members:
     :undoc-members:
     :show-inheritance:

--- a/tests/api/server/test_ExtensionManifest.py
+++ b/tests/api/server/test_ExtensionManifest.py
@@ -30,11 +30,11 @@ class TestExtensionManifest:
         manifest.refresh()
         assert manifest.get_name() == "Test Extension"
 
-    def test_load_icon__load_image__is_called(self, ext_dir, mocker):
-        load_image = mocker.patch('ulauncher.api.server.ExtensionManifest.load_image')
+    def test_load_icon__load_icon__is_called(self, ext_dir, mocker):
+        load_icon = mocker.patch('ulauncher.api.server.ExtensionManifest.load_icon')
         manifest = ExtensionManifest('test_extension', {'icon': 'images/icon.png'}, ext_dir)
-        assert manifest.load_icon(100) is load_image.return_value
-        load_image.assert_called_with(os.path.join(ext_dir, 'test_extension', 'images/icon.png'), 100)
+        assert manifest.load_icon(100) is load_icon.return_value
+        load_icon.assert_called_with(os.path.join(ext_dir, 'test_extension', 'images/icon.png'), 100)
 
     def test_validate__name_empty__exception_raised(self, ext_dir):
         manifest = ExtensionManifest('test_extension', {'required_api_version': '1'}, ext_dir)

--- a/tests/modes/apps/test_AppResultItem.py
+++ b/tests/modes/apps/test_AppResultItem.py
@@ -3,9 +3,8 @@ import mock
 import pytest
 import gi
 gi.require_version('Gio', '2.0')
-gi.require_version('GdkPixbuf', '2.0')
 # pylint: disable=wrong-import-position
-from gi.repository import Gio, GdkPixbuf
+from gi.repository import Gio
 from ulauncher.utils.db.KeyValueJsonDb import KeyValueJsonDb
 from ulauncher.modes.apps.AppResultItem import AppResultItem
 from ulauncher.modes.QueryHistoryDb import QueryHistoryDb
@@ -56,7 +55,7 @@ class TestAppResultItem:
         assert app1.get_description(Query('q')) == 'Your own yes-man'
 
     def test_get_icon(self, app1):
-        assert isinstance(app1.get_icon(), GdkPixbuf.Pixbuf)
+        assert isinstance(app1.get_icon(), str)
         assert app1.get('Icon') == 'dialog-yes'
 
     def test_search_score(self, app1):

--- a/tests/modes/file_browser/test_FileBrowserResultItem.py
+++ b/tests/modes/file_browser/test_FileBrowserResultItem.py
@@ -54,10 +54,8 @@ class TestFileBrowserResultItem:
     def test_get_name(self, result_item, path):
         assert result_item.get_name() == path.get_basename.return_value
 
-    def test_icon(self, result_item, path, mocker):
-        get_file_icon = mocker.patch('ulauncher.modes.file_browser.FileBrowserResultItem.get_file_icon')
-        assert result_item.get_icon() == get_file_icon.return_value
-        get_file_icon.assert_called_with(path, result_item.ICON_SIZE)
+    def test_icon(self, result_item):
+        assert isinstance(result_item.get_icon(), str)
 
     # pylint: disable=too-many-arguments
     def test_on_enter(self, result_item, path, file_queries, OpenAction, SetUserQueryAction):

--- a/tests/modes/shortcuts/test_ShortcutResultItem.py
+++ b/tests/modes/shortcuts/test_ShortcutResultItem.py
@@ -41,10 +41,8 @@ class TestShortcutResultItem:
         assert item.get_description(Query('keyword test')) == 'https://site/?q=...'
         assert item.get_description(Query('goo')) == 'https://site/?q=...'
 
-    def test_get_icon(self, mocker, item):
-        load_icon = mocker.patch('ulauncher.modes.shortcuts.ShortcutResultItem.load_icon')
-        assert item.get_icon() is load_icon.return_value
-        load_icon.assert_called_once_with('icon_path', 40)
+    def test_get_icon(self, item):
+        assert isinstance(item.get_icon(), str)
 
     def test_on_enter(self, item, ActionList, OpenUrlAction, SetUserQueryAction):
         assert item.on_enter(Query('kw test')) is ActionList.return_value

--- a/tests/modes/shortcuts/test_ShortcutResultItem.py
+++ b/tests/modes/shortcuts/test_ShortcutResultItem.py
@@ -42,9 +42,9 @@ class TestShortcutResultItem:
         assert item.get_description(Query('goo')) == 'https://site/?q=...'
 
     def test_get_icon(self, mocker, item):
-        load_image = mocker.patch('ulauncher.modes.shortcuts.ShortcutResultItem.load_image')
-        assert item.get_icon() is load_image.return_value
-        load_image.assert_called_once_with('icon_path', 40)
+        load_icon = mocker.patch('ulauncher.modes.shortcuts.ShortcutResultItem.load_icon')
+        assert item.get_icon() is load_icon.return_value
+        load_icon.assert_called_once_with('icon_path', 40)
 
     def test_on_enter(self, item, ActionList, OpenUrlAction, SetUserQueryAction):
         assert item.on_enter(Query('kw test')) is ActionList.return_value

--- a/tests/ui/windows/test_UlauncherWindow.py
+++ b/tests/ui/windows/test_UlauncherWindow.py
@@ -49,8 +49,8 @@ class TestUlauncherWindow:
         return mocked
 
     @pytest.fixture(autouse=True)
-    def load_image(self, mocker):
-        return mocker.patch('ulauncher.ui.windows.UlauncherWindow.load_image')
+    def load_icon(self, mocker):
+        return mocker.patch('ulauncher.ui.windows.UlauncherWindow.load_icon')
 
     @pytest.fixture(autouse=True)
     def show_notification(self, mocker):

--- a/ulauncher/api/server/ExtensionManifest.py
+++ b/ulauncher/api/server/ExtensionManifest.py
@@ -2,7 +2,7 @@ import os
 from json import load
 from typing import cast, Optional, List, Union
 from ulauncher.config import EXTENSIONS_DIR
-from ulauncher.utils.image_loader import load_image
+from ulauncher.utils.icon import load_icon
 from ulauncher.api.shared.errors import UlauncherAPIError, ErrorName
 from ulauncher.api.version import api_version, satisfies
 from ulauncher.utils.mypy_extensions import TypedDict
@@ -74,7 +74,7 @@ class ExtensionManifest:
 
     def load_icon(self, size, path=None):
         abs_path = os.path.join(self.extensions_dir, self.extension_id, path) if path else self.get_icon_path()
-        return load_image(abs_path, size)
+        return load_icon(abs_path, size)
 
     def get_required_api_version(self) -> str:
         return self.manifest['required_api_version']

--- a/ulauncher/api/shared/item/ExtensionResultItem.py
+++ b/ulauncher/api/shared/item/ExtensionResultItem.py
@@ -3,7 +3,7 @@ import sys
 
 from ulauncher.api.shared.action.BaseAction import BaseAction
 from ulauncher.api.shared.item.ResultItem import ResultItem
-from ulauncher.utils.image_loader import load_image
+from ulauncher.utils.icon import load_icon
 from ulauncher.modes.QueryHistoryDb import QueryHistoryDb
 
 
@@ -28,7 +28,7 @@ class ExtensionResultItem(ResultItem):
             if not icon_path.startswith('/'):
                 icon_path = os.path.join(self.extension_path, icon_path)
 
-            return load_image(icon_path, self.get_icon_size())
+            return load_icon(icon_path, self.get_icon_size())
 
         # assuming it's GtkPixbuf
         return self._icon

--- a/ulauncher/api/shared/item/ExtensionResultItem.py
+++ b/ulauncher/api/shared/item/ExtensionResultItem.py
@@ -3,7 +3,6 @@ import sys
 
 from ulauncher.api.shared.action.BaseAction import BaseAction
 from ulauncher.api.shared.item.ResultItem import ResultItem
-from ulauncher.utils.icon import load_icon
 from ulauncher.modes.QueryHistoryDb import QueryHistoryDb
 
 
@@ -22,13 +21,8 @@ class ExtensionResultItem(ResultItem):
             raise Exception("Incorrect type of on_enter argument")
 
     def get_icon(self):
-        if isinstance(self._icon, str):
-            icon_path = self._icon
-
-            if not icon_path.startswith('/'):
-                icon_path = os.path.join(self.extension_path, icon_path)
-
-            return load_icon(icon_path, self.get_icon_size())
+        if isinstance(self._icon, str) and not self._icon.startswith('/') and "." in self._icon:
+            return os.path.join(self.extension_path, self._icon)
 
         # assuming it's GtkPixbuf
         return self._icon

--- a/ulauncher/modes/apps/AppResultItem.py
+++ b/ulauncher/modes/apps/AppResultItem.py
@@ -10,7 +10,7 @@ from ulauncher.utils.fuzzy_search import get_score
 from ulauncher.api.shared.action.LaunchAppAction import LaunchAppAction
 from ulauncher.api.shared.item.ResultItem import ResultItem
 from ulauncher.modes.QueryHistoryDb import QueryHistoryDb
-from ulauncher.utils.image_loader import get_app_icon_pixbuf
+from ulauncher.utils.icon import load_icon
 
 settings = Settings.get_instance()
 _app_starts = KeyValueJsonDb(join(STATE_DIR, 'app_starts.json')).open()
@@ -93,7 +93,7 @@ class AppResultItem(ResultItem):
         return self._query_history.find(query) == self._name
 
     def get_icon(self):
-        return get_app_icon_pixbuf(self._app_info.get_icon(), self.get_icon_size())
+        return load_icon(self._app_info.get_string('Icon'), self.get_icon_size())
 
     def on_enter(self, query):
         self._query_history.save_query(str(query), self._name)

--- a/ulauncher/modes/apps/AppResultItem.py
+++ b/ulauncher/modes/apps/AppResultItem.py
@@ -10,7 +10,6 @@ from ulauncher.utils.fuzzy_search import get_score
 from ulauncher.api.shared.action.LaunchAppAction import LaunchAppAction
 from ulauncher.api.shared.item.ResultItem import ResultItem
 from ulauncher.modes.QueryHistoryDb import QueryHistoryDb
-from ulauncher.utils.icon import load_icon
 
 settings = Settings.get_instance()
 _app_starts = KeyValueJsonDb(join(STATE_DIR, 'app_starts.json')).open()
@@ -93,7 +92,7 @@ class AppResultItem(ResultItem):
         return self._query_history.find(query) == self._name
 
     def get_icon(self):
-        return load_icon(self._app_info.get_string('Icon'), self.get_icon_size())
+        return self._app_info.get_string('Icon')
 
     def on_enter(self, query):
         self._query_history.save_query(str(query), self._name)

--- a/ulauncher/modes/calc/CalcResultItem.py
+++ b/ulauncher/modes/calc/CalcResultItem.py
@@ -2,7 +2,6 @@ from ulauncher.api.shared.action.CopyToClipboardAction import CopyToClipboardAct
 from ulauncher.api.shared.action.DoNothingAction import DoNothingAction
 from ulauncher.api.shared.item.ResultItem import ResultItem
 from ulauncher.config import get_data_file
-from ulauncher.utils.icon import load_icon
 
 
 class CalcResultItem(ResultItem):
@@ -23,7 +22,7 @@ class CalcResultItem(ResultItem):
         return 'Enter to copy to the clipboard' if self.result else self.error
 
     def get_icon(self):
-        return load_icon(get_data_file('icons/calculator.png'), self.get_icon_size())
+        return get_data_file('icons/calculator.png')
 
     def on_enter(self, query):
         if self.result is not None:

--- a/ulauncher/modes/calc/CalcResultItem.py
+++ b/ulauncher/modes/calc/CalcResultItem.py
@@ -2,7 +2,7 @@ from ulauncher.api.shared.action.CopyToClipboardAction import CopyToClipboardAct
 from ulauncher.api.shared.action.DoNothingAction import DoNothingAction
 from ulauncher.api.shared.item.ResultItem import ResultItem
 from ulauncher.config import get_data_file
-from ulauncher.utils.image_loader import load_image
+from ulauncher.utils.icon import load_icon
 
 
 class CalcResultItem(ResultItem):
@@ -23,7 +23,7 @@ class CalcResultItem(ResultItem):
         return 'Enter to copy to the clipboard' if self.result else self.error
 
     def get_icon(self):
-        return load_image(get_data_file('icons/calculator.png'), self.get_icon_size())
+        return load_icon(get_data_file('icons/calculator.png'), self.get_icon_size())
 
     def on_enter(self, query):
         if self.result is not None:

--- a/ulauncher/modes/file_browser/FileBrowserResultItem.py
+++ b/ulauncher/modes/file_browser/FileBrowserResultItem.py
@@ -10,7 +10,6 @@ from ulauncher.api.shared.action.RenderResultListAction import RenderResultListA
 from ulauncher.api.shared.action.SetUserQueryAction import SetUserQueryAction
 from ulauncher.api.shared.item.SmallResultItem import SmallResultItem
 from ulauncher.utils.Path import Path
-from ulauncher.utils.icon import load_icon
 
 from ulauncher.modes.file_browser.FileQueries import FileQueries
 from ulauncher.modes.file_browser.alt_menu.CopyPathToClipboardItem import CopyPathToClipboardItem
@@ -49,7 +48,7 @@ class FileBrowserResultItem(SmallResultItem):
         query = os.path.basename(query)
         return super().get_name_highlighted(query, color)
 
-    def get_file_icon(self):
+    def get_icon(self):
         if self.path.is_dir():
             return SPECIAL_DIRS.get(str(self.path)) or "folder"
 
@@ -61,9 +60,6 @@ class FileBrowserResultItem(SmallResultItem):
             return "application-x-executable"
 
         return "unknown"
-
-    def get_icon(self):
-        return load_icon(self.get_file_icon(), self.get_icon_size())
 
     def on_enter(self, query):
         self._file_queries.save_query(self.path.get_abs_path())

--- a/ulauncher/modes/file_browser/FileBrowserResultItem.py
+++ b/ulauncher/modes/file_browser/FileBrowserResultItem.py
@@ -1,15 +1,32 @@
 import os
+import mimetypes
+import gi
+gi.require_version('GLib', '2.0')
+# pylint: disable=wrong-import-position
+from gi.repository import GLib
 
 from ulauncher.api.shared.action.OpenAction import OpenAction
 from ulauncher.api.shared.action.RenderResultListAction import RenderResultListAction
 from ulauncher.api.shared.action.SetUserQueryAction import SetUserQueryAction
 from ulauncher.api.shared.item.SmallResultItem import SmallResultItem
 from ulauncher.utils.Path import Path
-from ulauncher.utils.icon import get_file_icon
+from ulauncher.utils.icon import load_icon
 
 from ulauncher.modes.file_browser.FileQueries import FileQueries
 from ulauncher.modes.file_browser.alt_menu.CopyPathToClipboardItem import CopyPathToClipboardItem
 from ulauncher.modes.file_browser.alt_menu.OpenFolderItem import OpenFolderItem
+
+SPECIAL_DIRS = {
+    GLib.get_user_special_dir(GLib.UserDirectory.DIRECTORY_DOWNLOAD): 'folder-download',
+    GLib.get_user_special_dir(GLib.UserDirectory.DIRECTORY_DOCUMENTS): 'folder-documents',
+    GLib.get_user_special_dir(GLib.UserDirectory.DIRECTORY_MUSIC): 'folder-music',
+    GLib.get_user_special_dir(GLib.UserDirectory.DIRECTORY_PICTURES): 'folder-pictures',
+    GLib.get_user_special_dir(GLib.UserDirectory.DIRECTORY_PUBLIC_SHARE): 'folder-publicshare',
+    GLib.get_user_special_dir(GLib.UserDirectory.DIRECTORY_TEMPLATES): 'folder-templates',
+    GLib.get_user_special_dir(GLib.UserDirectory.DIRECTORY_VIDEOS): 'folder-videos',
+    GLib.get_user_special_dir(GLib.UserDirectory.DIRECTORY_DESKTOP): 'user-desktop',
+    os.path.expanduser('~'): 'folder-home'
+}
 
 
 class FileBrowserResultItem(SmallResultItem):
@@ -32,8 +49,21 @@ class FileBrowserResultItem(SmallResultItem):
         query = os.path.basename(query)
         return super().get_name_highlighted(query, color)
 
+    def get_file_icon(self):
+        if self.path.is_dir():
+            return SPECIAL_DIRS.get(str(self.path)) or "folder"
+
+        mime = mimetypes.guess_type(self.path.get_basename())[0]
+        if mime:
+            return mime.replace("/", "-")
+
+        if self.path.is_exe():
+            return "application-x-executable"
+
+        return "unknown"
+
     def get_icon(self):
-        return get_file_icon(self.path, self.get_icon_size())
+        return load_icon(self.get_file_icon(), self.get_icon_size())
 
     def on_enter(self, query):
         self._file_queries.save_query(self.path.get_abs_path())

--- a/ulauncher/modes/file_browser/FileBrowserResultItem.py
+++ b/ulauncher/modes/file_browser/FileBrowserResultItem.py
@@ -5,7 +5,7 @@ from ulauncher.api.shared.action.RenderResultListAction import RenderResultListA
 from ulauncher.api.shared.action.SetUserQueryAction import SetUserQueryAction
 from ulauncher.api.shared.item.SmallResultItem import SmallResultItem
 from ulauncher.utils.Path import Path
-from ulauncher.utils.image_loader import get_file_icon
+from ulauncher.utils.icon import get_file_icon
 
 from ulauncher.modes.file_browser.FileQueries import FileQueries
 from ulauncher.modes.file_browser.alt_menu.CopyPathToClipboardItem import CopyPathToClipboardItem

--- a/ulauncher/modes/file_browser/alt_menu/CopyPathToClipboardItem.py
+++ b/ulauncher/modes/file_browser/alt_menu/CopyPathToClipboardItem.py
@@ -1,6 +1,5 @@
 from ulauncher.api.shared.action.CopyToClipboardAction import CopyToClipboardAction
 from ulauncher.api.shared.item.SmallResultItem import SmallResultItem
-from ulauncher.utils.icon import load_icon
 
 
 class CopyPathToClipboardItem(SmallResultItem):
@@ -20,7 +19,7 @@ class CopyPathToClipboardItem(SmallResultItem):
         pass
 
     def get_icon(self):
-        return load_icon('edit-copy', self.get_icon_size())
+        return 'edit-copy'
 
     def on_enter(self, query):
         return CopyToClipboardAction(self.path.get_abs_path())

--- a/ulauncher/modes/file_browser/alt_menu/CopyPathToClipboardItem.py
+++ b/ulauncher/modes/file_browser/alt_menu/CopyPathToClipboardItem.py
@@ -1,6 +1,6 @@
 from ulauncher.api.shared.action.CopyToClipboardAction import CopyToClipboardAction
 from ulauncher.api.shared.item.SmallResultItem import SmallResultItem
-from ulauncher.utils.image_loader import get_themed_icon_by_name
+from ulauncher.utils.icon import load_icon
 
 
 class CopyPathToClipboardItem(SmallResultItem):
@@ -20,7 +20,7 @@ class CopyPathToClipboardItem(SmallResultItem):
         pass
 
     def get_icon(self):
-        return get_themed_icon_by_name('edit-copy', self.get_icon_size())
+        return load_icon('edit-copy', self.get_icon_size())
 
     def on_enter(self, query):
         return CopyToClipboardAction(self.path.get_abs_path())

--- a/ulauncher/modes/file_browser/alt_menu/OpenFolderItem.py
+++ b/ulauncher/modes/file_browser/alt_menu/OpenFolderItem.py
@@ -1,6 +1,6 @@
 from ulauncher.api.shared.action.OpenAction import OpenAction
 from ulauncher.api.shared.item.SmallResultItem import SmallResultItem
-from ulauncher.utils.image_loader import get_themed_icon_by_name
+from ulauncher.utils.icon import load_icon
 
 
 class OpenFolderItem(SmallResultItem):
@@ -24,7 +24,7 @@ class OpenFolderItem(SmallResultItem):
         return self._name
 
     def get_icon(self):
-        return get_themed_icon_by_name('system-file-manager', self.get_icon_size())
+        return load_icon('system-file-manager', self.get_icon_size())
 
     def on_enter(self, query):
         return OpenAction(self.path.get_abs_path())

--- a/ulauncher/modes/file_browser/alt_menu/OpenFolderItem.py
+++ b/ulauncher/modes/file_browser/alt_menu/OpenFolderItem.py
@@ -1,6 +1,5 @@
 from ulauncher.api.shared.action.OpenAction import OpenAction
 from ulauncher.api.shared.item.SmallResultItem import SmallResultItem
-from ulauncher.utils.icon import load_icon
 
 
 class OpenFolderItem(SmallResultItem):
@@ -24,7 +23,7 @@ class OpenFolderItem(SmallResultItem):
         return self._name
 
     def get_icon(self):
-        return load_icon('system-file-manager', self.get_icon_size())
+        return 'system-file-manager'
 
     def on_enter(self, query):
         return OpenAction(self.path.get_abs_path())

--- a/ulauncher/modes/shortcuts/ShortcutResultItem.py
+++ b/ulauncher/modes/shortcuts/ShortcutResultItem.py
@@ -5,8 +5,7 @@ from ulauncher.api.shared.action.OpenUrlAction import OpenUrlAction
 from ulauncher.api.shared.action.RunScriptAction import RunScriptAction
 from ulauncher.api.shared.action.SetUserQueryAction import SetUserQueryAction
 from ulauncher.api.shared.item.ResultItem import ResultItem
-from ulauncher.utils.image_loader import load_image
-from ulauncher.config import get_data_file
+from ulauncher.utils.icon import load_icon
 from ulauncher.modes.QueryHistoryDb import QueryHistoryDb
 
 
@@ -55,8 +54,7 @@ class ShortcutResultItem(ResultItem):
         return description.replace('%s', '...')
 
     def get_icon(self):
-        icon = self.icon or get_data_file('icons', 'executable.png')
-        return load_image(icon, self.get_icon_size())
+        return load_icon(self.icon, self.get_icon_size())
 
     def selected_by_default(self, query):
         """

--- a/ulauncher/modes/shortcuts/ShortcutResultItem.py
+++ b/ulauncher/modes/shortcuts/ShortcutResultItem.py
@@ -5,7 +5,6 @@ from ulauncher.api.shared.action.OpenUrlAction import OpenUrlAction
 from ulauncher.api.shared.action.RunScriptAction import RunScriptAction
 from ulauncher.api.shared.action.SetUserQueryAction import SetUserQueryAction
 from ulauncher.api.shared.item.ResultItem import ResultItem
-from ulauncher.utils.icon import load_icon
 from ulauncher.modes.QueryHistoryDb import QueryHistoryDb
 
 
@@ -54,7 +53,7 @@ class ShortcutResultItem(ResultItem):
         return description.replace('%s', '...')
 
     def get_icon(self):
-        return load_icon(self.icon, self.get_icon_size())
+        return self.icon
 
     def selected_by_default(self, query):
         """

--- a/ulauncher/ui/ResultItemWidget.py
+++ b/ulauncher/ui/ResultItemWidget.py
@@ -6,8 +6,9 @@ gi.require_version('Gdk', '3.0')
 # pylint: disable=wrong-import-position
 from gi.repository import Gtk, Gdk
 
-from ulauncher.utils.Theme import Theme
 from ulauncher.utils.display import get_monitor_scale_factor
+from ulauncher.utils.icon import load_icon
+from ulauncher.utils.Theme import Theme
 from ulauncher.modes.Query import Query
 
 logger = logging.getLogger(__name__)
@@ -35,7 +36,7 @@ class ResultItemWidget(Gtk.EventBox):
         self.query = query
         self.set_index(index)
 
-        self.set_icon(item_object.get_icon())
+        self.set_icon(load_icon(item_object.get_icon(), item_object.get_icon_size()))
         self.set_description(item_object.get_description(query))
         self.set_name_highlighted()
 

--- a/ulauncher/ui/windows/UlauncherWindow.py
+++ b/ulauncher/ui/windows/UlauncherWindow.py
@@ -28,7 +28,7 @@ from ulauncher.utils.Settings import Settings
 from ulauncher.utils.decorator.singleton import singleton
 from ulauncher.utils.timer import timer
 from ulauncher.utils.display import get_current_screen_geometry, get_primary_screen_geometry, get_monitor_scale_factor
-from ulauncher.utils.image_loader import load_image
+from ulauncher.utils.icon import load_icon
 from ulauncher.utils.desktop.notification import show_notification
 from ulauncher.utils.wayland import is_wayland_compatibility_on
 from ulauncher.utils.Theme import Theme, load_available_themes
@@ -369,7 +369,7 @@ class UlauncherWindow(Gtk.Window, WindowHelper):
 
     def _render_prefs_icon(self):
         scale_factor = get_monitor_scale_factor()
-        prefs_pixbuf = load_image(get_data_file('icons', 'gear.svg'), 16 * scale_factor)
+        prefs_pixbuf = load_icon(get_data_file('icons', 'gear.svg'), 16 * scale_factor)
         surface = Gdk.cairo_surface_create_from_pixbuf(prefs_pixbuf, scale_factor, self.get_window())
         prefs_image = Gtk.Image.new_from_surface(surface)
         self.prefs_btn.set_image(prefs_image)

--- a/ulauncher/utils/icon.py
+++ b/ulauncher/utils/icon.py
@@ -1,33 +1,15 @@
-import os
 import logging
-import mimetypes
 from functools import lru_cache
 
 import gi
-gi.require_version('GLib', '2.0')
 gi.require_version('Gtk', '3.0')
-gi.require_version('Gio', '2.0')
 gi.require_version('GdkPixbuf', '2.0')
-
 # pylint: disable=wrong-import-position
-from gi.repository import Gtk, GLib, GdkPixbuf
+from gi.repository import Gtk, GdkPixbuf
 from ulauncher.config import get_data_file
-
 
 icon_theme = Gtk.IconTheme.get_default()
 logger = logging.getLogger(__name__)
-
-SPECIAL_DIRS = {
-    GLib.get_user_special_dir(GLib.UserDirectory.DIRECTORY_DOWNLOAD): 'folder-download',
-    GLib.get_user_special_dir(GLib.UserDirectory.DIRECTORY_DOCUMENTS): 'folder-documents',
-    GLib.get_user_special_dir(GLib.UserDirectory.DIRECTORY_MUSIC): 'folder-music',
-    GLib.get_user_special_dir(GLib.UserDirectory.DIRECTORY_PICTURES): 'folder-pictures',
-    GLib.get_user_special_dir(GLib.UserDirectory.DIRECTORY_PUBLIC_SHARE): 'folder-publicshare',
-    GLib.get_user_special_dir(GLib.UserDirectory.DIRECTORY_TEMPLATES): 'folder-templates',
-    GLib.get_user_special_dir(GLib.UserDirectory.DIRECTORY_VIDEOS): 'folder-videos',
-    GLib.get_user_special_dir(GLib.UserDirectory.DIRECTORY_DESKTOP): 'user-desktop',
-    os.path.expanduser('~'): 'folder-home'
-}
 
 
 @lru_cache(maxsize=50)
@@ -44,32 +26,3 @@ def load_icon(icon, size):
     except Exception as e:
         logger.info('Could not load icon %s. E: %s', icon, e)
         return load_icon(get_data_file('icons', 'executable.png'), size)
-
-
-def _get_themed_icon_by_name(icon_name, icon_size):
-    return icon_theme.load_icon(icon_name, icon_size, Gtk.IconLookupFlags.FORCE_SIZE)
-
-
-def get_file_icon(path, icon_size):
-    """
-    :param ~ulauncher.utils.Path.Path path:
-    :param int icon_size:
-    """
-    # pylint: disable=broad-except
-    try:
-        if path.is_dir():
-            special_dir = SPECIAL_DIRS.get(str(path))
-            if special_dir:
-                return _get_themed_icon_by_name(special_dir, icon_size)
-            return _get_themed_icon_by_name('folder', icon_size)
-
-        mime = mimetypes.guess_type(path.get_basename())[0]
-        if mime:
-            return _get_themed_icon_by_name(mime.replace('/', '-'), icon_size)
-
-        if path.is_exe():
-            return _get_themed_icon_by_name("application-x-executable", icon_size)
-    except Exception as e:
-        logger.warning('Icon not found %s. %s: %s', path, type(e).__name__, e)
-
-    return _get_themed_icon_by_name("unknown", icon_size)

--- a/ulauncher/utils/icon.py
+++ b/ulauncher/utils/icon.py
@@ -10,7 +10,7 @@ gi.require_version('Gio', '2.0')
 gi.require_version('GdkPixbuf', '2.0')
 
 # pylint: disable=wrong-import-position
-from gi.repository import Gtk, Gio, GLib, GdkPixbuf
+from gi.repository import Gtk, GLib, GdkPixbuf
 from ulauncher.config import get_data_file
 
 
@@ -31,53 +31,22 @@ SPECIAL_DIRS = {
 
 
 @lru_cache(maxsize=50)
-def load_image(path, size):
+def load_icon(icon, size):
     """
-    :param str path:
+    :param str icon:
     :param int size:
-
-    :rtype: :class:`GtkPixbuf` or :code:`None`
-    :returns: None if :func:`new_from_file_at_size` raises error
-    """
-    path = os.path.expanduser(path)
-    # pylint: disable=broad-except
-    try:
-        return GdkPixbuf.Pixbuf.new_from_file_at_size(path, size, size)
-    except Exception as e:
-        logger.warning('Could not load image %s. E: %s', path, e)
-
-
-def get_app_icon_pixbuf(icon, icon_size):
-    """
-    :param Gio.Icon icon:
-    :param int icon_size:
     :rtype: :class:`GtkPixbuf`
     """
-    pixbuf_icon = None
-    # pylint: disable=broad-except
-
-    if isinstance(icon, Gio.ThemedIcon):
-        try:
-            icon_name = icon.get_names()[0]
-            if not icon_name:
-                return None
-            pixbuf_icon = get_themed_icon_by_name(icon_name, icon_size)
-        except Exception as e:
-            logger.info('Could not load icon for %s. E: %s', icon_name, e)
-
-    elif isinstance(icon, Gio.FileIcon):
-        pixbuf_icon = load_image(icon.get_file().get_path(), icon_size)
-
-    elif isinstance(icon, str):
-        pixbuf_icon = load_image(icon, icon_size)
-
-    if not pixbuf_icon:
-        pixbuf_icon = load_image(get_data_file('icons', 'executable.png'), icon_size)
-
-    return pixbuf_icon
+    try:
+        if icon.startswith("/"):
+            return GdkPixbuf.Pixbuf.new_from_file_at_size(icon, size, size)
+        return icon_theme.load_icon(icon, size, Gtk.IconLookupFlags.FORCE_SIZE)
+    except Exception as e:
+        logger.info('Could not load icon %s. E: %s', icon, e)
+        return load_icon(get_data_file('icons', 'executable.png'), size)
 
 
-def get_themed_icon_by_name(icon_name, icon_size):
+def _get_themed_icon_by_name(icon_name, icon_size):
     return icon_theme.load_icon(icon_name, icon_size, Gtk.IconLookupFlags.FORCE_SIZE)
 
 
@@ -91,16 +60,16 @@ def get_file_icon(path, icon_size):
         if path.is_dir():
             special_dir = SPECIAL_DIRS.get(str(path))
             if special_dir:
-                return get_themed_icon_by_name(special_dir, icon_size)
-            return get_themed_icon_by_name('folder', icon_size)
+                return _get_themed_icon_by_name(special_dir, icon_size)
+            return _get_themed_icon_by_name('folder', icon_size)
 
         mime = mimetypes.guess_type(path.get_basename())[0]
         if mime:
-            return get_themed_icon_by_name(mime.replace('/', '-'), icon_size)
+            return _get_themed_icon_by_name(mime.replace('/', '-'), icon_size)
 
         if path.is_exe():
-            return get_themed_icon_by_name("application-x-executable", icon_size)
+            return _get_themed_icon_by_name("application-x-executable", icon_size)
     except Exception as e:
         logger.warning('Icon not found %s. %s: %s', path, type(e).__name__, e)
 
-    return get_themed_icon_by_name("unknown", icon_size)
+    return _get_themed_icon_by_name("unknown", icon_size)


### PR DESCRIPTION
There's a crazy amount of different icon loader methods that does almost the same thing: `load_image()`, `get_themed_icon_by_name()`, `get_app_icon_pixbuf()` and to some extent `get_file_icon()`.

* This PR merges them into one simple method that takes either a path or a themed icon name and returns a pixbuf (this means it implements #803).
* `get_file_icon()` is moved into the `FileBrowserResultItem` class (the only place that uses it).
* And the code to load the icon was moved to ResultItemWidget instead of duplicating it for all the ResultItem implementations.

### Checklist
- [x] Verify that the test command `./ul test` is passing (the CI server will check this if you don't)
- [x] Update the documentation according to your changes (when applicable)
- [ ] Write unit tests for your changes (when applicable)
