### PR TITLE
Formatting the result with locale for calc mode

### DIFF
--- a/ulauncher/modes/calc/CalcResult.py
+++ b/ulauncher/modes/calc/CalcResult.py
@@ -1,3 +1,5 @@
+import locale
+
 from ulauncher.api import Result
 from ulauncher.api.shared.action.CopyToClipboardAction import CopyToClipboardAction
 from ulauncher.api.shared.action.DoNothingAction import DoNothingAction
@@ -12,7 +14,7 @@ class CalcResult(Result):
         self.error = error
 
     def get_name(self) -> str:
-        return str(self.result) if self.result is not None else 'Error!'
+        return locale.format_string('%d', self.result, grouping=True) if self.result is not None else 'Error!'
 
     # pylint: disable=super-init-not-called, arguments-differ
     def get_name_highlighted(self, *args) -> None:

--- a/ulauncher/modes/calc/CalcResult.py
+++ b/ulauncher/modes/calc/CalcResult.py
@@ -14,7 +14,7 @@ class CalcResult(Result):
         self.error = error
 
     def get_name(self) -> str:
-        return locale.format_string('%d', self.result, grouping=True) if self.result is not None else 'Error!'
+        return locale.format_string('%d', int(self.result), grouping=True) if self.result is not None else 'Error!'
 
     # pylint: disable=super-init-not-called, arguments-differ
     def get_name_highlighted(self, *args) -> None:


### PR DESCRIPTION
<!--
Thank you for submitting a PR to Ulauncher!

Please read our contribution instructions if you haven't:
https://github.com/Ulauncher/Ulauncher#code-contribution

Explain the changes in this PR and link to related issue(s) if applicable

NOTE THAT OUR WORK AT THIS TIME IS FOCUSED ON THE v6 branch https://github.com/Ulauncher/Ulauncher/tree/v6
This is where we want contributions. We won't make more v5 releases unless it's critical fixes.
-->

Closes #688 , adds a comma sep for the calc mode result using the locale of the system. Does not add the comma on copy, the copy still gets the raw integer

### Checklist
- [X] Verify that the test command `./ul test` is passing (the CI server will check this if you don't)
- [x] Update the documentation according to your changes (when applicable)
- [x] Write unit tests for your changes (when applicable)
