### PR TITLE
Run extensions on demand

### DIFF
--- a/tests/modes/extensions/test_extension_mode.py
+++ b/tests/modes/extensions/test_extension_mode.py
@@ -30,6 +30,7 @@ def _mock_service(mocker: MockerFixture) -> MagicMock:
     mocker.patch.object(ext_service, "get", mocked.get)
     mocker.patch.object(ext_service, "iterate", mocked.iterate)
     mocker.patch.object(ext_service, "is_running", mocked.is_running)
+    mocker.patch.object(ext_service, "start_extension", mocked.start_extension)
     return mocked
 
 
@@ -49,6 +50,7 @@ def test_handle_query__transitioning_extension_waits(mocker: MockerFixture) -> N
 
     callback.assert_not_called()
     timer.assert_called_once()
+    mocked_service.start_extension.assert_called_once()
     assert mode._active_ext is ext
 
 

--- a/tests/modes/extensions/test_extension_runtime.py
+++ b/tests/modes/extensions/test_extension_runtime.py
@@ -36,11 +36,6 @@ class TestExtensionRuntime:
     def time(self, mocker: MockerFixture) -> MagicMock:
         return mocker.patch("ulauncher.modes.extensions.extension_runtime.time")
 
-    @pytest.fixture
-    def mock_timer(self, mocker: MockerFixture) -> MagicMock:
-        """Mock the timer utility function used for scheduling delayed kills."""
-        return mocker.patch("ulauncher.modes.extensions.extension_runtime.scheduling.timer")
-
     def test_run__basic_execution__is_called(self, subprocess_launcher: MagicMock) -> None:
         extid = "mock.test_run__basic_execution__is_called"
 
@@ -113,8 +108,8 @@ class TestExtensionRuntime:
             "Exited", 'Extension "mock.test_handle_exit" exited with code 9 after 5.0 seconds.'
         )
 
-    def test_stop(self, mock_timer: MagicMock) -> None:
-        """Test that stop() closes the connection and schedules a kill timer."""
+    def test_stop(self) -> None:
+        """Test that stop() closes the connection and kills the process immediately."""
         extid = "mock.test_stop"
         exit_handler = Mock()
         runtime: Any = ExtensionRuntime(extid, ["mock/path/to/ext"], None, exit_handler)
@@ -124,7 +119,7 @@ class TestExtensionRuntime:
         runtime.stop()
 
         runtime._msg_controller.close.assert_called_once()
-        mock_timer.assert_called_once_with(0.5, runtime._kill)
+        runtime._subprocess.send_signal.assert_called_once_with(signal.SIGKILL)
 
     def test_kill__sends_sigkill(self) -> None:
         """Test that _kill() sends SIGKILL if the process is still running."""

--- a/ulauncher/api/shared/event.py
+++ b/ulauncher/api/shared/event.py
@@ -81,8 +81,9 @@ class UnloadEvent(BaseEvent):
     """
     Is triggered when an extension is about to be unloaded (terminated).
 
-    The extension has 300ms to handle this event and shut down properly.
-    After that it will be terminated with SIGKILL
+    The extension is terminated immediately, so this event is best-effort:
+    on_unload is not guaranteed to run to completion. Do not rely on it for
+    critical cleanup.
     """
 
 

--- a/ulauncher/cli/commands/install.py
+++ b/ulauncher/cli/commands/install.py
@@ -1,4 +1,3 @@
-import asyncio
 import logging
 
 from ulauncher.cli import CLIArguments
@@ -13,7 +12,7 @@ def run(args: CLIArguments) -> int:
     # registry.install is idempotent and will also upgrade to latest (if installed) or shadow non-manageable.
     url = normalize_ext_arg(args.input)
     try:
-        record = asyncio.run(get_ext_registry().install(url))
+        record = get_ext_registry().install(url)
         dbus_trigger_event("extensions:reload", [record.id])
     except (ValueError, ext_exceptions.UrlError):  # error already logged
         return 1

--- a/ulauncher/cli/commands/install.py
+++ b/ulauncher/cli/commands/install.py
@@ -3,7 +3,6 @@ import logging
 from ulauncher.cli import CLIArguments
 from ulauncher.cli.commands import get_ext_registry, normalize_ext_arg
 from ulauncher.modes.extensions import ext_exceptions
-from ulauncher.utils.dbus import dbus_trigger_event
 
 logger = logging.getLogger(__name__)
 
@@ -12,8 +11,7 @@ def run(args: CLIArguments) -> int:
     # registry.install is idempotent and will also upgrade to latest (if installed) or shadow non-manageable.
     url = normalize_ext_arg(args.input)
     try:
-        record = get_ext_registry().install(url)
-        dbus_trigger_event("extensions:reload", [record.id])
+        get_ext_registry().install(url)
     except (ValueError, ext_exceptions.UrlError):  # error already logged
         return 1
     except (ext_exceptions.NetworkError, ext_exceptions.RemoteError):

--- a/ulauncher/cli/commands/uninstall.py
+++ b/ulauncher/cli/commands/uninstall.py
@@ -1,4 +1,3 @@
-import asyncio
 import logging
 
 from ulauncher.cli import CLIArguments
@@ -14,7 +13,7 @@ def run(args: CLIArguments) -> int:
             logger.error("Extension %s is externally managed and can not be uninstalled (%s)", record.id, record.path)
             return 1
         try:
