### PR TITLE
Add support for extensions hosted with Gitea and Codeberg

### DIFF
--- a/preferences-src/src/components/pages/ExtensionConfig.vue
+++ b/preferences-src/src/components/pages/ExtensionConfig.vue
@@ -19,11 +19,11 @@
           @click="onDropdownClick"
           :text="(canSave && 'Save') || (canCheckUpdates && 'Check Updates') || 'Remove'"
         >
-          <b-dropdown-item @click="checkUpdates" v-if="canCheckUpdates && canSave">Check Updates</b-dropdown-item>
+          <b-dropdown-item @click="checkUpdates" v-if="canCheckUpdates && canSave">Check updates</b-dropdown-item>
           <b-dropdown-item @click="openRemoveModal">Remove</b-dropdown-item>
           <b-dropdown-divider v-if="extension.url"/>
-          <b-dropdown-item v-if="extension.url" @click="reportIssue">Report Issue</b-dropdown-item>
-          <b-dropdown-item v-if="extension.url" @click="openGithub">Open Github</b-dropdown-item>
+          <b-dropdown-item v-if="extension.url" @click="openRepo">Open repository</b-dropdown-item>
+          <b-dropdown-item v-if="extension.url" @click="reportIssue">Report issue</b-dropdown-item>
           <b-dropdown-item disabled v-if="extension.last_commit">
             <i class="fa fa-calendar fa-fw"></i>
             {{ lastCommitDate }}
@@ -227,9 +227,6 @@ export default {
       let date = new Date(isoDate)
       return `${date.getFullYear()}-${date.getMonth() + 1}-${date.getDate()}`
     },
