### PR TITLE
Small v6 bugfixes

### DIFF
--- a/tests/ui/test_ItemNavigation.py
+++ b/tests/ui/test_ItemNavigation.py
@@ -56,11 +56,11 @@ class TestItemNavigation:
     def test_enter_no_index(self, nav, items):
         nav.select(2)
         selected_result = items[2].result
-        assert nav.enter('test') is selected_result.on_enter.return_value.keep_app_open.return_value
+        assert nav.enter('test') is (not selected_result.on_enter.return_value.keep_app_open.return_value)
         selected_result.on_enter.return_value.run.assert_called_with()
 
     def test_enter__alternative(self, nav, items):
         nav.select(2)
         selected_result = items[2].result
-        assert nav.enter('test', alt=True) is selected_result.on_alt_enter.return_value.keep_app_open.return_value
+        assert nav.enter('test', alt=True) is (not selected_result.on_alt_enter.return_value.keep_app_open.return_value)
         selected_result.on_alt_enter.return_value.run.assert_called_with()

--- a/ulauncher/modes/ModeHandler.py
+++ b/ulauncher/modes/ModeHandler.py
@@ -43,8 +43,8 @@ class ModeHandler:
         else:
             # No mode selected, which means search
             results = self.search(query)
-            # If the search result is empty, add the default items for all other modes (only shotcuts currently)
-            if not results:
+            # If the search result is empty, add the default items for all other modes (only shortcuts currently)
+            if not results and query:
                 for mode in self.modes:
                     results.extend(mode.get_fallback_results())
             RenderResultListAction(results).run()

--- a/ulauncher/ui/ItemNavigation.py
+++ b/ulauncher/ui/ItemNavigation.py
@@ -70,6 +70,6 @@ class ItemNavigation:
             if isinstance(action, list):
                 action = RenderResultListAction(action)
             action.run()
-            return action.keep_app_open()
+            return not action.keep_app_open()
 
         return None

--- a/ulauncher/ui/windows/UlauncherWindow.py
+++ b/ulauncher/ui/windows/UlauncherWindow.py
@@ -308,7 +308,7 @@ class UlauncherWindow(Gtk.Window, WindowHelper):
             self.results_nav.select(index)
 
     def enter_result(self, index=None, alt=False):
-        if not self.results_nav.enter(self._get_user_query(), index, alt=alt):
+        if self.results_nav.enter(self._get_user_query(), index, alt=alt):
             # hide the window if it has to be closed on enter
             self.hide_and_clear_input()
 

--- a/ulauncher/ui/windows/UlauncherWindow.py
+++ b/ulauncher/ui/windows/UlauncherWindow.py
@@ -153,7 +153,11 @@ class UlauncherWindow(Gtk.Window, WindowHelper):
         """
         Triggered by user input
         """
-        ModeHandler.get_instance().on_query_change(self._get_user_query())
+        query = self._get_user_query()
+        # This might seem odd, but this makes sure any normalization done in get_user_query() is
+        # reflected in the input box. In particular, stripping out the leading white-space.
+        self.input.set_text(query)
+        ModeHandler.get_instance().on_query_change(query)
 
     # pylint: disable=inconsistent-return-statements
     def on_input_key_press_event(self, widget, event):
@@ -250,7 +254,7 @@ class UlauncherWindow(Gtk.Window, WindowHelper):
         if not is_wayland_compatibility_on():
             self.present_with_time(Keybinder.get_current_event_time())
 
-        if not self.input.get_text():
+        if not self._get_input_text():
             # make sure frequent apps are shown if necessary
             self.show_results([])
         elif self.settings.get_property('clear-previous-query'):
@@ -291,8 +295,11 @@ class UlauncherWindow(Gtk.Window, WindowHelper):
             display_name = Gtk.accelerator_get_label(key, mode)
             show_notification("Ulauncher", f"Hotkey is set to {display_name}")
 
+    def _get_input_text(self):
+        return self.input.get_text().lstrip()
+
     def _get_user_query(self):
-        return Query(self.input.get_text().lstrip())
+        return Query(self._get_input_text())
 
     def select_result(self, index, onHover=False):
         if time.time() - self._results_render_time > 0.1:

--- a/ulauncher/ui/windows/UlauncherWindow.py
+++ b/ulauncher/ui/windows/UlauncherWindow.py
@@ -68,6 +68,7 @@ class UlauncherWindow(Gtk.Window, WindowHelper):
         self.input = self.ui['input']
         self.prefs_btn = self.ui['prefs_btn']
         self.result_box = self.ui["result_box"]
+        self.scroll_container = self.ui["result_box_scroll_container"]
 
         self.input.connect('changed', self.on_input_changed)
         self.prefs_btn.connect('clicked', self.on_mnu_preferences_activate)
@@ -350,13 +351,14 @@ class UlauncherWindow(Gtk.Window, WindowHelper):
             self.results_nav = ItemNavigation(self.result_box.get_children())
             self.results_nav.select_default(self._get_user_query())
 
-            self.result_box.show_all()
             self.result_box.set_margin_bottom(10)
             self.result_box.set_margin_top(3)
             self.apply_css(self.result_box)
+            self.scroll_container.show_all()
         else:
-            self.result_box.set_margin_bottom(0)
-            self.result_box.set_margin_top(0)
+            # Hide the scroll container when there are no results since it normally takes up a
+            # minimum amount of space even if it is empty.
+            self.scroll_container.hide()
         logger.debug('render %s results', len(results))
 
     def _render_prefs_icon(self):


### PR DESCRIPTION
I fixed a few small issues I ran into today:
- I was getting spurious results show up when I first started Ulauncher, specifically a few of the fallback searches, but I had no query. Though interestingly it didn't happen every time. It definitely happened every time when I just typed spaces, but of course that wasn't a meaningful query because we `lstrip()` anyway. I also made it so that you can't even type the leading spaces, so that the user experience matches what is actually used.
- Looks like the extra space below the query box when there are no results was just due to a minimum size for the scrolling container. I added to code to just hide the container when there are no results.
- I had an issue where launching apps wouldn't close ulauncher. I found what appeared to be an inverted conditional.

### Checklist
- [X] Verify that the test command `./ul test` is passing (the CI server will check this if you don't)
- [] Update the documentation according to your changes (when applicable)
- [ ] Write unit tests for your changes (when applicable)