-            asyncio.run(get_ext_registry().uninstall(record))
+            get_ext_registry().uninstall(record)
         except OSError:
             logger.error("Could not uninstall %s", record.id)  # noqa: TRY400 - traceback is noise here
             return 1

--- a/ulauncher/cli/commands/uninstall.py
+++ b/ulauncher/cli/commands/uninstall.py
@@ -2,7 +2,6 @@ import logging
 
 from ulauncher.cli import CLIArguments
 from ulauncher.cli.commands import get_ext_record, get_ext_registry
-from ulauncher.utils.dbus import dbus_trigger_event
 
 logger = logging.getLogger(__name__)
 
@@ -17,7 +16,6 @@ def run(args: CLIArguments) -> int:
         except OSError:
             logger.error("Could not uninstall %s", record.id)  # noqa: TRY400 - traceback is noise here
             return 1
-        dbus_trigger_event("extensions:stop", [record.id])
         return 0
 
     logger.error("Error: Argument '%s' does not match any installed extension", args.input)

--- a/ulauncher/cli/commands/upgrade.py
+++ b/ulauncher/cli/commands/upgrade.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import asyncio
 import logging
 
 from ulauncher.cli import CLIArguments
@@ -24,7 +23,7 @@ def _log_url_error(ext_id: str, url: str, *, fatal: bool) -> None:
         log("Could not upgrade %s: invalid URL '%s'", ext_id, url)
 
 
-async def _upgrade_all_extensions() -> list[str]:
+def _upgrade_all_extensions() -> list[str]:
     updated_extensions: list[str] = []
     registry = get_ext_registry()
 
@@ -33,7 +32,7 @@ async def _upgrade_all_extensions() -> list[str]:
             continue
 
         try:
-            updated = await registry.update(record)
+            updated = registry.update(record)
             if updated:
                 updated_extensions.append(record.id)
         except ext_exceptions.UrlError:
@@ -52,7 +51,7 @@ def upgrade_one(record: ExtensionRecord) -> bool:
         logger.error("Extension %s is externally managed and can not be upgraded (%s)", record.id, record.path)
         return False
     try:
-        updated = asyncio.run(get_ext_registry().update(record))
+        updated = get_ext_registry().update(record)
     except ext_exceptions.UrlError:
         _log_url_error(record.id, record.state.url, fatal=True)
         return False
@@ -74,7 +73,7 @@ def run(args: CLIArguments) -> int:
         logger.error("Error: Argument '%s' does not match any installed extension", args.input)
         return 1
 
-    updated_extensions = asyncio.run(_upgrade_all_extensions())
+    updated_extensions = _upgrade_all_extensions()
     if updated_extensions:
         dbus_trigger_event("extensions:reload", updated_extensions)
 

--- a/ulauncher/cli/commands/upgrade.py
+++ b/ulauncher/cli/commands/upgrade.py
@@ -6,7 +6,6 @@ from ulauncher.cli import CLIArguments
 from ulauncher.cli.commands import get_ext_record, get_ext_registry
 from ulauncher.modes.extensions import ext_exceptions
 from ulauncher.modes.extensions.extension_record import ExtensionRecord
-from ulauncher.utils.dbus import dbus_trigger_event
 
 logger = logging.getLogger(__name__)
 
@@ -51,7 +50,7 @@ def upgrade_one(record: ExtensionRecord) -> bool:
         logger.error("Extension %s is externally managed and can not be upgraded (%s)", record.id, record.path)
         return False
     try:
-        updated = get_ext_registry().update(record)
+        get_ext_registry().update(record)
     except ext_exceptions.UrlError:
         _log_url_error(record.id, record.state.url, fatal=True)
         return False
@@ -61,8 +60,6 @@ def upgrade_one(record: ExtensionRecord) -> bool:
     except (ext_exceptions.ExtensionError, OSError):
         logger.error("Could not upgrade %s", record.id)  # noqa: TRY400 - already logged in update()
         return False
-    if updated:
-        dbus_trigger_event("extensions:reload", [record.id])
     return True
 
 
@@ -74,8 +71,5 @@ def run(args: CLIArguments) -> int:
         return 1
 
     updated_extensions = _upgrade_all_extensions()
-    if updated_extensions:
-        dbus_trigger_event("extensions:reload", updated_extensions)
-
     logger.info("\n%s extensions updated", len(updated_extensions))
     return 0

