### PR TITLE
Add ulauncher-toggle query param to set up initial query.

### DIFF
--- a/bin/ulauncher-toggle
+++ b/bin/ulauncher-toggle
@@ -1,6 +1,28 @@
 #!/bin/sh
+QUERY={}
+
+# Parse optional parameters
+
+die() { echo "$*" >&2; exit 2; }  # complain to STDERR and exit with error
+needs_arg() { if [ -z "$OPTARG" ]; then die "No arg for --$OPT option"; fi; }
+
+while getopts q:-: OPT; do
+  # portable support long options: https://stackoverflow.com/a/28466267/519360
+  if [ "$OPT" = "-" ]; then   # long option: reformulate OPT and OPTARG
+    OPT="${OPTARG%%=*}"       # extract long option name
+    OPTARG="${OPTARG#$OPT}"   # extract long option argument (may be empty)
+    OPTARG="${OPTARG#=}"      # if long option argument, remove assigning `=`
+  fi
+  case "$OPT" in
+    q | query )  needs_arg; QUERY="{'query': <'$OPTARG'>}" ;;
+    ??* )          die "Illegal option --$OPT" ;;  # bad long option
+    ? )            exit 2 ;;  # bad short option (error reported via getopts)
+  esac
+done
+shift $((OPTIND-1)) # remove parsed options and args from $@ list
+
 gdbus call --session \
   --dest net.launchpad.ulauncher \
   --object-path /net/launchpad/ulauncher \
   --method org.gtk.Application.Activate \
-  {}
+  "$QUERY"

--- a/ulauncher/main.py
+++ b/ulauncher/main.py
@@ -39,10 +39,10 @@ class UlauncherApp(Gtk.Application):
         self.window.set_application(self)
         self.window.finish_initializing()
 
-    def do_before_emit(self, data ):
+    def do_before_emit(self, data):
         query = data.lookup_value("query",  GLib.VariantType("s"))
         if query:      
-           self.window.initial_query = query.unpack() + " "
+           self.window.initial_query = query.unpack()
 
     def do_activate(self, *args, **kwargs):
         self.window.show_window()

--- a/ulauncher/main.py
+++ b/ulauncher/main.py
@@ -39,6 +39,11 @@ class UlauncherApp(Gtk.Application):
         self.window.set_application(self)
         self.window.finish_initializing()
 
+    def do_before_emit(self, data ):
+        query = data.lookup_value("query",  GLib.VariantType("s"))
+        if query:      
+           self.window.initial_query = query.unpack() + " "
+
     def do_activate(self, *args, **kwargs):
         self.window.show_window()
 

--- a/ulauncher/ui/windows/UlauncherWindow.py
+++ b/ulauncher/ui/windows/UlauncherWindow.py
@@ -56,6 +56,7 @@ class UlauncherWindow(Gtk.ApplicationWindow):
     results_nav = None
     settings = Settings.get_instance()
     is_focused = False
+    initial_query = None
     _current_accel_name = None
     _css_provider = None
     _drag_start_coords = None
@@ -246,7 +247,11 @@ class UlauncherWindow(Gtk.ApplicationWindow):
         if IS_X11_COMPATIBLE:
             self.present_with_time(Keybinder.get_current_event_time())
 
-        if not self._get_input_text():
+        if self.initial_query:
+            self.input.set_text(self.initial_query)
+            self.input.set_position(len(self.initial_query))
+            self.initial_query=None
+        elif not self._get_input_text():
             # make sure frequent apps are shown if necessary
             self.show_results([])
         elif self.settings.get_property('clear-previous-query'):


### PR DESCRIPTION
This PR makes possible to pre set the query when calling `ulauncher-toggle` 
usage: 

`ulauncher-toggle` => Same  default behavior
`ulauncher-toggle -q some_query`
`ulauncher-toggle -q "some long query"`
`ulauncher-toggle --query=some_query`
`ulauncher-toggle --query="some long query"`


