### PR TITLE
Update `ulauncher-toggle` to use gdbus

### DIFF
--- a/bin/ulauncher-toggle
+++ b/bin/ulauncher-toggle
@@ -1,2 +1,6 @@
 #!/bin/sh
-exec ulauncher
+gdbus call --session \
+  --dest net.launchpad.ulauncher \
+  --object-path /net/launchpad/ulauncher \
+  --method org.gtk.Application.Activate \
+  {}


### PR DESCRIPTION
This sends a direct `org.gtk.Application.Activate` message to the window reducing latency of toggling from 810ms to 9ms on a test machine.

