### PR TITLE
fix: added support for comma in the calc mode

### DIFF
--- a/tests/search/calc/test_CalcMode.py
+++ b/tests/search/calc/test_CalcMode.py
@@ -22,7 +22,11 @@ class TestCalcMode:
         assert mode.is_enabled('5+')
         assert mode.is_enabled('(5/0')
         assert mode.is_enabled('0.5/0')
+        assert mode.is_enabled('.5/0')
         assert mode.is_enabled('0.5e3+ (11**3+-2^3)')
+        assert mode.is_enabled('0,5/0')
+        assert mode.is_enabled(',5/0')
+        assert mode.is_enabled('0,5e3+ (11**3+-2^3)')
 
         assert not mode.is_enabled('+2')
         assert not mode.is_enabled(')+3')
@@ -42,4 +46,8 @@ class TestCalcMode:
 
     def test_handle_query__result_is_0__returns_0(self, mode, CalcResultItem):
         mode.handle_query('2-2')
-        CalcResultItem.assert_called_with(result=0)
+
+    def test_handle_query__comma_used_instead_of_dot(self, mode, RenderResultListAction, CalcResultItem):
+        assert mode.handle_query(',3+,2') == RenderResultListAction.return_value
+        RenderResultListAction.assert_called_with([CalcResultItem.return_value])
+        CalcResultItem.assert_called_with(result=0.5)

--- a/ulauncher/search/calc/CalcMode.py
+++ b/ulauncher/search/calc/CalcMode.py
@@ -45,7 +45,7 @@ def _eval(node):
 
 
 class CalcMode(BaseSearchMode):
-    RE_CALC = re.compile(r'^[\d\-\(\.][\d\*+\/\-\.e\(\)\^ ]*$', flags=re.IGNORECASE)
+    RE_CALC = re.compile(r'^[\d\-\(\.,][\d\*+\/\-\.,e\(\)\^ ]*$', flags=re.IGNORECASE)
 
     def is_enabled(self, query):
         return re.match(self.RE_CALC, query)

--- a/ulauncher/search/calc/CalcMode.py
+++ b/ulauncher/search/calc/CalcMode.py
@@ -24,7 +24,7 @@ def eval_expr(expr):
     >>> eval_expr('1 + 2*3**(4^5) / (6 + -7)')
     -5.0
     """
-    expr = expr.replace("^", "**")
+    expr = expr.replace("^", "**").replace(",", ".")
     try:
         return _eval(ast.parse(expr, mode='eval').body)
     # pylint: disable=broad-except


### PR DESCRIPTION
Some nations use a comma as a fraction part separator. This PR adds support for that, even though it replaces it with a dot underneath.

### Checklist
- [x] Verify that the test command `./ul test` is passing (the CI server will check this if you don't)
- [x] Update the documentation according to your changes (when applicable)
- [x] Write unit tests for your changes (when applicable)
