### PR TITLE
Switch to Gtk.Application and make `ulauncher` command "toggle" by default

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -34,7 +34,7 @@ For the v6 branch you need the the following to setup the local build environmen
 
   ```sh
   sudo apt-get install \
-    gobject-introspection libgtk-3-0 libkeybinder-3.0-0 wmctrl \
+    gobject-introspection libgtk-3-0 libkeybinder-3.0-0 \
     gir1.2-{glib-2.0,gtk-3.0,gdkpixbuf-2.0,notify-0.7,webkit2-4.0,keybinder-3.0,ayatanaappindicator3-0.1} \
     python3-{all,gi,levenshtein}
   ```
@@ -60,8 +60,7 @@ For the v6 branch you need the the following to setup the local build environmen
 
   ```sh
   sudo pacman -Syu --needed \
-    gtk3 webkit2gtk libappindicator-gtk3 libnotify libkeybinder3 wmctrl \
-    python-{gobject,levenshtein}
+    gtk3 webkit2gtk libappindicator-gtk3 libnotify libkeybinder3 python-{gobject,levenshtein}
   ```
 </details>
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -36,7 +36,7 @@ For the v6 branch you need the the following to setup the local build environmen
   sudo apt-get install \
     gobject-introspection libgtk-3-0 libkeybinder-3.0-0 wmctrl \
     gir1.2-{glib-2.0,gtk-3.0,gdkpixbuf-2.0,notify-0.7,webkit2-4.0,keybinder-3.0,ayatanaappindicator3-0.1} \
-    python3-{all,gi,dbus,levenshtein}
+    python3-{all,gi,levenshtein}
   ```
 
 </details>
@@ -61,7 +61,7 @@ For the v6 branch you need the the following to setup the local build environmen
   ```sh
   sudo pacman -Syu --needed \
     gtk3 webkit2gtk libappindicator-gtk3 libnotify libkeybinder3 wmctrl \
-    python-{gobject,dbus,levenshtein}
+    python-{gobject,levenshtein}
   ```
 </details>
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -25,7 +25,6 @@ RUN apt-get update && \
         gir1.2-notify-0.7 \
         python3-all \
         python3-gi \
-        python3-dbus \
         python3-levenshtein \
         python3-paramiko \
         python3-pip && \

--- a/bin/ulauncher-toggle
+++ b/bin/ulauncher-toggle
@@ -1,13 +1,4 @@
 #!/bin/sh
-
-dbus-send \
-    --session \
-    --print-reply \
-    --dest=net.launchpad.ulauncher \
-    /net/launchpad/ulauncher \
-    net.launchpad.ulauncher.toggle_window
-
-# dbus-send is asynchronous and sometimes it takes a bit of time for Ulauncher window to be presented
-sleep 0.03
+ulauncher
 
 wmctrl -a "Ulauncher - Application Launcher"

--- a/bin/ulauncher-toggle
+++ b/bin/ulauncher-toggle
@@ -1,2 +1,2 @@
 #!/bin/sh
-ulauncher
+exec ulauncher

--- a/bin/ulauncher-toggle
+++ b/bin/ulauncher-toggle
@@ -1,4 +1,2 @@
 #!/bin/sh
 ulauncher
-
-wmctrl -a "Ulauncher - Application Launcher"

--- a/debian/control
+++ b/debian/control
@@ -25,7 +25,6 @@ Depends: ${misc:Depends},
  gir1.2-notify-0.7,
  gir1.2-gdkpixbuf-2.0,
  python3-gi,
- python3-dbus,
  python3-levenshtein,
  wmctrl
 Recommends: gir1.2-ayatanaappindicator3-0.1

--- a/debian/control
+++ b/debian/control
@@ -25,8 +25,7 @@ Depends: ${misc:Depends},
  gir1.2-notify-0.7,
  gir1.2-gdkpixbuf-2.0,
  python3-gi,
- python3-levenshtein,
- wmctrl
+ python3-levenshtein
 Recommends: gir1.2-ayatanaappindicator3-0.1
 Description: Application launcher for Linux
  See https://ulauncher.io for more information

--- a/docs/extensions/libs.rst
+++ b/docs/extensions/libs.rst
@@ -28,6 +28,3 @@ In future we'll make it possible to support ``requirements.txt`` for extensions.
 
 `gir1.2-appindicator3-0.1 <https://lazka.github.io/pgi-docs/#AppIndicator3-0.1>`_
   Allow applications to export a menu into the panel