--- a/ulauncher/modes/extensions/extension_mode.py
+++ b/ulauncher/modes/extensions/extension_mode.py
@@ -35,8 +35,8 @@ class ExtensionLaunchTrigger(Result):
 class ExtensionMode(Mode):
     """Mode that handles extension triggers and communication with extensions.
 
-    Acts as the service's ExtensionServiceListener: the service calls started, errored,
-    invalidate_cache and handle_message directly."""
+    Acts as the service's ExtensionServiceListener: the service calls started, errored
+    and handle_message directly."""
 
     _active_ext: ExtensionRecord | None = None
     _trigger_cache: dict[str, tuple[str, str]]  # keyword: (trigger_id, ext_id)
@@ -50,9 +50,6 @@ class ExtensionMode(Mode):
 
     def has_trigger_changes(self) -> bool:
         return not self._trigger_cache
-
-    def invalidate_cache(self) -> None:
-        self._trigger_cache.clear()
 
     def errored(self, ext_id: str) -> None:
         if not self._active_ext or self._active_ext.id != ext_id:
@@ -85,12 +82,14 @@ class ExtensionMode(Mode):
 
         self._active_ext = ext
         if not ext_service.is_running(ext):
-            # Transitioning (restart/preview/update/startup): wait for it to come up. Returning
-            # without a result lets core show "Loading..." after PLACEHOLDER_DELAY, and `started`
-            # re-runs the query once the extension is ready. The wait ends with a failure message if
-            # the extension exits with an error, otherwise empty after LOADING_TIMEOUT.
+            # Start on demand and wait for it to come up (it may also already be transitioning, e.g.
+            # a reload or update). Returning without a result lets core show "Loading..." after
+            # PLACEHOLDER_DELAY, and `started` re-runs the query once the extension is ready. The
+            # wait ends with a failure message if the extension exits with an error, otherwise empty
+            # after LOADING_TIMEOUT.
             self._pending_callback = callback
             self._loading_timer = scheduling.timer(LOADING_TIMEOUT, self._finish_loading)
+            ext_service.start_extension(ext)
             return
 
         event: ipc.InputTriggerEvent = {
@@ -203,8 +202,8 @@ class ExtensionMode(Mode):
             logger.error("No active extension to send request to")
             return
 
-        if not ext_service.is_running(self._active_ext):
-            logger.warning("Cannot send event to inactive extension %s", self._active_ext.id)
+        if not ext_service.is_running(self._active_ext) and not ext_service.start_extension(self._active_ext):
+            logger.warning("Could not start extension %s to handle event", self._active_ext.id)
             return
 
         self._request_id += 1

--- a/ulauncher/modes/extensions/extension_registry.py
+++ b/ulauncher/modes/extensions/extension_registry.py
@@ -18,13 +18,11 @@ logger = logging.getLogger(__name__)
 def _run_gio_blocking(start: Callable[[Callable[[Any], None], Callable[[Exception], None]], None]) -> Any:
     """Drive a callback-based Gio operation to completion synchronously on the calling thread.
 
-    Temporary bridge for step one of the asyncio/threading removal: extension_remote is now
-    callback-based, but the registry's install/update flows are still async and run in worker
-    threads (ext_handlers) or the CLI's asyncio loop. Gio.Subprocess callbacks dispatch on a GLib
-    main context, not the asyncio loop, and no GLib loop runs in those threads, so a plain
-    asyncio.Future shim would never resolve. Running a private GLib main loop (pushed as the
-    thread-default context) drives the operation to completion. Remove this when the registry
-    becomes callback-native.
+    The registry's install/update flows run either in a worker thread (the preferences UI's
+    ExtensionHandlers) or on the CLI's main thread, neither of which runs a GLib main loop.
+    Gio.Subprocess callbacks dispatch on a GLib main context, so without a running loop they would
+    never fire. A private GLib main loop (pushed as the thread-default context) drives the operation
+    to completion. Remove this once these call paths run on the main GLib loop.
     """
     context = GLib.MainContext.new()
     context.push_thread_default()
@@ -94,7 +92,7 @@ class ExtensionLifecycle(Protocol):
 
     def start_extension(self, record: ExtensionRecord) -> bool: ...
 
-    async def stop_extension(self, record: ExtensionRecord) -> None: ...
+    def stop_extension(self, record: ExtensionRecord) -> None: ...
 
 
 class _NoLifecycle:
@@ -104,7 +102,7 @@ class _NoLifecycle:
     def start_extension(self, _record: ExtensionRecord) -> bool:
         return False
 
-    async def stop_extension(self, _record: ExtensionRecord) -> None: ...
+    def stop_extension(self, _record: ExtensionRecord) -> None: ...
 
 
 class ExtensionRegistry:
@@ -148,20 +146,20 @@ class ExtensionRegistry:
 
         yield from sorted(records.values(), key=sort_key)
 
-    async def install(self, url: str, commit_hash: str | None = None) -> ExtensionRecord:
+    def install(self, url: str, commit_hash: str | None = None) -> ExtensionRecord:
         logger.info("Installing extension: %s", url)
         remote = ExtensionRemote(url)
-        if Path(remote.target_dir).exists():  # noqa: ASYNC240
+        if Path(remote.target_dir).exists():
             logger.info('Extension with URL "%s" is already installed. Updating', remote.url)
 
         record = ExtensionRecord(remote.ext_id, remote.target_dir)
-        await self._install_from_remote(record, remote, commit_hash, url=url)
+        self._install_from_remote(record, remote, commit_hash, url=url)
         logger.info("Extension %s installed successfully", record.id)
         return record
 
-    async def uninstall(self, record: ExtensionRecord) -> None:
+    def uninstall(self, record: ExtensionRecord) -> None:
         if record.is_manageable:
-            await self._lifecycle.stop_extension(record)
+            self._lifecycle.stop_extension(record)
         if not record.remove():
             return
         # A still-locatable extension after removal is a non-manageable copy (e.g. distro-packaged).
@@ -176,12 +174,12 @@ class ExtensionRegistry:
                 fallback_path,
             )
 
-    async def update(self, record: ExtensionRecord) -> bool:
+    def update(self, record: ExtensionRecord) -> bool:
         """
         :returns: False if already up-to-date, True if was updated
         """
         logger.debug("Checking for updates to %s", record.id)
-        has_update, commit_hash = await self.check_update(record)
+        has_update, commit_hash = self.check_update(record)
         if not has_update:
             logger.info('Extension "%s" is already on the latest version', record.id)
             return False
@@ -194,14 +192,14 @@ class ExtensionRegistry:
         )
 
         try:
-            await self._install_from_remote(record, ExtensionRemote(record.state.url), commit_hash)
+            self._install_from_remote(record, ExtensionRemote(record.state.url), commit_hash)
         except (ext_exceptions.ExtensionError, OSError):
             logger.exception("Could not update extension '%s'", record.id)
             raise
         logger.info("Successfully updated extension: %s", record.id)
         return True
 
-    async def check_update(self, record: ExtensionRecord) -> tuple[bool, str]:
+    def check_update(self, record: ExtensionRecord) -> tuple[bool, str]:
         """
         Returns tuple with commit info about a new version
         """
@@ -209,7 +207,7 @@ class ExtensionRegistry:
         has_update = record.state.commit_hash != commit_hash
         return has_update, commit_hash
 
-    async def _install_from_remote(
+    def _install_from_remote(
         self, record: ExtensionRecord, remote: ExtensionRemote, commit_hash: str | None, **extra_state: Any
     ) -> None:
         """Install (atomically): download, stop, swap and restart (if previously running).
