### PR TITLE
Extend calculator functionality

### DIFF
--- a/tests/modes/calc/test_CalcMode.py
+++ b/tests/modes/calc/test_CalcMode.py
@@ -11,26 +11,31 @@ class TestCalcMode:
 
     def test_is_enabled(self, mode):
         assert mode.is_enabled('5')
+        assert mode.is_enabled('+2')
         assert mode.is_enabled('-5')
         assert mode.is_enabled('5+')
         assert mode.is_enabled('(5/0')
         assert mode.is_enabled('0.5/0')
         assert mode.is_enabled('0.5e3+ (11**3+-2^3)')
         assert mode.is_enabled('5%2')
+        assert mode.is_enabled('sqrt(2)')
+        assert mode.is_enabled('1+sin(pi/2)')
 
-        assert not mode.is_enabled('+2')
-        assert not mode.is_enabled(')+3')
-        assert not mode.is_enabled('e3')
         assert not mode.is_enabled('a+b')
+        assert not mode.is_enabled('sqr()+1')
 
     def test_eval_expr_no_floating_point_errors(self):
-        assert eval_expr('110 / 3') == Decimal('36.66666666666666666666666667')
+        assert eval_expr('110 / 3') == Decimal('36.666666666666667')
         assert eval_expr('1.1 + 2.2') == Decimal('3.3')
+        assert eval_expr('sin(pi)') == Decimal('0')
+        assert abs(eval_expr('e**2') - eval_expr('exp(2)')) < Decimal('1e-10')
 
     def test_eval_expr_syntax_variation(self):
         assert eval_expr('5.5 * 10') == Decimal('55')
         assert eval_expr('12 / 1,5') == eval_expr('12 / 1.5') == Decimal('8')
         assert eval_expr('3 ** 2') == eval_expr('3^2') == Decimal('9')
+        assert eval_expr('sqrt(2)**2') == Decimal('2')
+        assert eval_expr('gamma(6)') == Decimal('120')
 
     def test_handle_query(self, mode):
         assert mode.handle_query('3+2')[0].result == 5

--- a/ulauncher/modes/calc/CalcMode.py
+++ b/ulauncher/modes/calc/CalcMode.py
@@ -22,7 +22,9 @@ functions = {"sqrt": Decimal.sqrt, "exp": Decimal.exp,
              "erf": math.erf, "erfc": math.erfc, "gamma": math.gamma,
              "lgamma": math.lgamma}
 
-regex = r'^(?:[\d\*+\/\%\-\.,e\(\)\^ ]|' + "|".join(functions.keys()) + r')+$'
+constants = {"pi": Decimal(math.pi), "e": Decimal(math.e)}
+
+regex = r'^(?:[\d\*+\/\%\-\.,e\(\)\^ ]|' + "|".join(functions.keys()) + "|" + "|".join(constants.keys()) + r')+$'
 
 def eval_expr(expr):
     """
@@ -51,6 +53,9 @@ def _eval(node):
         return operators[type(node.op)](_eval(node.left), _eval(node.right))
     if isinstance(node, ast.UnaryOp):  # <operator> <operand> e.g., -1
         return operators[type(node.op)](_eval(node.operand))
+    if isinstance(node, ast.Name): # <name>
+        if node.id in constants:
+            return constants[node.id]
     if isinstance(node, ast.Call): # <func>(<args>)
         if node.func.id in functions:
             value = functions[node.func.id](_eval(node.args[0]))

--- a/ulauncher/modes/calc/CalcMode.py
+++ b/ulauncher/modes/calc/CalcMode.py
@@ -1,5 +1,6 @@
 import re
 import ast
+import math
 from decimal import Decimal
 import operator as op
 
@@ -12,6 +13,16 @@ operators = {ast.Add: op.add, ast.Sub: op.sub, ast.Mult: op.mul,
              ast.Div: op.truediv, ast.Pow: op.pow, ast.BitXor: op.xor,
              ast.USub: op.neg, ast.Mod: op.mod}
 
+functions = {"sqrt": Decimal.sqrt, "exp": Decimal.exp,
+             "ln": Decimal.ln, "log10": Decimal.log10,
+             "sin": math.sin, "cos": math.cos, "tan": math.tan,
+             "asin": math.asin, "acos": math.acos, "atan": math.atan,
+             "sinh": math.sinh, "cosh": math.cosh, "tanh": math.tanh,
+             "asinh": math.asinh, "acosh": math.acosh, "atanh": math.atanh,
+             "erf": math.erf, "erfc": math.erfc, "gamma": math.gamma,
+             "lgamma": math.lgamma}
+
+regex = r'^(?:[\d\*+\/\%\-\.,e\(\)\^ ]|' + "|".join(functions.keys()) + r')+$'
 
 def eval_expr(expr):
     """