-
-`python-dbus <https://github.com/LEW21/pydbus>`_
-  Python DBus library.

--- a/setup.cfg
+++ b/setup.cfg
@@ -36,7 +36,6 @@ scripts =
 	bin/ulauncher
 	bin/ulauncher-toggle
 install_requires = 
-	dbus-python
 	PyGObject
 	python-Levenshtein
 

--- a/ulauncher.desktop
+++ b/ulauncher.desktop
@@ -4,7 +4,7 @@ Comment=Application launcher for Linux
 GenericName=Launcher
 Categories=GNOME;GTK;Utility;
 TryExec=ulauncher
-Exec=env GDK_BACKEND=x11 ulauncher --no-window
+Exec=env GDK_BACKEND=x11 ulauncher
 Icon=ulauncher
 SingleMainWindow=true
 Terminal=false

--- a/ulauncher/main.py
+++ b/ulauncher/main.py
@@ -42,7 +42,7 @@ class UlauncherApp(Gtk.Application):
             AppIndicator.get_instance().show()
 
     def do_activate(self, *args, **kwargs):
-        self.window.show()
+        self.window.show_window()
 
     def do_command_line(self, *args, **kwargs):
         # This is where we handle "--no-window" which we need to get from the remote call

--- a/ulauncher/main.py
+++ b/ulauncher/main.py
@@ -1,54 +1,68 @@
 import sys
+import argparse
 import signal
 import logging
 from functools import partial
 # This xinit import must happen before any GUI libraries are initialized.
 # pylint: disable=wrong-import-position,wrong-import-order,ungrouped-imports,unused-import
 import ulauncher.utils.xinit  # noqa: F401
-
 import gi
 gi.require_version('Gtk', '3.0')
-gi.require_version('GLib', '2.0')
 # pylint: disable=wrong-import-position
-from gi.repository import Gtk, GLib
-import dbus
-import dbus.service
-from dbus.mainloop.glib import DBusGMainLoop
-
+from gi.repository import Gio, GLib, Gtk
 from ulauncher.config import API_VERSION, VERSION, get_options
 from ulauncher.utils.wayland import is_wayland, is_wayland_compatibility_on
-from ulauncher.ui.windows.UlauncherWindow import UlauncherWindow
-from ulauncher.ui.AppIndicator import AppIndicator
 from ulauncher.utils.Settings import Settings
 from ulauncher.utils.setup_logging import setup_logging
 
+
+class UlauncherApp(Gtk.Application):
+    # Gtk.Applications check if the app is already registered and if so,
+    # new instances sends the signals to the registered one
+    # So all methods except __init__ runs on the main app
+    window = None
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(
+            *args,
+            application_id="net.launchpad.ulauncher",
+            flags=Gio.ApplicationFlags.HANDLES_COMMAND_LINE,
+            **kwargs
+        )
+        self.connect("startup", self.setup)  # runs only once on the main instance
+
+    def setup(self, _):
+        self.hold()  # Keep the app running even without a window
+        # These modules are very heavy, so we don't want to load them in the remote
+        # pylint: disable=import-outside-toplevel
+        from ulauncher.ui.windows.UlauncherWindow import UlauncherWindow
+        from ulauncher.ui.AppIndicator import AppIndicator
+        self.window = UlauncherWindow.get_instance()
+        if Settings.get_instance().get_property('show-indicator-icon'):
+            AppIndicator.get_instance().show()
+
+    def do_activate(self, *args, **kwargs):
+        self.window.show()
+
+    def do_command_line(self, *args, **kwargs):
+        # This is where we handle "--no-window" which we need to get from the remote call
+        # All other aguments are persistent and handled in config.get_options()
+        parser = argparse.ArgumentParser(prog='gui')
+        parser.add_argument("--no-window", action="store_true")
+        args, _ = parser.parse_known_args(args[0].get_arguments()[1:])
+
+        if not args.no_window:
+            self.activate()
+
+        return 0
+
+
 logger = logging.getLogger('ulauncher')
 
-DBUS_SERVICE = 'net.launchpad.ulauncher'
-DBUS_PATH = '/net/launchpad/ulauncher'
 
