### PR TITLE
Handle extension download network issues

### DIFF
--- a/preferences-src/src/components/pages/Extensions.vue
+++ b/preferences-src/src/components/pages/Extensions.vue
@@ -55,6 +55,7 @@
         hide-header-close
         no-fade
         no-auto-focus
+        size="lg"
         @shown="onAddExtFormShown"
         @ok="onModalOk"
       >

--- a/preferences-src/src/components/widgets/ExtensionErrorExplanation.vue
+++ b/preferences-src/src/components/widgets/ExtensionErrorExplanation.vue
@@ -37,6 +37,17 @@
         <p
           v-else-if="errorName === 'AlreadyAdded'"
         >You've already installed this extension.</p>
+        <p
+          v-else-if="errorName === 'Network'"
+        >
+          A network error occurred: <b>{{ errorMessage }}</b>
+          <br><br>Please check that your network is ok, that the repository is not private, and that the extension has all the required files.
+          <br><br>You can also install extensions manually by adding them to 
+          <a
+            href
+            @click.prevent="openExtensionsDir()"
+          >your extension directory</a>.
+        </p>
         <p v-else>
           An unexpected error occurred.
           <br>Please copy the technical details and report this problem via
@@ -79,6 +90,9 @@ export default {
   methods: {
     openUrlInBrowser(url) {
       jsonp('prefs:///open/web-url', { url: url })
+    },
+    openExtensionsDir() {
+      jsonp('prefs:///open/extensions-dir')
     },
     alertVariant() {
       if (this.errorName === 'Other') {

--- a/ulauncher/api/shared/errors.py
+++ b/ulauncher/api/shared/errors.py
@@ -8,6 +8,7 @@ class ExtensionError(Enum):
     InvalidUrl = 'InvalidUrl'
     InvalidVersionDeclaration = 'InvalidVersionDeclaration'
     MissingVersionDeclaration = 'MissingVersionDeclaration'
+    Network = 'Network'
     Other = 'Other'
 
 

--- a/ulauncher/modes/extensions/ExtensionRemote.py
+++ b/ulauncher/modes/extensions/ExtensionRemote.py
@@ -128,12 +128,12 @@ class ExtensionRemote:
             return self.get_commit(branch_name)
         except URLError as e:
             if not versions:
-                raise ExtensionRemoteError("Could not access repository", ExtensionError.Other) from e
+                raise ExtensionRemoteError("Could not access repository", ExtensionError.Network) from e
             if getattr(e, "code") == 404:
                 message = f'Invalid branch "{branch_name}" in version declaration.'
                 raise ExtensionRemoteError(message, ExtensionError.InvalidVersionDeclaration) from e
             message = f'Could not fetch repository "{branch_name}".'
-            raise ExtensionRemoteError(message, ExtensionError.Other) from e
+            raise ExtensionRemoteError(message, ExtensionError.Network) from e
 
     def validate_versions(self, versions) -> bool:
         missing = ExtensionError.MissingVersionDeclaration

--- a/ulauncher/ui/windows/PreferencesWindow.py
+++ b/ulauncher/ui/windows/PreferencesWindow.py
@@ -312,6 +312,11 @@ class PreferencesWindow(Gtk.ApplicationWindow):
         logger.info('Open Web URL %s', url)
         OpenAction(url).run()
 
+    @rt.route('/open/extensions-dir')
+    def prefs_open_extensions_dir(self, _):
+        logger.info('Open extensions directory "%s" in default file manager.', EXTENSIONS_DIR)
+        OpenAction(EXTENSIONS_DIR).run()
+
     @rt.route('/shortcut/get-all')
     def prefs_shortcut_get_all(self, query):
         logger.info('Handling /shortcut/get-all')


### PR DESCRIPTION
Fixes #679 (see: https://github.com/Ulauncher/Ulauncher/issues/679#issuecomment-913100543)

Shows a more friendly error for network issues / invalid links.

As a fallback solution the user is shown a link that opens the extensions directory in their default file manager. Extensions installed manually to this folder can't get updated by ulauncher and their folders won't be named "safely" as unique "extension ids", so our deduplication code won't work either. But they load/run.

![Screenshot from 2022-05-03 08-27-08](https://user-images.githubusercontent.com/515120/166412347-1a6bd43c-3ec8-466b-9f46-0a6fb5866249.png)
