### PR TITLE
Automatic event binding

### DIFF
--- a/docs/diagram-source.txt
+++ b/docs/diagram-source.txt
@@ -5,9 +5,9 @@ participant Extension
 User->Ulauncher: types in query
 note over Ulauncher: extracts keyword\nand checks if any extension\ncan handle it
 Ulauncher->Extension: sends KeywordQueryEvent
-note over Extension: on_event method of \nKeywordQueryEventListener\nis triggered
+note over Extension: on_query_change method is triggered
 note over Extension: handles event by preparing\na list of result items
-Extension->Ulauncher: returns a list of ExtensionResults in on_event
+Extension->Ulauncher: returns a list of ExtensionResults in on_query_change
 note over Ulauncher: runs the action
 Ulauncher->User: render a list of items\nsent by the extension
 User->Ulauncher: selects an item

--- a/ulauncher/api/extension.py
+++ b/ulauncher/api/extension.py
@@ -1,10 +1,12 @@
 import logging
 from collections import defaultdict
+from inspect import signature
 
 from ulauncher.api.shared.Response import Response
 from ulauncher.api.shared.action.BaseAction import BaseAction
 from ulauncher.api.shared.action.RenderResultListAction import RenderResultListAction
-from ulauncher.api.shared.event import PreferencesEvent, PreferencesUpdateEvent
+from ulauncher.api.shared.event import KeywordQueryEvent, ItemEnterEvent, SystemExitEvent, \
+    PreferencesEvent, PreferencesUpdateEvent
 from ulauncher.api.client.EventListener import EventListener
 from ulauncher.api.client.Client import Client
 from ulauncher.api.client.setup_logging import setup_logging, get_extension_name
@@ -22,8 +24,19 @@ class Extension:
         self.preferences = {}
         self.logger = logging.getLogger(__name__)
         setup_logging()
+        # subscribe with methods if user has added their own
+        if self.__class__.on_query_change is not Extension.on_query_change:
+            self.subscribe(KeywordQueryEvent, self, 'on_query_change')
+        if self.__class__.on_item_enter is not Extension.on_item_enter:
+            self.subscribe(ItemEnterEvent, self, 'on_item_enter')
+        if self.__class__.on_system_exit is not Extension.on_system_exit:
+            self.subscribe(SystemExitEvent, self, 'on_system_exit')
+        if self.__class__.on_preferences is not Extension.on_preferences:
+            self.subscribe(PreferencesEvent, self, 'on_preferences')
+        if self.__class__.on_preferences_update is not Extension.on_preferences_update:
+            self.subscribe(PreferencesUpdateEvent, self, 'on_preferences_update')
 
-    def subscribe(self, event_type, event_listener):
+    def subscribe(self, event_type, event_listener, method='on_event'):
         """
         Example:
 
@@ -31,8 +44,9 @@ class Extension:
 
         :param type event_type:
         :param ~ulauncher.api.client.EventListener.EventListener event_listener:
+        :param str method:
         """
-        self._listeners[event_type].append(event_listener)
+        self._listeners[event_type].append((event_listener, method))
 
     def get_listeners_for_event(self, event):
         """
@@ -50,8 +64,12 @@ class Extension:
             self.logger.debug('No listeners for event %s', type(event).__name__)
             return
 
-        for listener in listeners:
-            action = listener.on_event(event, self)
+        for listener, method in listeners:
+            _method = getattr(listener, method)
+            param_count = len(signature(_method).parameters)
+            # method can and likely will be a member on self for new extensions, in which case
+            # it can access self. But for backward compatibility we need to pass self
+            action = _method(event) if param_count == 1 else _method(event, self)
             if isinstance(action, list):
                 action = RenderResultListAction(action)
             if action:
@@ -65,6 +83,21 @@ class Extension:
         self.subscribe(PreferencesEvent, PreferencesEventListener())
         self.subscribe(PreferencesUpdateEvent, PreferencesUpdateEventListener())
         self._client.connect()
+
+    def on_query_change(self, event):
+        pass
+
+    def on_item_enter(self, event):
+        pass
+
+    def on_system_exit(self, event):
+        pass
+
+    def on_preferences(self, event):
+        pass
+
+    def on_preferences_update(self, event):
+        pass
 
 
 # pylint: disable=too-few-public-methods


### PR DESCRIPTION
Adds new blank methods on the `Extension` class so users can extend and override those to bind the events without a ton of boilerplate code.

See https://github.com/friday/ulauncher-encoder/commit/cc382bea970e171b02fa3b3fef41cd9e72180ef1 (this extension/commit works only with the PR applied)

I have some further changes in mind for these like renaming the "preferences" event to "load" event, but wanted this to get merged first.

### Checklist
- [x] Verify that the test command `./ul test` is passing (the CI server will check this if you don't)
- [x] Update the documentation according to your changes (when applicable)
- [ ] Write unit tests for your changes (when applicable)