@@ -221,7 +219,7 @@ class ExtensionRegistry:
         # Concurrent installs of the same id clobber each other (wouldn't have worked anyway).
         staging_dir = str(Path(paths.EXTENSIONS_STAGING) / record.id)
         rmtree(staging_dir, ignore_errors=True)
-        Path(staging_dir).mkdir(parents=True)  # noqa: ASYNC240
+        Path(staging_dir).mkdir(parents=True)
         remote.target_dir = staging_dir
         was_running = False
 
@@ -238,7 +236,7 @@ class ExtensionRegistry:
 
             was_running = self._lifecycle.is_running(record)
             if _should_restart():
-                await self._lifecycle.stop_extension(record)
+                self._lifecycle.stop_extension(record)
             if not _swap_dir(staging_dir, target_path):
                 msg = f"Failed to swap the staged extension into {target_path}"
                 raise OSError(msg)

--- a/ulauncher/modes/extensions/extension_registry.py
+++ b/ulauncher/modes/extensions/extension_registry.py
@@ -210,7 +210,10 @@ class ExtensionRegistry:
     def _install_from_remote(
         self, record: ExtensionRecord, remote: ExtensionRemote, commit_hash: str | None, **extra_state: Any
     ) -> None:
-        """Install (atomically): download, stop, swap and restart (if previously running).
+        """Install (atomically): download, then swap into place.
+
+        A running instance is left alone: it keeps serving from the code it already loaded until the
+        launcher window next closes and stops it, after which the next query starts the new version.
 
         `extra_state` is merged into the saved state (install records the source url; update adds nothing).
         """
@@ -221,12 +224,6 @@ class ExtensionRegistry:
         rmtree(staging_dir, ignore_errors=True)
         Path(staging_dir).mkdir(parents=True)
         remote.target_dir = staging_dir
-        was_running = False
-
-        def _should_restart() -> bool:
-            # a preview extension need not and should not be restarted (runs from dev path)
-            is_previewed = self.preview is not None and self.preview.id == record.id
-            return was_running and not is_previewed
 
         try:
             downloaded_hash, commit_timestamp = _run_gio_blocking(
@@ -234,9 +231,6 @@ class ExtensionRegistry:
             )
             _run_gio_blocking(ExtensionDependencies(remote.ext_id, staging_dir).install)
 
-            was_running = self._lifecycle.is_running(record)
-            if _should_restart():
-                self._lifecycle.stop_extension(record)
             if not _swap_dir(staging_dir, target_path):
                 msg = f"Failed to swap the staged extension into {target_path}"
                 raise OSError(msg)
@@ -245,5 +239,3 @@ class ExtensionRegistry:
             )
         finally:
             rmtree(staging_dir, ignore_errors=True)
-            if _should_restart():
-                self._lifecycle.start_extension(record)

--- a/ulauncher/modes/extensions/extension_runtime.py
+++ b/ulauncher/modes/extensions/extension_runtime.py
@@ -10,7 +10,6 @@ from weakref import WeakSet
 
 from ulauncher.gi import Gio, GLib
 from ulauncher.internals import ipc
-from ulauncher.utils import scheduling
 from ulauncher.utils.socket_msg_controller import SocketMsgController
 
 DEBUGPY_HOST = "127.0.0.1"
@@ -105,8 +104,7 @@ class ExtensionRuntime:
         aborted_subprocesses.add(self._subprocess)
 
         self._msg_controller.close()
-        # wait for graceful shutdown before forcibly killing
-        scheduling.timer(0.5, self._kill)
+        self._kill()
 
     def _kill(self) -> None:
         if self._subprocess.get_identifier():

--- a/ulauncher/modes/extensions/extension_service.py
+++ b/ulauncher/modes/extensions/extension_service.py
@@ -12,7 +12,6 @@ from ulauncher.modes.extensions.extension_dependencies import ExtensionDependenc
 from ulauncher.modes.extensions.extension_record import ExtensionRecord, PreviewExtensionRecord
 from ulauncher.modes.extensions.extension_registry import ExtensionRegistry
 from ulauncher.modes.extensions.extension_runtime import DEBUGPY_HOST, DEBUGPY_PORT, ExtensionRuntime
-from ulauncher.utils import scheduling
 from ulauncher.utils.eventbus import EventBus
 
 if TYPE_CHECKING:
@@ -29,8 +28,6 @@ class ExtensionServiceListener(Protocol):
     def started(self, ext_id: str) -> None: ...
 
     def errored(self, ext_id: str) -> None: ...
-
-    def invalidate_cache(self) -> None: ...
 
     def handle_message(self, ext_id: str, message: ipc.ExtensionMessage) -> None: ...
 
@@ -54,16 +51,10 @@ class ExtensionService(ExtensionRegistry):
 
     def activate(self, listener: ExtensionServiceListener) -> None:
         """