-
-class UlauncherDbusService(dbus.service.Object):
-    def __init__(self, window):
-        self.window = window
-        bus_name = dbus.service.BusName(DBUS_SERVICE, bus=dbus.SessionBus())
-        super().__init__(bus_name, DBUS_PATH)
-
-    @dbus.service.method(DBUS_SERVICE)
-    def toggle_window(self):
-        self.window.toggle_window()
-
-
-def reload_config(win):
+def reload_config(app):
     logger.info("Reloading config")
-    win.init_theme()
-
-
-def graceful_exit(data):
-    logger.info("Exiting gracefully nesting level %s: %s", Gtk.main_level(), data)
-    # ExtensionServer.get_instance().stop()
-    # Gtk.main_quit()
-    sys.exit(0)
+    app.window.init_theme()
 
 
 def main():
@@ -74,43 +88,23 @@ def main():
         # --no-window flag prevents the app from starting.
         sys.exit("The --hide-window argument has been renamed to --no-window")
 
-    # start DBus loop
-    DBusGMainLoop(set_as_default=True)
-    bus = dbus.SessionBus()
-    instance = bus.request_name(DBUS_SERVICE)
-
-    if instance != dbus.bus.REQUEST_NAME_REPLY_PRIMARY_OWNER:
-        print(
-            "DBus name already taken. Ulauncher is probably backgrounded. Did you mean `ulauncher-toggle`?",
-            file=sys.stderr
-        )
-        toggle_window = dbus.SessionBus().get_object(DBUS_SERVICE, DBUS_PATH).get_dbus_method("toggle_window")
-        toggle_window()
-        return
-
     # log uncaught exceptions
     def except_hook(exctype, value, tb):
         logger.error("Uncaught exception", exc_info=(exctype, value, tb))
 
     sys.excepthook = except_hook
 
-    window = UlauncherWindow.get_instance()
-    UlauncherDbusService(window)
-    if not options.no_window:
-        window.show()
-
-    if Settings.get_instance().get_property('show-indicator-icon'):
-        AppIndicator.get_instance().show()
+    app = UlauncherApp()
 
     GLib.unix_signal_add(
         GLib.PRIORITY_DEFAULT,
         signal.SIGHUP,
-        partial(reload_config, window),
+        partial(reload_config, app),
         None
     )
-    GLib.unix_signal_add(GLib.PRIORITY_DEFAULT, signal.SIGTERM, graceful_exit, None)
+    GLib.unix_signal_add(GLib.PRIORITY_DEFAULT, signal.SIGTERM, app.quit)
 
     try:
-        Gtk.main()
+        app.run(sys.argv)
     except KeyboardInterrupt:
         logger.warning('On KeyboardInterrupt')

--- a/ulauncher/main.py
+++ b/ulauncher/main.py
@@ -38,6 +38,7 @@ class UlauncherApp(Gtk.Application):
         from ulauncher.ui.windows.UlauncherWindow import UlauncherWindow
         from ulauncher.ui.AppIndicator import AppIndicator
         self.window = UlauncherWindow.get_instance()
+        self.window.set_application(self)
         if Settings.get_instance().get_property('show-indicator-icon'):
             AppIndicator.get_instance().show()
 

--- a/ulauncher/main.py
+++ b/ulauncher/main.py
@@ -12,7 +12,6 @@ gi.require_version('Gtk', '3.0')
 from gi.repository import Gio, GLib, Gtk
 from ulauncher.config import API_VERSION, VERSION, get_options
 from ulauncher.utils.wayland import is_wayland, is_wayland_compatibility_on
-from ulauncher.utils.Settings import Settings
 from ulauncher.utils.setup_logging import setup_logging
 
 
@@ -36,11 +35,8 @@ class UlauncherApp(Gtk.Application):
         # These modules are very heavy, so we don't want to load them in the remote
         # pylint: disable=import-outside-toplevel
         from ulauncher.ui.windows.UlauncherWindow import UlauncherWindow
-        from ulauncher.ui.AppIndicator import AppIndicator
         self.window = UlauncherWindow.get_instance()
         self.window.set_application(self)
-        if Settings.get_instance().get_property('show-indicator-icon'):
-            AppIndicator.get_instance().show()
 
     def do_activate(self, *args, **kwargs):
         self.window.show_window()

