### PR TITLE
Scrollable result list view

### DIFF
--- a/data/ui/UlauncherWindow.ui
+++ b/data/ui/UlauncherWindow.ui
@@ -5,7 +5,6 @@
   <requires lib="ulauncher_window" version="1.0"/>
   <!-- interface-local-resource-path ../media -->
   <object class="UlauncherWindow" id="ulauncher_window">
-    <property name="width-request">604</property>
     <property name="can-focus">False</property>
     <property name="has-focus">True</property>
     <property name="title">Ulauncher - Application Launcher</property>
@@ -84,22 +83,29 @@
           </packing>
         </child>
         <child>
-          <object class="GtkBox" id="result_box">
+          <object class="GtkScrolledWindow" id="result_box_scroll_container">
             <property name="visible">True</property>
-            <property name="can-focus">False</property>
-            <property name="orientation">vertical</property>
+            <property name="can-focus">True</property>
+            <property name="hscrollbar-policy">never</property>
+            <property name="shadow-type">in</property>
+            <property name="max-content-height">500</property>
+            <property name="propagate-natural-height">True</property>
             <child>
-              <placeholder/>
+              <object class="GtkViewport" id="result_box_viewport">
+                <property name="visible">True</property>
+                <property name="can-focus">False</property>
+                <child>
+                  <object class="GtkBox" id="result_box">
+                    <property name="visible">True</property>
+                    <property name="can-focus">False</property>
+                    <property name="orientation">vertical</property>
+                    <style>
+                      <class name="result-box"/>
+                    </style>
+                  </object>
+                </child>
+              </object>
             </child>
-            <child>
-              <placeholder/>
-            </child>
-            <child>
-              <placeholder/>
-            </child>
-            <style>
-              <class name="result-box"/>
-            </style>
           </object>
           <packing>
             <property name="expand">False</property>

--- a/tests/ui/test_ResultWidget.py
+++ b/tests/ui/test_ResultWidget.py
@@ -1,3 +1,4 @@
+from types import SimpleNamespace
 import pytest
 import mock
 from gi.repository import GdkPixbuf
@@ -16,6 +17,10 @@ class TestResultWidget:
     @pytest.fixture(autouse=True)
     def Theme(self, mocker):
         return mocker.patch('ulauncher.ui.ResultWidget.Theme')
+
+    @pytest.fixture(autouse=True)
+    def scroll_to_focus(self, mocker):
+        return mocker.patch('ulauncher.ui.ResultWidget.ResultWidget.scroll_to_focus')
 
     @pytest.fixture
     def result_wgt(self, builder, item_obj):
@@ -99,7 +104,7 @@ class TestResultWidget:
         mock_get_toplevel = mocker.patch.object(result_wgt, 'get_toplevel')
 
         result_wgt.set_index(4)
-        result_wgt.on_mouse_hover(None, None)
+        result_wgt.on_mouse_hover(None, SimpleNamespace(time=1111111111))
         mock_get_toplevel.return_value.select_result.assert_called_with(4, onHover=True)
 
     def test_set_description(self, result_wgt, builder):

--- a/ulauncher/modes/ModeHandler.py
+++ b/ulauncher/modes/ModeHandler.py
@@ -61,7 +61,7 @@ class ModeHandler:
                 return mode
         return None
 
-    def search(self, query, min_score=50, limit=9):
+    def search(self, query, min_score=50, limit=50):
         searchables = []
         for mode in self.modes:
             searchables.extend(list(mode.get_searchable_items()))

--- a/ulauncher/modes/file_browser/FileBrowserMode.py
+++ b/ulauncher/modes/file_browser/FileBrowserMode.py
@@ -14,7 +14,7 @@ from ulauncher.modes.file_browser.FileQueries import FileQueries
 
 
 class FileBrowserMode(BaseMode):
-    LIMIT = 17
+    LIMIT = 50
 
     def __init__(self):
         self._file_queries = FileQueries.get_instance()  # type: FileQueries

--- a/ulauncher/ui/windows/UlauncherWindow.py
+++ b/ulauncher/ui/windows/UlauncherWindow.py
@@ -235,13 +235,12 @@ class UlauncherWindow(Gtk.Window, WindowHelper):
         # destroy command moved into dialog to allow for a help button
 
     def position_window(self):
-        window_width = self.get_size()[0]
         geo = get_monitor_geometry(self.settings.get_property('render-on-screen') != "default-monitor")
-
-        # The topmost pixel of the window should be at 1/5 of the current screen's height
-        # Window should be positioned in the center horizontally
-        # Also, add offset x and y, in order to move window to the current screen
-        self.move(geo.width / 2 - window_width / 2 + geo.x, geo.height / 5 + geo.y)
+        max_height = geo.height - (geo.height * 0.15) - 100  # 100 is roughly the height of the text input
+        window_width = 500 * get_scaling_factor()
+        self.set_property('width-request', window_width)
+        self.ui["result_box_scroll_container"].set_property('max-content-height', max_height)
+        self.move(geo.width * 0.5 - window_width * 0.5 + geo.x, geo.y + geo.height * 0.12)
 
     def show_window(self):
         # works only when the following methods are called in that exact order
@@ -328,6 +327,7 @@ class UlauncherWindow(Gtk.Window, WindowHelper):
         self.results_nav = None
         self.result_box.foreach(lambda w: w.destroy())
 
+        limit = len(self.settings.get_jump_keys()) or 25
         show_recent_apps = self.settings.get_property('show-recent-apps')
         recent_apps_number = int(show_recent_apps) if show_recent_apps.isnumeric() else 0
         if not self.input.get_text() and recent_apps_number > 0:
@@ -337,7 +337,7 @@ class UlauncherWindow(Gtk.Window, WindowHelper):
 
         if results:
             self._results_render_time = time.time()
-            for item in results:
+            for item in results[:limit]:
                 self.result_box.add(item)
             self.results_nav = ItemNavigation(self.result_box.get_children())
             self.results_nav.select_default(self._get_user_query())

--- a/ulauncher/utils/display.py
+++ b/ulauncher/utils/display.py
@@ -25,9 +25,7 @@ def get_monitor_geometry(use_mouse_position=True):
         except Exception as e:
             logger.exception("Unexpected exception: %s", e)
 
-    geo = default_screen.get_monitor_geometry(monitor_nr)
-    logger.debug("Monitor %s - X: %s, Y: %s, W: %s, H: %s", monitor_nr, geo.x, geo.y, geo.width, geo.height)
-    return geo
+    return default_screen.get_monitor_geometry(monitor_nr)
 
 
 def get_scaling_factor() -> int:


### PR DESCRIPTION
This implements #246 and also should improve #561 a bit.

The window height is dynamic but with a max based on the window height now. Previously there was a fixed max height.
To prevent the window from being placed inconsistently or move up and down when you type I had to move it up a bit more.

The maximum amount of items result view will now be either the amount of characters in the jump code setting (default: 36) or 25 if the jump codes have been disabled. This can be changed. I just went with something. This is also applied for extensions results, not just the search results and the file browser results like before. So extension devs no longer should have to deal with this.

The theme css hides the actual scrollbar, but you can scroll with the scroll wheel and you can press up and down arrows and tab to go to the next result, which will scroll.

### Checklist
- [x] Verify that the test command `./ul test` is passing (the CI server will check this if you don't)
- [x] Update the documentation according to your changes (when applicable)
- [x] Write unit tests for your changes (when applicable)