@@ -40,12 +51,18 @@ def _eval(node):
         return operators[type(node.op)](_eval(node.left), _eval(node.right))
     if isinstance(node, ast.UnaryOp):  # <operator> <operand> e.g., -1
         return operators[type(node.op)](_eval(node.operand))
+    if isinstance(node, ast.Call): # <func>(<args>)
+        if node.func.id in functions:
+            value = functions[node.func.id](_eval(node.args[0]))
+            if isinstance(value, float):
+                value = Decimal(value)
+            return value
 
     raise TypeError(node)
 
 
 class CalcMode(BaseMode):
-    RE_CALC = re.compile(r'^[\d\-\(\.,][\d\*+\/\%\-\.,e\(\)\^ ]*$', flags=re.IGNORECASE)
+    RE_CALC = re.compile(regex, flags=re.IGNORECASE)
 
     def is_enabled(self, query):
         return bool(re.match(self.RE_CALC, query))

--- a/ulauncher/modes/calc/CalcMode.py
+++ b/ulauncher/modes/calc/CalcMode.py
@@ -26,6 +26,7 @@ constants = {"pi": Decimal(math.pi), "e": Decimal(math.e)}
 
 regex = r'^(?:[\d\*+\/\%\-\.,e\(\)\^ ]|' + "|".join(functions.keys()) + "|" + "|".join(constants.keys()) + r')+$'
 
+
 def eval_expr(expr):
     """
     >>> eval_expr('2^6')
@@ -39,7 +40,7 @@ def eval_expr(expr):
     """
     expr = expr.replace("^", "**").replace(",", ".")
     try:
-        return _eval(ast.parse(expr, mode='eval').body)
+        return _eval(ast.parse(expr, mode='eval').body).quantize(Decimal("1e-15"))
     # pylint: disable=broad-except
     except Exception:
         # if failed, try without the last symbol
@@ -53,10 +54,10 @@ def _eval(node):
         return operators[type(node.op)](_eval(node.left), _eval(node.right))
     if isinstance(node, ast.UnaryOp):  # <operator> <operand> e.g., -1
         return operators[type(node.op)](_eval(node.operand))
-    if isinstance(node, ast.Name): # <name>
+    if isinstance(node, ast.Name):  # <name>
         if node.id in constants:
             return constants[node.id]
-    if isinstance(node, ast.Call): # <func>(<args>)
+    if isinstance(node, ast.Call):  # <func>(<args>)
         if node.func.id in functions:
             value = functions[node.func.id](_eval(node.args[0]))
             if isinstance(value, float):


### PR DESCRIPTION
I was checking out Ulauncher when I noticed that the builtin calculator lacks math functions as well as constants. This PR adds this functionality and corresponding tests.

I had to change the `is_enabled` regex to allow expressions to start with functions or constants. This also allows expressions like `+3` to be picked up, whereas it was not before. From my limited testing this expansion does not conflict with other operations, but expressions like `)+3` are picked up. This seems like a good trade-off as such a string seems like a mathematical expression and the calculator just emits an invalid expression error.

With mathematical functions expressions like `sin(pi)` are possible, which should be 0, but with machine precision it results in `0.xxE-16`, therefore I added a rounding step after evaluating the expression.
### Checklist
- [x] Verify that the test command `./ul test` is passing (the CI server will check this if you don't)
- [ ] Update the documentation according to your changes (when applicable)
- [x] Write unit tests for your changes (when applicable)
