### PR TITLE
Make the icon error handling a little more complete.

### DIFF
--- a/ulauncher/utils/icon.py
+++ b/ulauncher/utils/icon.py
@@ -15,6 +15,7 @@ logger = logging.getLogger(__name__)
 
 DEFAULT_EXE_ICON = "icons/executable.png"
 
+
 def get_icon_path(icon, size=32, base_path=""):
     """
     :param str icon:

--- a/ulauncher/utils/icon.py
+++ b/ulauncher/utils/icon.py
@@ -13,6 +13,7 @@ from ulauncher.config import get_asset
 icon_theme = Gtk.IconTheme.get_default()
 logger = logging.getLogger(__name__)
 
+DEFAULT_EXE_ICON = "icons/executable.png"
 
 def get_icon_path(icon, size=32, base_path=""):
     """
@@ -33,7 +34,7 @@ def get_icon_path(icon, size=32, base_path=""):
     except Exception as e:
         logger.info('Could not load icon path %s. E: %s', icon, e)
 
-    return get_asset('icons/executable.png')
+    return get_asset(DEFAULT_EXE_ICON)
 
 
 @lru_cache(maxsize=50)
@@ -43,5 +44,10 @@ def load_icon(icon, size):
     :param int size:
     :rtype: :class:`GtkPixbuf`
     """
-    icon_path = get_icon_path(icon, size)
-    return GdkPixbuf.Pixbuf.new_from_file_at_size(icon_path, size, size)
+    try:
+        icon_path = get_icon_path(icon, size)
+        return GdkPixbuf.Pixbuf.new_from_file_at_size(icon_path, size, size)
+    except Exception as e:
+        logger.warning("Could not load icon %s, using default: %s", icon, e)
+        icon_path = get_asset(DEFAULT_EXE_ICON)
+        return GdkPixbuf.Pixbuf.new_from_file_at_size(icon_path, size, size)


### PR DESCRIPTION
I noticed some strange behavior where some characters I would type would have results, then the next character wouldn't and then next would. I found it was due to an uncaught exception loading an icon:
```
2022-03-29 22:20:27,557 | ERROR | ulauncher: except_hook() | Uncaught exception
Traceback (most recent call last):
  File "/home/troycurtisjr/working/oss/Ulauncher/v6/ulauncher/ui/windows/UlauncherWindow.py", line 369, in show_results
    results = self.create_item_widgets(results, self._get_user_query())
  File "/home/troycurtisjr/working/oss/Ulauncher/v6/ulauncher/ui/windows/UlauncherWindow.py", line 406, in create_item_widgets
    item_frame.initialize(builder, result, index, query)
  File "/home/troycurtisjr/working/oss/Ulauncher/v6/ulauncher/ui/ResultWidget.py", line 55, in initialize
    self.set_icon(load_icon(result.icon, result.ICON_SIZE * self.scaling_factor))
  File "/home/troycurtisjr/working/oss/Ulauncher/v6/ulauncher/utils/icon.py", line 47, in load_icon
    return GdkPixbuf.Pixbuf.new_from_file_at_size(icon_path, size, size)
gi.repository.GLib.GError: g-file-error-quark: Failed to open file “/usr/share/ulauncher/media/stackoverflow-icon.svg”: No such file or directory (4)
```
There was already some handling for not finding the file path, but there could also be errors loading the file itself (like this case), so I added in some additional handling.

### Checklist
- [X] Verify that the test command `./ul test` is passing (the CI server will check this if you don't)
- [ ] Update the documentation according to your changes (when applicable)
- [ ] Write unit tests for your changes (when applicable)
