### PR TITLE
Remove tilde autocompletion in file browser mode

### DIFF
--- a/tests/modes/file_browser/test_FileBrowserMode.py
+++ b/tests/modes/file_browser/test_FileBrowserMode.py
@@ -59,9 +59,6 @@ class TestFileBrowserMode:
     def test_filter_dot_files(self, mode):
         assert mode.filter_dot_files(['a', '.b', 'c', '.d']) == ['a', 'c']
 
-    def test_handle_query__query_is_tilde__tilde_slash_is_set_for_query(self, mode, SetUserQueryAction):
-        assert mode.handle_query('~') == SetUserQueryAction.return_value
-
     def test_handle_qury__path_from_q_exists__dir_listing_rendered(self, mode, path, mocker, RenderAction):
         path.get_existing_dir.return_value = '/tmp/dir'
         path.get_abs_path.return_value = path.get_existing_dir.return_value

--- a/ulauncher/modes/file_browser/FileBrowserMode.py
+++ b/ulauncher/modes/file_browser/FileBrowserMode.py
@@ -51,9 +51,6 @@ class FileBrowserMode(BaseMode):
         return list(filter(lambda f: not f.startswith('.'), file_list))
 
     def handle_query(self, query: str) -> BaseAction:
-        if query == '~':
-            return SetUserQueryAction('~/')
-
         path = Path(query)  # type: Path
         result_items = []  # type: List[FileBrowserResultItem]
 


### PR DESCRIPTION
`~` (tilde) is a "dead key".

If a user types `~u` it becomes `ũ`, but it can also become two characters if the key pressed after `~` isn't a character that doesn't come with this diacritic variation. The user has to type the next character after `~` in order for us to even see that they pressed tilde.

This stands in conflict with our code for the file browser mode where we autocomplete `~` into `~/`, except if the user starts typing we will only see the query changing from an empty string into to `~/`. That is unless the user does something strange like pasting `~` from elsewhere, or escaping it by typing space after tilde.

For something intended to simplify for users it shouldn't be so hard to trigger. It's better not to have this autocompletion at all, especially as it is also questionable to change the user input with this event (it's better for the user experience and consistency that this is something neither the Ulauncher app or extensions can change, see #864).

### Checklist
- [x] Verify that the test command `./ul test` is passing (the CI server will check this if you don't)
- [ ] Update the documentation according to your changes (when applicable)
- [ ] Write unit tests for your changes (when applicable)
