### PR TITLE
Add pip-run support for extensions

### DIFF
--- a/ulauncher/modes/extensions/ExtensionManifest.py
+++ b/ulauncher/modes/extensions/ExtensionManifest.py
@@ -37,6 +37,7 @@ ManifestJson = TypedDict('ManifestJson', {
     'description': str,
     'developer_name': str,
     'icon': str,
+    'use_pip_run': bool,
     'options': Optional[Options],
     'preferences': List[ManifestPreferenceItem]
 })
@@ -81,6 +82,9 @@ class ExtensionManifest:
 
     def get_developer_name(self) -> str:
         return self.manifest['developer_name']
+
+    def get_use_pip_run(self) -> bool:
+        return self.manifest.get('use_pip_run', False)
 
     def get_preferences(self) -> List[ManifestPreferenceItem]:
         return self.manifest.get('preferences', [])

--- a/ulauncher/modes/extensions/ExtensionRunner.py
+++ b/ulauncher/modes/extensions/ExtensionRunner.py
@@ -85,7 +85,9 @@ class ExtensionRunner:
         manifest.validate()
         manifest.check_compatibility()
 
-        cmd = [sys.executable, os.path.join(self.extensions_dir, extension_id, 'main.py')]
+        cmd = ['pip-run', '--'] if manifest.get_use_pip_run() else [sys.executable]
+        cmd.extend([os.path.join(self.extensions_dir, extension_id, 'main.py')])
+
         env = {}
         env['PYTHONPATH'] = ':'.join(filter(bool, [ULAUNCHER_APP_DIR, os.getenv('PYTHONPATH')]))
 


### PR DESCRIPTION
After discovering ulauncher a couple of days ago, and experimenting with plugins, I've created a small change which would allow extensions to indicate what third-party dependencies they would need using [pip-run](https://github.com/jaraco/pip-run#script-runner).

By adding a `__requires__` definition within `main.py`, a script can indicate which dependencies it needs to be installed. These dependencies are then installed in a transient virtualenv from which the script can run from.

My changes assumes that `pip-run` is available somewhere on the system path, and only attempts to run a script using `pip-run` if indicated in the manifest.

One slight issue is that this adds some overhead (even if the libraries are cached locally), and there is enough of a delay (at least with testing locally) between Ulauncher executing the extension and the extension being ready that you often won't get any options being presented during the first invocation.

I've had to make these changes against the dev branch rather than the v6 branch, as I've been struggling to run the v6 branch locally (I've filed #947 in relation to this).

Anyway, interested in what your thoughts are as a proof-of-concept.