--- a/ulauncher/ui/AppIndicator.py
+++ b/ulauncher/ui/AppIndicator.py
@@ -49,10 +49,7 @@ class AppIndicator:
 
     @classmethod
     @singleton
-    def get_instance(cls):
-        # pylint: disable=import-outside-toplevel
-        from ulauncher.ui.windows.UlauncherWindow import UlauncherWindow
-        window = UlauncherWindow.get_instance()
+    def get_instance(cls, window):
         indicator = cls("ulauncher")
         indicator.set_icon('ulauncher-indicator')
         indicator.add_menu_item(window.on_mnu_preferences_activate, "Preferences")

--- a/ulauncher/ui/AppIndicator.py
+++ b/ulauncher/ui/AppIndicator.py
@@ -58,7 +58,7 @@ class AppIndicator:
         indicator.add_menu_item(window.on_mnu_preferences_activate, "Preferences")
         indicator.add_menu_item(window.on_mnu_about_activate, "About")
         indicator.add_seperator()
-        indicator.add_menu_item(Gtk.main_quit, "Exit")
+        indicator.add_menu_item(lambda *_: window.get_application().quit(), "Exit")
         return indicator
 
     def __init__(self, iconname):

--- a/ulauncher/ui/windows/UlauncherWindow.py
+++ b/ulauncher/ui/windows/UlauncherWindow.py
@@ -264,12 +264,6 @@ class UlauncherWindow(Gtk.ApplicationWindow, WindowHelper):
         else:
             self.input.grab_focus()
 
