### PR TITLE
Calculator: Add trigonometric methods and constants

### DIFF
--- a/tests/modes/calc/test_CalcMode.py
+++ b/tests/modes/calc/test_CalcMode.py
@@ -11,21 +11,24 @@ class TestCalcMode:
 
     def test_is_enabled(self, mode):
         assert mode.is_enabled('5')
+        assert mode.is_enabled('+2')
         assert mode.is_enabled('-5')
         assert mode.is_enabled('5+')
         assert mode.is_enabled('(5/0')
         assert mode.is_enabled('0.5/0')
         assert mode.is_enabled('0.5e3+ (11**3+-2^3)')
         assert mode.is_enabled('5%2')
+        assert mode.is_enabled('sqrt(2)')
+        assert mode.is_enabled('1+sin(pi/2)')
 
-        assert not mode.is_enabled('+2')
-        assert not mode.is_enabled(')+3')
-        assert not mode.is_enabled('e3')
         assert not mode.is_enabled('a+b')
+        assert not mode.is_enabled('sqr()+1')
 
     def test_eval_expr_no_floating_point_errors(self):
         assert eval_expr('110 / 3') == Decimal('36.666666666666667')
         assert eval_expr('1.1 + 2.2') == Decimal('3.3')
+        assert eval_expr('sin(pi)') == Decimal('0')
+        assert abs(eval_expr('e**2') - eval_expr('exp(2)')) < Decimal('1e-10')
 
     def test_eval_expr_rounding(self):
         assert str(eval_expr('3.300 + 7.1')) == '10.4'
@@ -37,6 +40,8 @@ class TestCalcMode:
         assert eval_expr('12 / 1,5') == eval_expr('12 / 1.5') == Decimal('8')
         assert eval_expr('3 ** 2') == eval_expr('3^2') == Decimal('9')
         assert eval_expr('7+') == eval_expr('7 **') == eval_expr('(7') == Decimal('7')
+        assert eval_expr('sqrt(2)**2') == Decimal('2')
+        assert eval_expr('gamma(6)') == Decimal('120')
 
     def test_handle_query(self, mode):
         assert mode.handle_query('3+2')[0].result == 5

--- a/tests/modes/calc/test_CalcMode.py
+++ b/tests/modes/calc/test_CalcMode.py
@@ -11,7 +11,6 @@ class TestCalcMode:
 
     def test_is_enabled(self, mode):
         assert mode.is_enabled('5')
-        assert mode.is_enabled('+2')
         assert mode.is_enabled('-5')
         assert mode.is_enabled('5+')
         assert mode.is_enabled('(5/0')
@@ -20,9 +19,23 @@ class TestCalcMode:
         assert mode.is_enabled('5%2')
         assert mode.is_enabled('sqrt(2)')
         assert mode.is_enabled('1+sin(pi/2)')
+        assert mode.is_enabled('pi * 2')
+        assert mode.is_enabled('sqrt()+1')
 
         assert not mode.is_enabled('a+b')
-        assert not mode.is_enabled('sqr()+1')
+        assert not mode.is_enabled('Add/Remove')
+        assert not mode.is_enabled('+2')
+        assert not mode.is_enabled(')+3')
+        assert not mode.is_enabled('asdf()')
+        assert not mode.is_enabled('pi')
+        assert not mode.is_enabled('e')
+        assert not mode.is_enabled('exp')
+        assert not mode.is_enabled('cos')
+        assert not mode.is_enabled('tan')
+        assert not mode.is_enabled('pi e')
+        assert not mode.is_enabled('pie')
+        assert not mode.is_enabled('pi2')
+        assert not mode.is_enabled('cospitanagamma')
 
     def test_eval_expr_no_floating_point_errors(self):
         assert eval_expr('110 / 3') == Decimal('36.666666666666667')
@@ -54,3 +67,7 @@ class TestCalcMode:
         assert invalid_result.name == 'Error!'
         assert invalid_result.description == 'Invalid expression'
         assert mode.handle_query('6 2')[0].name == 'Error!'
+        assert mode.handle_query('()*2')[0].name == 'Error!'
+        assert mode.handle_query('a+b')[0].name == 'Error!'
+        assert mode.handle_query('sqrt()+1')[0].name == 'Error!'
+        assert mode.handle_query('2pi')[0].name == 'Error!'

--- a/tests/modes/calc/test_CalcMode.py
+++ b/tests/modes/calc/test_CalcMode.py
@@ -55,6 +55,16 @@ class TestCalcMode:
         assert eval_expr('7+') == eval_expr('7 **') == eval_expr('(7') == Decimal('7')
         assert eval_expr('sqrt(2)**2') == Decimal('2')
         assert eval_expr('gamma(6)') == Decimal('120')
