### PR TITLE
Support list as a shortcut/alias to RenderResultListAction

### DIFF
--- a/docs/diagram-source.txt
+++ b/docs/diagram-source.txt
@@ -7,7 +7,7 @@ note over Ulauncher: extracts keyword\nand checks if any extension\ncan handle i
 Ulauncher->Extension: sends KeywordQueryEvent
 note over Extension: on_event method of \nKeywordQueryEventListener\nis triggered
 note over Extension: handles event by preparing\na list of result items
-Extension->Ulauncher: returns RenderResultListAction in on_event
+Extension->Ulauncher: returns a list of ExtensionResultItems in on_event
 note over Ulauncher: runs the action
 Ulauncher->User: render a list of items\nsent by the extension
 User->Ulauncher: selects an item

--- a/docs/extensions/tutorial.rst
+++ b/docs/extensions/tutorial.rst
@@ -171,7 +171,6 @@ Copy the following code to ``main.py``::
   from ulauncher.api.client.EventListener import EventListener
   from ulauncher.api.shared.event import KeywordQueryEvent, ItemEnterEvent
   from ulauncher.api.shared.item.ExtensionResultItem import ExtensionResultItem
-  from ulauncher.api.shared.action.RenderResultListAction import RenderResultListAction
   from ulauncher.api.shared.action.HideWindowAction import HideWindowAction
 
 
@@ -192,7 +191,7 @@ Copy the following code to ``main.py``::
                                                description='Item description %s' % i,
                                                on_enter=HideWindowAction()))
 
-          return RenderResultListAction(items)
+          return items
 
   if __name__ == '__main__':
       DemoExtension().run()
@@ -259,8 +258,7 @@ Basic API Concepts
 
 **3. Render results**
 
-  Return :class:`~ulauncher.api.shared.action.RenderResultListAction.RenderResultListAction` in order to render results.
-  :class:`~ulauncher.api.shared.item.ExtensionResultItem.ExtensionResultItem` describes a single result item.
+  Return a list of :class:`~ulauncher.api.shared.item.ExtensionResultItem.ExtensionResultItem` in order to render results.
 
   You can also use :class:`~ulauncher.api.shared.item.ExtensionSmallResultItem.ExtensionSmallResultItem` if you want
   to render more items. You won't have item description with this type.
@@ -276,7 +274,7 @@ Basic API Concepts
                                                  description='Item description %s' % i,
                                                  on_enter=HideWindowAction()))
 
-            return RenderResultListAction(items)
+            return items
 
 
   :code:`on_enter` is an action that will be ran when item is entered/clicked.
@@ -333,9 +331,9 @@ Custom Action on Item Enter
             # do additional actions here...
 
             # you may want to return another list of results
-            return RenderResultListAction([ExtensionResultItem(icon='images/icon.png',
-                                                               name=data['new_name'],
-                                                               on_enter=HideWindowAction())])
+            return [ExtensionResultItem(icon='images/icon.png',
+                                        name=data['new_name'],
+                                        on_enter=HideWindowAction())]
 
 **3. Subscribe to ItemEnterEvent**
 

--- a/tests/modes/calc/test_CalcMode.py
+++ b/tests/modes/calc/test_CalcMode.py
@@ -6,14 +6,6 @@ from ulauncher.modes.calc.CalcMode import CalcMode, eval_expr
 class TestCalcMode:
 
     @pytest.fixture
-    def RenderResultListAction(self, mocker):
-        return mocker.patch('ulauncher.modes.calc.CalcMode.RenderResultListAction')
-
-    @pytest.fixture
-    def CalcResultItem(self, mocker):
-        return mocker.patch('ulauncher.modes.calc.CalcMode.CalcResultItem')
-
-    @pytest.fixture
     def mode(self):
         return CalcMode()
 
@@ -39,17 +31,12 @@ class TestCalcMode:
         assert eval_expr('12 / 1,5') == eval_expr('12 / 1.5') == Decimal('8')
         assert eval_expr('3 ** 2') == eval_expr('3^2') == Decimal('9')
 