-        Set the listener that lifecycle events report to, and start the enabled extensions.
+        Set the listener that lifecycle events report to.
         Called by ExtensionMode when the app loads its modes.
         """
         self.listener = listener
-        scheduling.run_when_idle(self._start_extensions)
-
-    def _start_extensions(self) -> None:
-        for ext in self.iterate():
-            if ext.state.is_enabled:
-                self.start_extension(ext)
 
     def _run_batch_job(
         self,
@@ -107,9 +98,6 @@ class ExtensionService(ExtensionRegistry):
             return True  # if already started, count as successful
 
         def exit_handler(cause: str, error_msg: str) -> None:
-            if listener := self.listener:
-                listener.invalidate_cache()
-
             if cause != "Stopped":
                 logger.error('Extension "%s" exited with an error: %s (%s)', record.id, error_msg, cause)
                 self.runtimes.pop(record.id, None)
@@ -166,15 +154,13 @@ class ExtensionService(ExtensionRegistry):
 
         # socketpair/spawnv can fail for host-environment reasons (fd exhaustion, fork limits,
         # missing interpreter). Route these through exit_handler like a crash so the error is
-        # surfaced consistently and any queued start listeners get cleaned up, rather than
-        # raising out into callers.
+        # surfaced consistently, rather than raising out into callers.
         try:
             self.runtimes[record.id] = ExtensionRuntime(record.id, cmd, env, exit_handler, message_handler)
         except (OSError, GLib.Error) as err:
             exit_handler("FailedToStart", str(err))
             return False
         if listener := self.listener:
-            listener.invalidate_cache()
             listener.started(record.id)
         return self.is_running(record)
 
@@ -234,44 +220,48 @@ class ExtensionService(ExtensionRegistry):
         )
 
     @events.on
+    def stop_all(self) -> None:
+        """Stop all running extensions when the launcher window closes. Previews are kept running."""
+        for ext in self.iterate():
+            if self.is_running(ext) and not ext.is_preview:
+                self.stop_extension(ext)
+
+    @events.on
     def preview_ext(self, ext_id: str, path: str, with_debugger: bool = False) -> None:
         """Run an extension from a dev path WITHOUT installing it. Triggered from the CLI via D-Bus.
 
         While the preview is active, the record with this id launches from the dev path; its
-        dependencies are installed by the CLI before this is called.
+        dependencies are installed by the CLI before this is called. The extension itself starts on
+        demand when its keyword is matched.
         """
 
         logger.info("[preview] Previewing ext_id=%s path=%s debugger=%s", ext_id, path, with_debugger)
         self.preview = PreviewExtensionRecord(ext_id, path, with_debugger=with_debugger)
 
-        # Guard the restart against a stop_preview that races in during the stop: only relaunch if
-        # this preview is still the active one, otherwise stop_preview owns restoring the extension.
-        def start_if_still_previewing() -> None:
-            if self.preview and self.preview.id == ext_id:
-                self._run_batch_job([ext_id], ["start"])
+        # Stop a still-running installed instance so the next on-demand start launches from the dev path.
+        if self.is_running(self.preview):
+            self.stop_extension(self.preview)
 
-        # Relaunch from the dev path, stopping any conflicting installed instances
-        self._run_batch_job([ext_id], ["stop"], callback=start_if_still_previewing)
+        # With the debugger, start now so debugpy is listening for the IDE to attach before the first
+        # query, instead of the port only opening once the extension is triggered.
+        if with_debugger and not self.start_extension(self.preview):
+            logger.error("[preview] Could not start preview extension '%s' with the debugger", ext_id)
 
     @events.on
     def stop_preview(self) -> None:
-        """Stop the active preview and restore the installed extension. Triggered from the CLI via D-Bus"""
+        """Stop the active preview. Triggered from the CLI via D-Bus.
+
+        The installed extension (if any) restarts on demand from its installed path.
+        """
         if not self.preview:
             # will happen if preview is interrupted before started
             logger.debug("[preview] Ignoring stop_preview; no preview active")
             return
 
-        ext_id = self.preview.id
-        logger.info("[preview] Stopping preview %s", ext_id)
-
-        def restore_original() -> None:
-            self.preview = None
-            # Reload from the installed path, or drop the record if the extension was never installed.
-            record = self.get(ext_id)
-            if record and record.is_enabled:
-                self._run_batch_job([ext_id], ["start"])
-
-        self._run_batch_job([ext_id], ["stop"], callback=restore_original)
+        logger.info("[preview] Stopping preview %s", self.preview.id)
+        if self.is_running(self.preview):
+            self.stop_extension(self.preview)
+        self.preview = None
 
 
 ext_service = ExtensionService()

--- a/ulauncher/modes/extensions/extension_service.py
+++ b/ulauncher/modes/extensions/extension_service.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import json
 import logging
 import sys
-from typing import TYPE_CHECKING, Any, Callable, Literal, Protocol
+from typing import TYPE_CHECKING, Any, Protocol
 
 from ulauncher import cli, paths
 from ulauncher.gi import GLib
@@ -36,8 +36,9 @@ class ExtensionService(ExtensionRegistry):
     """The app's ExtensionRegistry: also owns the extension processes and handles lifecycle intents.
 
     Extensions only run in the app process, so only app code uses the service. The CLI does its