+        assert eval_expr('lgamma(3)') == eval_expr('ln(gamma(3))') == Decimal('0.693147180559945')
+        # Nonsense expressions probably. I justed wanted to cover all methods
+        assert eval_expr('pi * 2 + exp(4)') == Decimal('60.881335340323825')
+        assert eval_expr('log10(e) / cos(5)') == Decimal('1.531027060212625')
+        assert eval_expr('cos(tanh(tan(2') == Decimal('0.561155145812412')
+        assert eval_expr('atan(sin(erf(8') == Decimal('0.69952164434852')
+        assert eval_expr('cosh(erfc(1.2))') == Decimal('1.004024487774208')
+        assert eval_expr('asin(acosh(1.2))') == Decimal('0.671757384841459')
+        assert eval_expr('sinh(acos(0.4') == Decimal('1.436961780213685')
+        assert eval_expr('asinh(6) + atanh(0.9) + ln(0.7)') == Decimal('3.6073243982894')
 
     def test_handle_query(self, mode):
         assert mode.handle_query('3+2')[0].result == 5

--- a/ulauncher/modes/calc/CalcMode.py
+++ b/ulauncher/modes/calc/CalcMode.py
@@ -1,5 +1,6 @@
 import re
 import ast
+import math
 from decimal import Decimal
 import operator as op
 from functools import lru_cache
@@ -13,6 +14,16 @@ operators = {ast.Add: op.add, ast.Sub: op.sub, ast.Mult: op.mul,
              ast.Div: op.truediv, ast.Pow: op.pow, ast.BitXor: op.xor,
              ast.USub: op.neg, ast.Mod: op.mod}
 
+functions = {"sqrt": Decimal.sqrt, "exp": Decimal.exp,
+             "ln": Decimal.ln, "log10": Decimal.log10,
+             "sin": math.sin, "cos": math.cos, "tan": math.tan,
+             "asin": math.asin, "acos": math.acos, "atan": math.atan,
+             "sinh": math.sinh, "cosh": math.cosh, "tanh": math.tanh,
+             "asinh": math.asinh, "acosh": math.acosh, "atanh": math.atanh,
+             "erf": math.erf, "erfc": math.erfc, "gamma": math.gamma,
+             "lgamma": math.lgamma}
+
+regex = r'^(?:[\d\*+\/\%\-\.,e\(\)\^ ]|' + "|".join(functions.keys()) + r')+$'
 
 # Show a friendlier output for incomplete queries, instead of "Invalid"
 def normalize_expr(expr):
@@ -55,12 +66,18 @@ def _eval(node):
         return operators[type(node.op)](_eval(node.left), _eval(node.right))
     if isinstance(node, ast.UnaryOp):  # <operator> <operand> e.g., -1
         return operators[type(node.op)](_eval(node.operand))
+    if isinstance(node, ast.Call): # <func>(<args>)
+        if node.func.id in functions:
+            value = functions[node.func.id](_eval(node.args[0]))
+            if isinstance(value, float):
+                value = Decimal(value)
+            return value
 
     raise TypeError(node)
 
 
 class CalcMode(BaseMode):
-    RE_CALC = re.compile(r'^[\d\-\(\.,][\d\*+\/\%\-\.,e\(\)\^ ]*$', flags=re.IGNORECASE)
+    RE_CALC = re.compile(regex, flags=re.IGNORECASE)
 
     def is_enabled(self, query):
         return bool(re.match(self.RE_CALC, query))

--- a/ulauncher/modes/calc/CalcMode.py
+++ b/ulauncher/modes/calc/CalcMode.py
@@ -23,7 +23,10 @@ functions = {"sqrt": Decimal.sqrt, "exp": Decimal.exp,
              "erf": math.erf, "erfc": math.erfc, "gamma": math.gamma,
              "lgamma": math.lgamma}
 
-regex = r'^(?:[\d\*+\/\%\-\.,e\(\)\^ ]|' + "|".join(functions.keys()) + r')+$'
+constants = {"pi": Decimal(math.pi), "e": Decimal(math.e)}
+
+regex = r'^(?:[\d\*+\/\%\-\.,e\(\)\^ ]|' + "|".join(functions.keys()) + "|" + "|".join(constants.keys()) + r')+$'
+
 
 # Show a friendlier output for incomplete queries, instead of "Invalid"
 def normalize_expr(expr):
@@ -66,7 +69,10 @@ def _eval(node):
         return operators[type(node.op)](_eval(node.left), _eval(node.right))
     if isinstance(node, ast.UnaryOp):  # <operator> <operand> e.g., -1
         return operators[type(node.op)](_eval(node.operand))
-    if isinstance(node, ast.Call): # <func>(<args>)
+    if isinstance(node, ast.Name):  # <name>
+        if node.id in constants:
+            return constants[node.id]
+    if isinstance(node, ast.Call):  # <func>(<args>)
         if node.func.id in functions:
             value = functions[node.func.id](_eval(node.args[0]))
             if isinstance(value, float):


### PR DESCRIPTION
All the actual functionality is exactly as implemented by @Henje in #1009, but this is rebased over #1014 which solved some of the issues with #1009. `is_enabled()` has also been completely rewritten to use ast (just checking the root node) instead of regex, which made it easier to prevent false positives.

Also added more tests.

It seems pretty solid to me after these changes.

### Checklist
- [x] Verify that the test command `./ul test` is passing (the CI server will check this if you don't)
- [ ] Update the documentation according to your changes (when applicable)
- [x] Write unit tests for your changes (when applicable)