-    def test_handle_query(self, mode, RenderResultListAction, CalcResultItem):
-        assert mode.handle_query('3+2') == RenderResultListAction.return_value
-        assert mode.handle_query('3+2*') == RenderResultListAction.return_value
-        RenderResultListAction.assert_called_with([CalcResultItem.return_value])
-        CalcResultItem.assert_called_with(result=5)
+    def test_handle_query(self, mode):
+        assert mode.handle_query('3+2')[0].result == 5
+        assert mode.handle_query('3+2*')[0].result == 5
+        assert mode.handle_query('2-2')[0].result == 0
 
-    def test_handle_query__invalid_expr(self, mode, RenderResultListAction, CalcResultItem):
-        assert mode.handle_query('3++') == RenderResultListAction.return_value
-        RenderResultListAction.assert_called_with([CalcResultItem.return_value])
-        CalcResultItem.assert_called_with(error='Invalid expression')
-
-    def test_handle_query__result_is_0__returns_0(self, mode, CalcResultItem):
-        mode.handle_query('2-2')
-        CalcResultItem.assert_called_with(result=0)
+    def test_handle_query__invalid_expr(self, mode):
+        [invalid_result] = mode.handle_query('3++')
+        assert invalid_result.get_name() == 'Error!'
+        assert invalid_result.error == 'Invalid expression'

--- a/tests/modes/file_browser/test_FileBrowserResultItem.py
+++ b/tests/modes/file_browser/test_FileBrowserResultItem.py
@@ -38,10 +38,6 @@ class TestFileBrowserResultItem:
         return mocker.patch('ulauncher.modes.file_browser.FileBrowserResultItem.OpenAction')
 
     @pytest.fixture(autouse=True)
-    def RenderAction(self, mocker):
-        return mocker.patch('ulauncher.modes.file_browser.FileBrowserResultItem.RenderResultListAction')
-
-    @pytest.fixture(autouse=True)
     def CopyPathToClipboardItem(self, mocker):
         return mocker.patch('ulauncher.modes.file_browser.FileBrowserResultItem.CopyPathToClipboardItem')
 
@@ -66,14 +62,12 @@ class TestFileBrowserResultItem:
         path.is_dir.return_value = False
         assert result_item.on_enter('query') == OpenAction.return_value
 
-    def test_on_alt_enter_dir(self, result_item, RenderAction, OpenFolderItem, CopyPathToClipboardItem):
-        assert result_item.on_alt_enter('query') == RenderAction.return_value
-        RenderAction.assert_called_with([OpenFolderItem.return_value, CopyPathToClipboardItem.return_value])
+    def test_on_alt_enter_dir(self, result_item, OpenFolderItem, CopyPathToClipboardItem):
+        assert result_item.on_alt_enter('query') == [OpenFolderItem.return_value, CopyPathToClipboardItem.return_value]
 
     # pylint: disable=too-many-arguments, redefined-outer-name
-    def test_on_alt_enter_file(self, result_item, path, OpenFolderItem, Path, RenderAction, CopyPathToClipboardItem):
+    def test_on_alt_enter_file(self, result_item, path, OpenFolderItem, Path, CopyPathToClipboardItem):
         path.is_dir.return_value = False
-        assert result_item.on_alt_enter('query') == RenderAction.return_value
+        assert result_item.on_alt_enter('query') == [OpenFolderItem.return_value, CopyPathToClipboardItem.return_value]
         Path.assert_called_with(path.get_dirname.return_value)
         OpenFolderItem.assert_called_with(Path.return_value)
-        RenderAction.assert_called_with([OpenFolderItem.return_value, CopyPathToClipboardItem.return_value])

--- a/tests/modes/shortcuts/test_ShortcutMode.py
+++ b/tests/modes/shortcuts/test_ShortcutMode.py
@@ -13,10 +13,6 @@ class TestShortcutMode:
         return mocker.patch('ulauncher.modes.shortcuts.ShortcutMode.ShortcutsDb.get_instance').return_value
 
     @pytest.fixture(autouse=True)
