### PR TITLE
V6 calc improvements

### DIFF
--- a/tests/modes/calc/test_CalcMode.py
+++ b/tests/modes/calc/test_CalcMode.py
@@ -31,6 +31,7 @@ class TestCalcMode:
         assert eval_expr('5.5 * 10') == Decimal('55')
         assert eval_expr('12 / 1,5') == eval_expr('12 / 1.5') == Decimal('8')
         assert eval_expr('3 ** 2') == eval_expr('3^2') == Decimal('9')
+        assert eval_expr('7+') == eval_expr('7 **') == eval_expr('(7') == Decimal('7')
 
     def test_handle_query(self, mode):
         assert mode.handle_query('3+2')[0].result == 5
@@ -42,3 +43,4 @@ class TestCalcMode:
         [invalid_result] = mode.handle_query('3++')
         assert invalid_result.name == 'Error!'
         assert invalid_result.description == 'Invalid expression'
+        assert mode.handle_query('6 2')[0].name == 'Error!'

--- a/tests/modes/calc/test_CalcMode.py
+++ b/tests/modes/calc/test_CalcMode.py
@@ -24,8 +24,13 @@ class TestCalcMode:
         assert not mode.is_enabled('a+b')
 
     def test_eval_expr_no_floating_point_errors(self):
-        assert eval_expr('110 / 3') == Decimal('36.66666666666666666666666667')
+        assert eval_expr('110 / 3') == Decimal('36.666666666666667')
         assert eval_expr('1.1 + 2.2') == Decimal('3.3')
+
+    def test_eval_expr_rounding(self):
+        assert str(eval_expr('3.300 + 7.1')) == '10.4'
+        assert str(eval_expr('5.5 + 3.50')) == '9'
+        assert str(eval_expr('10 / 3.0')) == '3.333333333333333'
 
     def test_eval_expr_syntax_variation(self):
         assert eval_expr('5.5 * 10') == Decimal('55')

--- a/ulauncher/modes/calc/CalcMode.py
+++ b/ulauncher/modes/calc/CalcMode.py
@@ -41,7 +41,11 @@ def eval_expr(expr):
     """
     expr = normalize_expr(expr)
     tree = ast.parse(expr, mode='eval').body
-    return _eval(tree)
+    result = _eval(tree).quantize(Decimal("1e-15"))
+    int_result = int(result)
+    if result == int_result:
+        return int_result
+    return result.normalize()  # Strip trailing zeros from decimal
 
 
 def _eval(node):
@@ -66,11 +70,6 @@ class CalcMode(BaseMode):
             result = eval_expr(query)
             if result is None:
                 raise ValueError()
-
-            # fixes issue with division where result is represented as a float (e.g., 1.0)
-            # although it is an integer (1)
-            if int(result) == result:
-                result = int(result)
 
             result = CalcResult(result=result)
         # pylint: disable=broad-except

--- a/ulauncher/modes/calc/CalcMode.py
+++ b/ulauncher/modes/calc/CalcMode.py
@@ -13,6 +13,19 @@ operators = {ast.Add: op.add, ast.Sub: op.sub, ast.Mult: op.mul,
              ast.USub: op.neg, ast.Mod: op.mod}
 
 
+# Show a friendlier output for incomplete queries, instead of "Invalid"
+def normalize_expr(expr):
+    # Dot is the Python notation for decimals
+    expr = expr.replace(",", ".")
+    # ^ means xor in Python. ** is the Python notation for pow
+    expr = expr.replace("^", "**")
+    # Strip trailing operator
+    expr = re.sub(r"\s*[\.\+\-\*/%\(]\*?\s*$", "", expr)
+    # Complete unfinished brackets
+    expr = expr + ")" * (expr.count("(") - expr.count(")"))
+    return expr
+
+
 def eval_expr(expr):
     """
     >>> eval_expr('2^6')
@@ -24,13 +37,9 @@ def eval_expr(expr):
     >>> eval_expr('1 + 2*3**(4^5) / (6 + -7)')
     -5.0
     """
-    expr = expr.replace("^", "**").replace(",", ".")
-    try:
-        return _eval(ast.parse(expr, mode='eval').body)
-    # pylint: disable=broad-except
-    except Exception:
-        # if failed, try without the last symbol
-        return _eval(ast.parse(expr[:-1], mode='eval').body)
+    expr = normalize_expr(expr)
+    tree = ast.parse(expr, mode='eval').body
+    return _eval(tree)
 
 
 def _eval(node):

--- a/ulauncher/modes/calc/CalcMode.py
+++ b/ulauncher/modes/calc/CalcMode.py
@@ -2,6 +2,7 @@ import re
 import ast
 from decimal import Decimal
 import operator as op
+from functools import lru_cache
 
 from ulauncher.modes.BaseMode import BaseMode
 from ulauncher.modes.calc.CalcResult import CalcResult
@@ -26,6 +27,7 @@ def normalize_expr(expr):
     return expr
 
 
+@lru_cache(maxsize=1000)
 def eval_expr(expr):
     """
     >>> eval_expr('2^6')


### PR DESCRIPTION
These fixes are meant to help for #1009

1. Fix bad fallback in `eval_expr()`. When `eval_expr()` failed it tried again, but stripped the last character. This would help to show for example "6" as the result  when typing "6 *", until you type a second number. But the fallback was wasteful and applied too wide. I replaced it with a much more specific regex replace that strips the last operator (including `**` which is one operator, but not `++` which is two)
2. I also added parenthesis completion for unfinished queries while I was at it.
3. Added memoization to avoid running the same evaluation repeatedly (should work especially well with the normalization)
4. Round the result to at most 15 decimals (as in #1009, but applied consistently and doesn't zero-pad results)