-    disk work with a plain ExtensionRegistry and asks the app to reconcile the processes via
-    D-Bus events ("extensions:reload", "extensions:stop", ...).
+    disk work with a plain ExtensionRegistry; extensions start on demand when queried and stop
+    when the launcher window closes, so a CLI install/upgrade needs no process reconciliation
+    (only the preview flow reaches the app, via "extensions:preview_ext"/"extensions:stop_preview").
     """
 
     runtimes: dict[str, ExtensionRuntime]
@@ -56,38 +57,11 @@ class ExtensionService(ExtensionRegistry):
         """
         self.listener = listener
 
-    def _run_batch_job(
-        self,
-        extension_ids: list[str],
-        jobs: list[Literal["start", "stop"]],
-        callback: Callable[[], None] | None = None,
-    ) -> None:
-        records: list[ExtensionRecord] = []
-        for ext_id in extension_ids:
-            if ext := self.get(ext_id):
-                records.append(ext)  # noqa: PERF401
-
-        for job in jobs:
-            if job == "start":
-                for record in records:
-                    if record.is_enabled:
-                        self.start_extension(record)
-            elif job == "stop":
-                for record in records:
-                    self.stop_extension(record)
-
-        if callback:
-            callback()
-
     def is_running(self, record: ExtensionRecord) -> bool:
         return record.id in self.runtimes
 
-    def toggle_enabled(self, record: ExtensionRecord, enabled: bool) -> bool:
+    def toggle_enabled(self, record: ExtensionRecord, enabled: bool) -> None:
         record.state.save(is_enabled=enabled, error_type="", error_message="")
-        if enabled:
-            return self.start_extension(record)
-        self.stop_extension(record)
-        return False
 
     def start_extension(self, record: ExtensionRecord) -> bool:
         """
@@ -189,35 +163,6 @@ class ExtensionService(ExtensionRegistry):
                     "args": (p_id, new_value, old_preferences[p_id]),
                 }
                 self.send_message(record, event_data)
-
-    @events.on
-    def reload(
-        self,
-        extension_ids: list[str] | None = None,
-    ) -> None:
-        if not extension_ids:
-            logger.warning("Reload message received without any extension IDs. No extensions will be restarted.")
-            return
-
-        logger.info("Reloading extension(s): %s", ", ".join(extension_ids))
-
-        self._run_batch_job(
-            extension_ids,
-            ["stop", "start"],
-            callback=lambda: logger.info("%s extensions (re)loaded", len(extension_ids)),
-        )
-
-    @events.on
-    def stop(self, extension_ids: list[str] | None = None) -> None:
-        if not extension_ids:
-            logger.warning("Stop message received without any extension IDs. No extensions will be stopped.")
-            return
-
-        logger.info("Stopping extension(s): %s", ", ".join(extension_ids))
-
-        self._run_batch_job(
-            extension_ids, ["stop"], callback=lambda: logger.info("%s extensions stopped", len(extension_ids))
-        )
 
     @events.on
     def stop_all(self) -> None:

--- a/ulauncher/modes/extensions/extension_service.py
+++ b/ulauncher/modes/extensions/extension_service.py
@@ -1,11 +1,8 @@
 from __future__ import annotations
 
-import asyncio
 import json
 import logging
 import sys
-from collections import defaultdict
-from threading import Thread
 from typing import TYPE_CHECKING, Any, Callable, Literal, Protocol
 
 from ulauncher import cli, paths
@@ -47,13 +44,11 @@ class ExtensionService(ExtensionRegistry):
     """
 
     runtimes: dict[str, ExtensionRuntime]
-    stopped_listeners: dict[str, list[Callable[[], None]]]
     listener: ExtensionServiceListener | None
 
     def __init__(self) -> None:
         super().__init__(lifecycle=self)
         self.runtimes = {}
-        self.stopped_listeners = defaultdict(list)
         self.listener = None
         events.set_self(self)
 
@@ -81,31 +76,26 @@ class ExtensionService(ExtensionRegistry):
             if ext := self.get(ext_id):
                 records.append(ext)  # noqa: PERF401
 
-        # run the reload in a separate thread to avoid blocking the main thread
-        async def run_batch_async() -> None:
-            for job in jobs:
-                if job == "start":
-                    for record in records:
-                        if record.is_enabled:
-                            self.start_extension(record)
-                elif job == "stop":
-                    await asyncio.gather(*[self.stop_extension(record) for record in records])
+        for job in jobs:
+            if job == "start":
+                for record in records:
+                    if record.is_enabled:
+                        self.start_extension(record)
+            elif job == "stop":
+                for record in records:
+                    self.stop_extension(record)
 