-    def RenderAction(self, mocker):
-        return mocker.patch('ulauncher.modes.shortcuts.ShortcutMode.RenderResultListAction')
-
-    @pytest.fixture(autouse=True)
     def ShortcutResultItem(self, mocker):
         return mocker.patch('ulauncher.modes.shortcuts.ShortcutMode.ShortcutResultItem')
 
@@ -48,12 +44,12 @@ class TestShortcutMode:
 
         assert mode.is_enabled(query)
 
-    def test_handle_query__return_value__is_RenderAction_object(self, mode, shortcuts_db, RenderAction):
+    def test_handle_query__return_value__is(self, mode, shortcuts_db, ShortcutResultItem):
         query = 'kw something'
         shortcut = {'keyword': 'kw'}
         shortcuts_db.get_shortcuts.return_value = [shortcut]
 
-        assert mode.handle_query(query) == RenderAction.return_value
+        assert mode.handle_query(query)[0] == ShortcutResultItem.return_value
 
     def test_handle_query__ShortcutResultItem__is_called(self, mode, shortcuts_db, ShortcutResultItem):
         query = 'kw something'
@@ -63,15 +59,6 @@ class TestShortcutMode:
         mode.handle_query(query)
 
         ShortcutResultItem.assert_called_once_with(keyword='kw')
-
-    def test_handle_query__RenderAction__is_called(self, mode, shortcuts_db, RenderAction, ShortcutResultItem):
-        query = 'kw something'
-        shortcut = {'keyword': 'kw'}
-        shortcuts_db.get_shortcuts.return_value = [shortcut]
-
-        mode.handle_query(query)
-
-        RenderAction.assert_called_once_with([ShortcutResultItem.return_value])
 
     def test_get_default_items__ShortcutResultItems__returned(self, mode, shortcuts_db, ShortcutResultItem):
         shortcut = {'keyword': 'kw', 'is_default_search': True}

--- a/tests/modes/test_Search.py
+++ b/tests/modes/test_Search.py
@@ -5,6 +5,9 @@ from ulauncher.modes.Search import Search
 
 
 class TestSearch:
+    @pytest.fixture(autouse=True)
+    def RenderAction(self, mocker):
+        return mocker.patch('ulauncher.modes.Search.RenderResultListAction')
 
     @pytest.fixture
     def search_mode(self):
@@ -14,11 +17,11 @@ class TestSearch:
     def search(self, search_mode):
         return Search([search_mode])
 
-    def test_on_query_change__run__is_called(self, search, search_mode):
+    def test_on_query_change__run__is_called(self, search, search_mode, RenderAction):
         search_mode.is_enabled.return_value = True
         search.on_query_change('test')
 
-        search_mode.handle_query.return_value.run.assert_called_once_with()
+        RenderAction.assert_called_once_with(search_mode.handle_query.return_value)
 
     def test_on_query_change__on_query_change__is_called_on_search_mode(self, search, search_mode):
         search_mode.is_enabled.return_value = True

--- a/ulauncher/api/client/Extension.py
+++ b/ulauncher/api/client/Extension.py
@@ -3,6 +3,7 @@ from collections import defaultdict
 
 from ulauncher.api.shared.Response import Response
 from ulauncher.api.shared.action.BaseAction import BaseAction
+from ulauncher.api.shared.action.RenderResultListAction import RenderResultListAction
 from ulauncher.api.shared.event import PreferencesEvent, PreferencesUpdateEvent
 from ulauncher.api.client.EventListener import EventListener
 from ulauncher.api.client.Client import Client
@@ -51,8 +52,10 @@ class Extension:
 
         for listener in listeners:
             action = listener.on_event(event, self)
+            if isinstance(action, list):
+                action = RenderResultListAction(action)
             if action:
-                assert isinstance(action, BaseAction), "on_event return value is not an instance of BaseAction"
+                assert isinstance(action, BaseAction), "on_event must return list of ResultItems or a BaseAction"
                 self._client.send(Response(event, action))
 
     def run(self):

--- a/ulauncher/modes/BaseMode.py
+++ b/ulauncher/modes/BaseMode.py
@@ -26,9 +26,9 @@ class BaseMode:
 
     def handle_query(self, query):
         """
-        :rtype: :class:`BaseAction`
+        :rtype: list of ResultItems
         """
-        return DoNothingAction()
+        return []
 
     def get_default_items(self):
         """

--- a/ulauncher/modes/Search.py
+++ b/ulauncher/modes/Search.py
@@ -1,5 +1,6 @@
 import logging
 
+from ulauncher.api.shared.action.RenderResultListAction import RenderResultListAction
 from ulauncher.modes.extensions.ExtensionMode import ExtensionMode
 from ulauncher.modes.apps.AppMode import AppMode
 from ulauncher.modes.shortcuts.ShortcutMode import ShortcutMode
@@ -37,7 +38,8 @@ class Search:
         for mode in self.search_modes:
             mode.on_query_change(query)
 
-        self._choose_search_mode(query).handle_query(query).run()
+        mode = self._choose_search_mode(query)
+        RenderResultListAction(mode.handle_query(query)).run()
 
     def on_key_press_event(self, widget, event, query):
         self._choose_search_mode(query).handle_key_press_event(widget, event, query).run()

--- a/ulauncher/modes/apps/AppMode.py
+++ b/ulauncher/modes/apps/AppMode.py
@@ -1,4 +1,3 @@
-from ulauncher.api.shared.action.RenderResultListAction import RenderResultListAction
 from ulauncher.modes.BaseMode import BaseMode
 from ulauncher.modes.apps.AppResultItem import AppResultItem
 
@@ -23,4 +22,4 @@ class AppMode(BaseMode):
         if not items:
             for mode in self.search_modes:
                 items.extend(mode.get_default_items())
-        return RenderResultListAction(items)
+        return items

--- a/ulauncher/modes/calc/CalcMode.py
+++ b/ulauncher/modes/calc/CalcMode.py
@@ -3,7 +3,6 @@ import ast
 from decimal import Decimal
 import operator as op
 
-from ulauncher.api.shared.action.RenderResultListAction import RenderResultListAction
 from ulauncher.modes.BaseMode import BaseMode
 from ulauncher.modes.calc.CalcResultItem import CalcResultItem
 
@@ -66,4 +65,4 @@ class CalcMode(BaseMode):
         # pylint: disable=broad-except
         except Exception:
             result_item = CalcResultItem(error='Invalid expression')
-        return RenderResultListAction([result_item])
+        return [result_item]

--- a/ulauncher/modes/file_browser/FileBrowserMode.py
+++ b/ulauncher/modes/file_browser/FileBrowserMode.py
@@ -5,9 +5,7 @@ gi.require_version('Gdk', '3.0')
 # pylint: disable=wrong-import-position
 from gi.repository import Gdk
 from ulauncher.utils.fuzzy_search import get_score
-from ulauncher.api.shared.action.BaseAction import BaseAction
 from ulauncher.api.shared.action.DoNothingAction import DoNothingAction
-from ulauncher.api.shared.action.RenderResultListAction import RenderResultListAction
 from ulauncher.api.shared.action.SetUserQueryAction import SetUserQueryAction
 from ulauncher.utils.Path import Path, InvalidPathError
 from ulauncher.modes.BaseMode import BaseMode
@@ -50,7 +48,7 @@ class FileBrowserMode(BaseMode):
     def filter_dot_files(self, file_list: List[str]) -> List[str]:
         return list(filter(lambda f: not f.startswith('.'), file_list))
 
-    def handle_query(self, query: str) -> BaseAction:
+    def handle_query(self, query: str) -> List[FileBrowserResultItem]:
         path = Path(query)  # type: Path
         result_items = []  # type: List[FileBrowserResultItem]
 
@@ -77,7 +75,7 @@ class FileBrowserMode(BaseMode):
         except (InvalidPathError, OSError):
             result_items = []
 
-        return RenderResultListAction(result_items)
+        return result_items
 
     def handle_key_press_event(self, widget, event, query):
         keyval = event.get_keyval()

--- a/ulauncher/modes/file_browser/FileBrowserResultItem.py
+++ b/ulauncher/modes/file_browser/FileBrowserResultItem.py
@@ -6,7 +6,6 @@ gi.require_version('GLib', '2.0')
 from gi.repository import GLib
 
 from ulauncher.api.shared.action.OpenAction import OpenAction
-from ulauncher.api.shared.action.RenderResultListAction import RenderResultListAction
 from ulauncher.api.shared.action.SetUserQueryAction import SetUserQueryAction
 from ulauncher.api.shared.item.SmallResultItem import SmallResultItem
 from ulauncher.utils.Path import Path
@@ -70,7 +69,7 @@ class FileBrowserResultItem(SmallResultItem):
 
     def on_alt_enter(self, query):
         menu_items = self._get_dir_alt_menu() if self.path.is_dir() else self._get_file_alt_menu()
-        return RenderResultListAction(menu_items)
+        return menu_items
 
     def _get_dir_alt_menu(self):
         """

