### PR TITLE
Make ulauncher "toggle" by default if it's already running

### DIFF
--- a/ulauncher.desktop
+++ b/ulauncher.desktop
@@ -4,7 +4,7 @@ Comment=Application launcher for Linux
 GenericName=Launcher
 Categories=GNOME;GTK;Utility;
 TryExec=ulauncher
-Exec=env GDK_BACKEND=x11 ulauncher --no-window
+Exec=env GDK_BACKEND=x11 ulauncher
 Icon=ulauncher
 SingleMainWindow=true
 Terminal=false

--- a/ulauncher/utils/dbus.py
+++ b/ulauncher/utils/dbus.py
@@ -1,0 +1,30 @@
+import sys
+import logging
+from dbus import bus, service, SessionBus
+from dbus.mainloop.glib import DBusGMainLoop
+from ulauncher.config import get_options
+
+DBUS_SERVICE = 'net.launchpad.ulauncher'
+DBUS_PATH = '/net/launchpad/ulauncher'
+logger = logging.getLogger('ulauncher')
+# Start DBus loop
+DBusGMainLoop(set_as_default=True)
+
+# If Ulauncher is already running, show the window of the running process, then exit the new process gracefully
+if SessionBus().request_name(DBUS_SERVICE) != bus.REQUEST_NAME_REPLY_PRIMARY_OWNER:
+    if get_options().no_window:
+        logger.warning("Ulauncher is already running")
+    else:
+        SessionBus().get_object(DBUS_SERVICE, DBUS_PATH).get_dbus_method("toggle_window")()
+    sys.exit(0)
+
+
+class UlauncherDbusService(service.Object):
+    def __init__(self, window):
+        self.window = window
+        bus_name = service.BusName(DBUS_SERVICE, bus=SessionBus())
+        super().__init__(bus_name, DBUS_PATH)
+
+    @service.method(DBUS_SERVICE)
+    def toggle_window(self):
+        self.window.toggle_window()


### PR DESCRIPTION
The title is a bit misleading, because ulauncher already does this, but it doesn't do it well.

This PR does four things:
1. Moves the part of the main scripts that checks for already running instances to the top, and avoid loading all the heavy dependencies until after this check. This makes the command `ulauncher` about as fast as `ulauncher-toggle`.
2. Check if it was invoked with `--no-window` (if it was, don't show the window of the running Ulauncher instance).
3. Removes the previous warning "DBus name already taken. Ulauncher is probably backgrounded. Did you mean `ulauncher-toggle`".
4. Remove `--no-window` from the desktop entry. I think it's better if the desktop entry follows the experience of a regular "app", that you can "launch", while the systemd service file has `--no-window`, because it should run in the background.

What's missing for this to be a perfect solution is the Wayland focus stealing fix from ulauncher-toggle, but that fix is unreliable anyway and I would want to replace it with something better (#986). I think we should keep `ulauncher-toggle` around for a while anyway because people have that in their DE configs.

### Checklist
- [x] Verify that the test command `./ul test` is passing (the CI server will check this if you don't)
- [ ] Update the documentation according to your changes (when applicable)
- [ ] Write unit tests for your changes (when applicable)