-        def run_batch() -> None:
-            asyncio.run(run_batch_async())
-            if callback:
-                callback()
-
-        Thread(target=run_batch).start()
+        if callback:
+            callback()
 
     def is_running(self, record: ExtensionRecord) -> bool:
         return record.id in self.runtimes
 
-    async def toggle_enabled(self, record: ExtensionRecord, enabled: bool) -> bool:
+    def toggle_enabled(self, record: ExtensionRecord, enabled: bool) -> bool:
         record.state.save(is_enabled=enabled, error_type="", error_message="")
         if enabled:
             return self.start_extension(record)
-        await self.stop_extension(record)
+        self.stop_extension(record)
         return False
 
     def start_extension(self, record: ExtensionRecord) -> bool:
@@ -117,12 +107,6 @@ class ExtensionService(ExtensionRegistry):
             return True  # if already started, count as successful
 
         def exit_handler(cause: str, error_msg: str) -> None:
-            listeners = self.stopped_listeners.get(record.id, [])
-            for stop_listener in listeners:
-                stop_listener()
-
-            listeners.clear()
-
             if listener := self.listener:
                 listener.invalidate_cache()
 
@@ -194,14 +178,10 @@ class ExtensionService(ExtensionRegistry):
             listener.started(record.id)
         return self.is_running(record)
 
-    async def stop_extension(self, record: ExtensionRecord) -> None:
+    def stop_extension(self, record: ExtensionRecord) -> None:
         """Stops the extension process if it is running."""
         if runtime := self.runtimes.pop(record.id, None):
-            stopped_future: asyncio.Future[None] = asyncio.Future()
-            self.stopped_listeners[record.id].append(lambda: stopped_future.set_result(None))
             runtime.stop()