--- a/ulauncher/modes/shortcuts/ShortcutMode.py
+++ b/ulauncher/modes/shortcuts/ShortcutMode.py
@@ -1,4 +1,3 @@
-from ulauncher.api.shared.action.RenderResultListAction import RenderResultListAction
 from ulauncher.modes.BaseMode import BaseMode
 from ulauncher.modes.shortcuts.ShortcutsDb import ShortcutsDb
 from ulauncher.modes.shortcuts.ShortcutResultItem import ShortcutResultItem
@@ -35,7 +34,7 @@ class ShortcutMode(BaseMode):
         if not shortcut:
             raise Exception('No active shortcut. This line should not be entered')
 
-        return RenderResultListAction([ShortcutResultItem(**shortcut)])
+        return [ShortcutResultItem(**shortcut)]
 
     def get_default_items(self):
         return self._create_items([s for s in self.shortcutsDb.get_shortcuts() if s['is_default_search']],

--- a/ulauncher/ui/ItemNavigation.py
+++ b/ulauncher/ui/ItemNavigation.py
@@ -1,3 +1,6 @@
+from ulauncher.api.shared.action.RenderResultListAction import RenderResultListAction
+
+
 class ItemNavigation:
     """
     Performs navigation through found results
@@ -58,6 +61,8 @@ class ItemNavigation:
             action = item.on_enter(query) if not alt else item.on_alt_enter(query)
             if not action:
                 return True
+            if isinstance(action, list):
+                action = RenderResultListAction(action)
             action.run()
             return action.keep_app_open()
 


### PR DESCRIPTION
Instead of this

```py
from ulauncher.api.shared.action.RenderResultListAction import RenderResultListAction
```
...and returning `RenderResultListAction(list_of_items)`, you can now just return `list_of_items`.

This applies to all places RenderResultListAction was previously used, including the modes `handle_query` method, the extension query listener and and the extensions `on_enter` and `on_alt_enter` method.

For the extension methods this change is backward compatible, but as step two to this (in a future major release) we should remove `RenderResultListAction` completely as an action and only support returning lists. Primarily because this API imports a lot of internals and it's problematic to expose it as part of the API #920 #285, and it's also better to restrict the extension query listener to _only_ accept this instead of any action, so that users get a more consistent and reliable experience (not something opening or the Ulauncher window hiding when they're typing the query) and extension developers get better guidelines to provide this. #864

### Checklist
- [x] Verify that the test command `./ul test` is passing (the CI server will check this if you don't)
- [x] Update the documentation according to your changes (when applicable)
- [x] Write unit tests for your changes (when applicable)