-    def toggle_window(self, key=None):
-        if self.is_visible():
-            self.hide()
-        else:
-            self.show_window()
-
     def mouse_down_event(self, _, event):
         """
         Prepare moving the window if the user drags
@@ -291,7 +285,7 @@ class UlauncherWindow(Gtk.ApplicationWindow, WindowHelper):
             self._current_accel_name = None
 
         logger.info("Trying to bind app hotkey: %s", accel_name)
-        Keybinder.bind(accel_name, self.toggle_window)
+        Keybinder.bind(accel_name, self.show_window)
         self._current_accel_name = accel_name
         if FIRST_RUN:
             (key, mode) = Gtk.accelerator_parse(accel_name)

--- a/ulauncher/ui/windows/UlauncherWindow.py
+++ b/ulauncher/ui/windows/UlauncherWindow.py
@@ -41,7 +41,7 @@ logger = logging.getLogger(__name__)
 
 
 # pylint: disable=too-many-instance-attributes, too-many-public-methods, attribute-defined-outside-init
-class UlauncherWindow(Gtk.Window, WindowHelper):
+class UlauncherWindow(Gtk.ApplicationWindow, WindowHelper):
     __gtype_name__ = "UlauncherWindow"
 
     _current_accel_name = None

--- a/ulauncher/ui/windows/UlauncherWindow.py
+++ b/ulauncher/ui/windows/UlauncherWindow.py
@@ -115,11 +115,6 @@ class UlauncherWindow(Gtk.ApplicationWindow, WindowHelper):
         """Display the preferences window for ulauncher."""
         self.activate_preferences(page='preferences')
 
-    def on_destroy(self, widget, data=None):
-        """Called when the UlauncherWindow is closed."""
-        # Clean up code for saving application state should be added here.
-        Gtk.main_quit()
-
     def on_preferences_dialog_destroyed(self, widget, data=None):
         '''only affects GUI
 

--- a/ulauncher/ui/windows/UlauncherWindow.py
+++ b/ulauncher/ui/windows/UlauncherWindow.py
@@ -2,6 +2,8 @@
 import os
 import time
 import logging
+import subprocess
+from shutil import which
 
 import gi
 gi.require_version('Gtk', '3.0')
@@ -30,7 +32,7 @@ from ulauncher.utils.timer import timer
 from ulauncher.utils.display import get_monitor, get_scaling_factor
 from ulauncher.utils.icon import load_icon
 from ulauncher.utils.desktop.notification import show_notification
-from ulauncher.utils.wayland import is_wayland_compatibility_on
+from ulauncher.utils.wayland import is_wayland, is_wayland_compatibility_on
 from ulauncher.utils.Theme import Theme, load_available_themes
 from ulauncher.modes.Query import Query
 from ulauncher.ui.windows.Builder import GladeObjectFactory
@@ -263,6 +265,9 @@ class UlauncherWindow(Gtk.Window, WindowHelper):
             self.input.set_text('')
         else:
             self.input.grab_focus()
+
+        if is_wayland and which("wmctrl"):
+            subprocess.run(["wmctrl", "-a", '"Ulauncher - Application Launcher"'], check=False)
 
     def toggle_window(self, key=None):
         if self.is_visible():

--- a/ulauncher/ui/windows/UlauncherWindow.py
+++ b/ulauncher/ui/windows/UlauncherWindow.py
@@ -18,6 +18,7 @@ from ulauncher.ui.ResultWidget import ResultWidget  # noqa: F401
 from ulauncher.ui.SmallResultWidget import SmallResultWidget   # noqa: F401
 
 from ulauncher.config import get_asset, get_options, FIRST_RUN
+from ulauncher.ui.AppIndicator import AppIndicator
 from ulauncher.ui.ItemNavigation import ItemNavigation
 from ulauncher.modes.ModeHandler import ModeHandler
 from ulauncher.modes.apps.AppResult import AppResult
@@ -88,6 +89,9 @@ class UlauncherWindow(Gtk.ApplicationWindow, WindowHelper):
         self.connect('button-press-event', self.mouse_down_event)
         self.connect('button-release-event', self.mouse_up_event)
         self.connect('motion_notify_event', self.mouse_move_event)
+
+        if self.settings.get_property('show-indicator-icon'):
+            AppIndicator.get_instance(self).show()
 
         if not is_wayland_compatibility_on():
             # bind hotkey

--- a/ulauncher/ui/windows/UlauncherWindow.py
+++ b/ulauncher/ui/windows/UlauncherWindow.py
@@ -2,8 +2,6 @@
 import os
 import time
 import logging
-import subprocess
-from shutil import which
 
 import gi
 gi.require_version('Gtk', '3.0')
@@ -32,7 +30,7 @@ from ulauncher.utils.timer import timer
 from ulauncher.utils.display import get_monitor, get_scaling_factor
 from ulauncher.utils.icon import load_icon
 from ulauncher.utils.desktop.notification import show_notification
-from ulauncher.utils.wayland import is_wayland, is_wayland_compatibility_on
+from ulauncher.utils.wayland import is_wayland_compatibility_on
 from ulauncher.utils.Theme import Theme, load_available_themes
 from ulauncher.modes.Query import Query
 from ulauncher.ui.windows.Builder import GladeObjectFactory
@@ -265,9 +263,6 @@ class UlauncherWindow(Gtk.Window, WindowHelper):
             self.input.set_text('')
         else:
             self.input.grab_focus()
-
-        if is_wayland and which("wmctrl"):
-            subprocess.run(["wmctrl", "-a", '"Ulauncher - Application Launcher"'], check=False)
 
     def toggle_window(self, key=None):
         if self.is_visible():


### PR DESCRIPTION
Alternative implementation of #987, using Gtk.Application for the main loop. This handles stuff we had to do manually before with dbus, so we can remove the `python-dbus` dependency.

I also removed `gi.require_version('GLib', '2.0')` because I recently learned it's [not needed](https://gitlab.gnome.org/GNOME/pygobject/-/blob/master/gi/importer.py#L64)

As a nice side effect, this seems to get rid of the race condition issue with ulaucher-toggle. Previously I ran into that a lot on Wayland, but now I removed the `sleep 0.03` bit completely and it works every time (still need wmctrl though).

I kept things in the same file mostly because I wanted to keep the changes minimal. This PR is just the first part and there' s so much more this opens up for:
* Move the `UlauncherApp` to it's own singleton module
* Moving logic from the window to the app so we can create a new window for each time (this way we won't need wmctrl in `ulauncher-toggle`)
* Use the application to send desktop notifications (removing the libnotify dependency).
* Move the argparse logic to the UlauncherApp.setup method instead of handling it in two places.


### Checklist
- [x] Verify that the test command `./ul test` is passing (the CI server will check this if you don't)
- [ ] Update the documentation according to your changes (when applicable)
- [ ] Write unit tests for your changes (when applicable)
