### PR TITLE
Fix AppResult exception for AppInfo which don't have a defined execut…

### DIFF
--- a/ulauncher/modes/apps/AppResult.py
+++ b/ulauncher/modes/apps/AppResult.py
@@ -26,9 +26,9 @@ class AppResult(Result):
         # get_executable uses Exec, which is always specified, but it will return the actual executable.
         # Sometimes the actual executable is not the app to start, but a wrappers like "env" or "sh -c"
         self._executable = basename(
-            app_info.get_string('TryExec')
-            or app_info.get_executable()
-            or ""
+            app_info.get_string('TryExec') or
+            app_info.get_executable() or
+            ""
         )
         self._app_info = app_info
         self._query_history = QueryHistoryDb.get_instance()

--- a/ulauncher/modes/apps/AppResult.py
+++ b/ulauncher/modes/apps/AppResult.py
@@ -25,7 +25,11 @@ class AppResult(Result):
         # TryExec is what we actually want (name of/path to exec), but it's often not specified
         # get_executable uses Exec, which is always specified, but it will return the actual executable.
         # Sometimes the actual executable is not the app to start, but a wrappers like "env" or "sh -c"
-        self._executable = basename(app_info.get_string('TryExec') or app_info.get_executable())
+        self._executable = basename(
+            app_info.get_string('TryExec')
+            or app_info.get_executable()
+            or ""
+        )
         self._app_info = app_info
         self._query_history = QueryHistoryDb.get_instance()
 


### PR DESCRIPTION
I updated to the latest v6 and was unable to get in results. It turns out that the QEMU desktop file I had did not define an executable. The resulted in passing `None` into `os.path.basename` which :boom:. There is already checks later for an empty executable, so all this needed was to replace `None` with `""` when there is no executable. 

### Checklist
- [x] Verify that the test command `./ul test` is passing (the CI server will check this if you don't)
- [-] Update the documentation according to your changes (when applicable)
- [-] Write unit tests for your changes (when applicable)