-
-            await asyncio.wait_for(stopped_future, timeout=5.0)
 
     def send_message(self, record: ExtensionRecord, message: ipc.Event, request_id: int | None = None) -> None:
         """

--- a/ulauncher/ui/app.py
+++ b/ulauncher/ui/app.py
@@ -222,15 +222,6 @@ class UlauncherApp(Gtk.Application):
 
     @events.on
     def show_preferences(self, page: str | None = None) -> None:
-        # It's technically possible to trigger this GAction before the app has started,
-        # in which case we would have to start all the modes + extensions just for the preferences
-        # or it would be broken in several ways (runtime status, start, install, preferences event)
-        # and the cli would send dbus messages to the preferences (would break `ulauncher preview`)
-        if not self._persistent and not self.windows:
-            logger.error("You have to start Ulauncher before you can open preferences.")
-            self.quit()
-            return
-
         # Register prefs in self.windows before closing main, so the main destroy handler
         # sees a remaining window and doesn't quit the app on non-persistent setups.
         from ulauncher.ui.preferences.preferences_window import PreferencesWindow

--- a/ulauncher/ui/app.py
+++ b/ulauncher/ui/app.py
@@ -131,7 +131,7 @@ class UlauncherApp(Gtk.Application):
             # Sync additional hold with user settings
             self.hold()
 
-            # Warm the modes so extension handlers register and enabled extensions start.
+            # Warm the modes so extension handlers register and the extension registry loads.
             # Skip if a window exists - it needs to control when this runs for startup performance reasons.
             def _warm_triggers() -> None:
                 if "main" not in self.windows:

--- a/ulauncher/ui/preferences/utils/ext_handlers.py
+++ b/ulauncher/ui/preferences/utils/ext_handlers.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import asyncio
 import logging
 import threading
 from typing import Callable
@@ -99,7 +98,7 @@ class ExtensionHandlers:
 
         def install_async() -> None:
             try:
-                ext = asyncio.run(ext_service.install(url))
+                ext = ext_service.install(url)
                 ext_service.start_extension(ext)
 
                 # Update UI in main thread
@@ -109,7 +108,7 @@ class ExtensionHandlers:
 
                 run_when_idle(update_ui)
 
-            except (ext_exceptions.ExtensionError, ValueError, OSError, asyncio.CancelledError) as error:
+            except (ext_exceptions.ExtensionError, ValueError, OSError) as error:
 
                 def show_error(error: BaseException) -> None:
                     progress_dialog.destroy()
@@ -127,9 +126,9 @@ class ExtensionHandlers:
 
         def toggle_async() -> None:
             try:
-                asyncio.run(ext_service.toggle_enabled(ext, state))
+                ext_service.toggle_enabled(ext, state)
 
-            except (ext_exceptions.ExtensionError, OSError, asyncio.CancelledError):
+            except (ext_exceptions.ExtensionError, OSError):
                 failed_action = "enable" if state else "disable"
                 error_msg = f"Failed to {failed_action} extension"
                 run_when_idle(self.dialog_launcher.show_error, error_msg, "Toggle operation failed")
@@ -152,7 +151,7 @@ class ExtensionHandlers:
 
             def remove_async() -> None:
                 try:
-                    asyncio.run(ext_service.uninstall(ext))
+                    ext_service.uninstall(ext)
 
                     def update_ui() -> None:
                         progress_dialog.destroy()
@@ -160,7 +159,7 @@ class ExtensionHandlers:
 
                     run_when_idle(update_ui)
 
-                except (ext_exceptions.ExtensionError, OSError, asyncio.CancelledError):
+                except (ext_exceptions.ExtensionError, OSError):
 
                     def show_error() -> None:
                         progress_dialog.destroy()
@@ -177,7 +176,7 @@ class ExtensionHandlers:
 
         def check_async() -> None:
             try:
-                has_update, commit_hash = asyncio.run(ext_service.check_update(ext))
+                has_update, commit_hash = ext_service.check_update(ext)
 
                 def update_ui() -> None:
                     if has_update:
@@ -190,7 +189,7 @@ class ExtensionHandlers:
 
                 run_when_idle(update_ui)
 
-            except (ext_exceptions.ExtensionError, OSError, asyncio.CancelledError) as e:
+            except (ext_exceptions.ExtensionError, OSError) as e:
                 callback()
                 run_when_idle(self.dialog_launcher.show_error, "Failed to check for updates", f"Error: {e!s}")
 
@@ -208,7 +207,7 @@ class ExtensionHandlers:
 
         def update_async() -> None:
             try:
-                asyncio.run(ext_service.update(ext))
+                ext_service.update(ext)
 
                 def update_ui() -> None:
                     callback()
@@ -220,7 +219,7 @@ class ExtensionHandlers:
 
                 run_when_idle(update_ui)
 
-            except (ext_exceptions.ExtensionError, OSError, asyncio.CancelledError) as e:
+            except (ext_exceptions.ExtensionError, OSError) as e:
                 callback()
 
                 def show_error(error: BaseException) -> None:

--- a/ulauncher/ui/preferences/utils/ext_handlers.py
+++ b/ulauncher/ui/preferences/utils/ext_handlers.py
@@ -99,7 +99,6 @@ class ExtensionHandlers:
         def install_async() -> None:
             try:
                 ext = ext_service.install(url)
-                ext_service.start_extension(ext)
 
                 # Update UI in main thread
                 def update_ui() -> None:

--- a/ulauncher/ui/preferences/utils/ext_utils.py
+++ b/ulauncher/ui/preferences/utils/ext_utils.py
@@ -5,9 +5,8 @@ import re
 from typing import Literal
 
 from ulauncher.modes.extensions.extension_record import ExtensionRecord
-from ulauncher.modes.extensions.extension_service import ext_service
 
-ExtStatus = Literal["on", "off", "error", "stopped", "preview"]
+ExtStatus = Literal["on", "off", "error", "preview"]
 
 
 def fmt_pango_code_block(text: str) -> str:
@@ -35,8 +34,6 @@ def get_status_str(ext: ExtensionRecord) -> ExtStatus:
         return "error"
     if not ext.is_enabled:
         return "off"
-    if not ext_service.is_running(ext):
-        return "stopped"
     if ext.is_preview:
         return "preview"
     return "on"

--- a/ulauncher/ui/preferences/views/extensions.py
+++ b/ulauncher/ui/preferences/views/extensions.py
@@ -70,10 +70,8 @@ class ExtensionsView(BaseView):
 
             self._load_extension_list()
 
-        # We need to reload extension state periodically to reflect changes
-        # - The initial runtime state is misleading/confusing "stopped" before they have started
-        # - If they are killed by task/oom killer
-        # - If they are installed or uninstalled by the CLI
+        # Reload periodically to reflect changes made outside this view, e.g. extensions installed
+        # or uninstalled via the CLI, or an extension entering an error state.
         reload_loop = scheduling.interval(REFRESH_INTERVAL, reload_extension_list)
 
     def _list_has_changes(self) -> bool:

--- a/ulauncher/ui/ulauncher_window.py
+++ b/ulauncher/ui/ulauncher_window.py
@@ -380,6 +380,7 @@ class UlauncherWindow(Gtk.ApplicationWindow):
             events.emit("app:set_query", "", update_input=False)
         if self.settings.grab_mouse_pointer:
             self.toggle_grab_pointer_device(False)
+        events.emit("extensions:stop_all")
         super().close()
         self.destroy()
 


### PR DESCRIPTION
See #1063

Update 2026: This is now a clean and fully working implementation. #1752 already moved a lot of things in the right direction.

This PR will wait to load the extension until the keyword is called, and then unloads it when the window is hidden. 

This avoid hogging ram and cpu needlessly. It also makes `ExtensionController` a lot less complex, because all methods are sync now.

The graceful timeout before killing is gone, but `UnloadEvent` is still present (it probably shouldn't be).

Removing reliance on the extension "running" state is also good, because that only works in the app runtime.

The log is now too noisy when closing an extension after closing the window:

```
2026-07-06 18:46:14,448 ℹ️  INFO modes.extensions.extension_runtime: Terminating extension "home.albin.src.personal.ulauncher-clipboard" stop:103
2026-07-06 18:46:14,449 ℹ️  INFO modes.extensions.extension_runtime: Extension home.albin.src.personal.ulauncher-clipboard connection closed socket_cleanup:65
2026-07-06 18:46:14,450 ℹ️  INFO modes.extensions.extension_runtime: Sending SIGKILL to extension home.albin.src.personal.ulauncher-clipboard _kill:111
2026-07-06 18:46:14,461 ℹ️  INFO modes.extensions.extension_runtime: Extension "home.albin.src.personal.ulauncher-clipboard" was stopped by the user handle_exit:149
```