### PR TITLE
Preload extension preferences

### DIFF
--- a/docs/extensions/events.rst
+++ b/docs/extensions/events.rst
@@ -25,15 +25,6 @@ PreferencesUpdateEvent
   :members:
   :undoc-members:
 
-
-PreferencesEvent
-----------------
-
-.. autoclass:: ulauncher.api.shared.event.PreferencesEvent
-  :members:
-  :undoc-members:
-
-
 UnloadEvent
 ---------------
 

--- a/tests/api/client/test_Extension.py
+++ b/tests/api/client/test_Extension.py
@@ -14,6 +14,10 @@ class TestExtension:
     def response(self, mocker):
         return mocker.patch('ulauncher.api.extension.Response').return_value
 
+    @pytest.fixture(autouse=True)
+    def load_preferences(self, mocker):
+        return mocker.patch('ulauncher.api.extension.Extension.load_preferences', return_value={})
+
     @pytest.fixture
     def extension(self):
         return Extension()

--- a/ulauncher/modes/extensions/ExtensionController.py
+++ b/ulauncher/modes/extensions/ExtensionController.py
@@ -97,6 +97,7 @@ class ExtensionController:
         self.controllers[self.extension_id] = self
         self._debounced_send_event = debounce(self.manifest.get_option('query_debounce', 0.05))(self._send_event)
 
+        # Deprecated and candidate for future removal
         self._send_event(PreferencesEvent(self.preferences.get_dict()))
 
     # pylint: disable=unused-argument

--- a/ulauncher/modes/extensions/ExtensionRunner.py
+++ b/ulauncher/modes/extensions/ExtensionRunner.py
@@ -9,7 +9,7 @@ from time import time
 from enum import Enum
 from gi.repository import Gio, GLib
 
-from ulauncher.config import EXTENSIONS_DIR, ULAUNCHER_APP_DIR, get_options
+from ulauncher.config import EXTENSIONS_DIR, EXT_PREFERENCES_DIR, ULAUNCHER_APP_DIR, get_options
 from ulauncher.utils.mypy_extensions import TypedDict
 from ulauncher.utils.decorator.singleton import singleton
 from ulauncher.utils.timer import timer
@@ -92,6 +92,9 @@ class ExtensionRunner:
             return
 
         launcher = Gio.SubprocessLauncher.new(Gio.SubprocessFlags.STDERR_PIPE)
+
+        launcher.setenv("EXTENSION_DIR", extension_dir, True)
+        launcher.setenv("EXT_PREFERENCES_DIR", EXT_PREFERENCES_DIR, True)
         for env_name, env_value in env.items():
             launcher.setenv(env_name, env_value, True)
 


### PR DESCRIPTION
In v5, the way extension developers handle preferences being loaded initially was to subscribe to the `PreferencesEvent`. This PR adds a much better way (so we can remove this event in the future).

It's now done in the `Extension.__init__` method. This makes things less confusing for users, without multiple extension init events/methods, and without any state there the extension preferences are yet to be loaded

```py
class MyExtension(Extension):
    def __init__(self):
        super().__init__()
        value = self.preferences.get('my_preference_id')
```

Maybe the preferences dict should really be an argument to the extension, but we can't control how it's initiated.

The code could definitely be prettier, but it gets the job done. I wanted to avoid importing the ExtensionManifest and ExtensionPreferences classes, so I ended up duplicating what they do. But at least it's all limited to the `load_preferences()` method and less than 20 loc. And I did have to pass two environment variables, but I thought that was an better than importing modules from outside the api directory or sending the whole json object stringified as via a environment variable.

### Checklist
- [x] Verify that the test command `./ul test` is passing (the CI server will check this if you don't)
- [ ] Update the documentation according to your changes (when applicable)
- [ ] Write unit tests for your changes (when applicable)