-    githubProjectPath(githubUrl) {
-      return githubUrl.split('.com/')[1]
-    },
     onDropdownClick() {
       switch (true) {
         case this.canSave:
@@ -243,7 +240,7 @@ export default {
     reportIssue() {
       this.openUrl(`${this.extension.url}/issues`)
     },
-    openGithub() {
+    openRepo() {
       this.openUrl(this.extension.url)
     },
     save() {

--- a/preferences-src/src/components/pages/Extensions.vue
+++ b/preferences-src/src/components/pages/Extensions.vue
@@ -62,8 +62,8 @@
 
         <b-form @submit.prevent="onUrlSubmit">
           <b-form-input
-            class="github-url-input"
-            ref="githubUrl"
+            class="repo-url-input"
+            ref="repoUrl"
             type="text"
             placeholder="https://github.com/org-name/project-name"
           ></b-form-input>
@@ -163,7 +163,7 @@ export default {
       )
     },
     onAddExtFormShown() {
-      this.$nextTick(() => this.$refs.githubUrl.focus())
+      this.$nextTick(() => this.$refs.repoUrl.focus())
       this.addingExtensionError = null
     },
     addExtDialog() {
@@ -197,14 +197,14 @@ export default {
       }
     },
     onModalOk(e) {
-      let input = this.$refs.githubUrl.$el
+      let input = this.$refs.repoUrl.$el
       if (input.value) {
         this.addExtension(input)
       }
       return e.preventDefault()
     },
     onUrlSubmit() {
-      let input = this.$refs.githubUrl.$el
+      let input = this.$refs.repoUrl.$el
       if (input.value) {
         this.addExtension(input)
       }

--- a/preferences-src/src/components/widgets/ExtensionErrorExplanation.vue
+++ b/preferences-src/src/components/widgets/ExtensionErrorExplanation.vue
@@ -4,10 +4,11 @@
       <small>
         <p
           v-if="errorName === 'InvalidUrl'"
-        >The URL must look like this: https://github.com/userName/projectName</p>
+        >The URL should be a GitHub or Gitea-compatible extension repository link.
+        <br>Examples: https://github.com/user/repo or https://codeberg.org/user/repo</p>
         <p
           v-else-if="errorName === 'MissingVersionDeclaration'"
-        >This extension does not provide a version compatible with your Ulauncher version.</p>
+        >This repository does not provide a Ulauncher extension version declaration. It is probably not a Ulauncher extension</p>
         <p v-else-if="errorName === 'InvalidVersionDeclaration'">
           There's an error in versions.json:
           <br>
@@ -26,11 +27,11 @@
           </p>
           <p v-if="extUrl">
             Please make sure that you are running the latest version of Ulauncher app.
-            If problem persists, report this issue to the author of the extension via
+            If problem persists, report this issue on the
             <a
               href
               @click.prevent="openUrlInBrowser(`${extUrl}/issues`)"
-            >Github issues</a>.
+            >extension issue page</a>.
           </p>
         </div>
         <p
@@ -50,11 +51,11 @@
             <b>updating</b> the extension. If the doesn't help let
           </span>
           <span v-else>Let</span>
-          the author know about this problem via
+          the author know about this problem on the
           <a
             href
             @click.prevent="openUrlInBrowser(`${extUrl}/issues`)"
-          >Github issues</a>.
+          >extension issue page</a>.
         </p>
       </small>
     </b-alert>

--- a/preferences-src/src/components/widgets/ExtensionRuntimeError.vue
+++ b/preferences-src/src/components/widgets/ExtensionRuntimeError.vue
@@ -24,15 +24,15 @@
           <br />Try installing this module manually:
           <code>pip3 install {{ errorMessage }} --user</code> and then restart Ulauncher.
           <br />If that doesn't help, report the issue on
-          <a href @click.prevent="openUrlInBrowser(`${extUrl}/issues`)">Github</a>.
+          <a href @click.prevent="openUrlInBrowser(`${extUrl}/issues`)">extension issue tracker</a>.
         </p>
         <p v-else>{{ errorMessage }}</p>
         <p v-if="extUrl && errorName !== 'NoExtensionsFlag' && errorName !== 'MissingModule'">
-          You can let the author know about this problem by creating a
+          You can let the author know about this problem by creating an
           <a
             href
             @click.prevent="openUrlInBrowser(`${extUrl}/issues`)"
-          >Github issue</a>.
+          >issue</a>.
         </p>
       </small>
     </b-alert>

--- a/tests/modes/apps/extensions/test_ExtensionDownloader.py
+++ b/tests/modes/apps/extensions/test_ExtensionDownloader.py
@@ -25,16 +25,16 @@ class TestExtensionDownloader:
     @pytest.fixture(autouse=True)
     def gh_ext(self, mocker):
         gh_ext = mocker.patch('ulauncher.modes.extensions.ExtensionDownloader.ExtensionRemote').return_value
-        gh_ext.get_ext_id.return_value = 'com.github.ulauncher.ulauncher-timer'
-        gh_ext.get_download_url.return_value = 'https://github.com/Ulauncher/ulauncher-timer/tarball/master'
+        gh_ext.extension_id = 'com.github.ulauncher.ulauncher-timer'
+        gh_ext.get_download_url.return_value = 'https://github.com/Ulauncher/ulauncher-timer/archive/master.tar.gz'
         gh_ext.get_last_commit.return_value = {
             'last_commit': '64e106c',
             'last_commit_time': '2017-05-01T07:30:39'
         }
-        gh_ext.find_compatible_version.return_value = {
-            'sha': '64e106c',
-            'time': iso_to_datetime('2017-05-01T07:30:39Z')
-        }
+        gh_ext.find_compatible_version.return_value = (
+            '64e106c',
+            iso_to_datetime('2017-05-01T07:30:39Z')
+        )
 
         return gh_ext
 


### PR DESCRIPTION
Major rewrite to the extension remote class (previously very hard coded for GitHub)

It now written to be Gitea-compatible. GitHub is mostly Gitea-compatible as Gitea borrowed their APIs endpoints to begin with I believe.

It should now work with self hosted Gitea instances or Codeberg which uses Gitea (see #925).

Can be tested with: https://codeberg.org/Petrarca/ulauncher-ssh

Also managed to avoid hard coding the default branch or making a request with the "contents" API that both Gitea and GitHub supports rather than using the "raw" links. The result is a json object that has the file base64 encoded.

My original intent was just to clean things up to prepare for a PR like this, using a generic ExtensionRemore class and subclasses for each vendor. But these are so similar that that approach made no sense for this integration. GitLab's API on the other hand is completely different, and they also allow self-hosting so they can't be "detected" via the host parameter.

I'm not sure why ExtensionDownloader is separate from ExtensionRemote. Imo they should be the same class. ExtensionRemote is only used from ExtensionDownloader. And ExtensionDownloader is mostly just a wrapper around ExtensionRemote.