### PR TITLE
Remove "download_missing" extension functionality

### DIFF
--- a/tests/ui/windows/test_UlauncherWindow.py
+++ b/tests/ui/windows/test_UlauncherWindow.py
@@ -26,10 +26,6 @@ class TestUlauncherWindow:
         return mocker.patch('ulauncher.ui.windows.UlauncherWindow.Theme')
 
     @pytest.fixture(autouse=True)
-    def get_options(self, mocker):
-        return mocker.patch('ulauncher.ui.windows.UlauncherWindow.get_options')
-
-    @pytest.fixture(autouse=True)
     def load_available_themes(self, mocker):
         return mocker.patch('ulauncher.ui.windows.UlauncherWindow.load_available_themes')
 
@@ -58,10 +54,6 @@ class TestUlauncherWindow:
     @pytest.fixture(autouse=True)
     def settings(self, mocker):
         return mocker.patch('ulauncher.ui.windows.UlauncherWindow.Settings.get_instance').return_value
-
-    @pytest.fixture(autouse=True)
-    def extDownloader(self, mocker):
-        return mocker.patch('ulauncher.ui.windows.UlauncherWindow.ExtensionDownloader.get_instance').return_value
 
     @pytest.fixture(autouse=True)
     def extRunner(self, mocker):

--- a/ulauncher/modes/extensions/ExtensionDownloader.py
+++ b/ulauncher/modes/extensions/ExtensionDownloader.py
@@ -8,13 +8,11 @@ from datetime import datetime
 from ulauncher.utils.mypy_extensions import TypedDict
 
 from ulauncher.config import EXTENSIONS_DIR
-from ulauncher.utils.decorator.run_async import run_async
 from ulauncher.utils.decorator.singleton import singleton
 from ulauncher.api.shared.errors import UlauncherAPIError, ExtensionError
 from ulauncher.modes.extensions.ExtensionDb import ExtensionDb, ExtensionRecord
 from ulauncher.modes.extensions.ExtensionRemote import ExtensionRemote
 from ulauncher.modes.extensions.ExtensionRunner import ExtensionRunner, ExtensionIsNotRunningError
-from ulauncher.modes.extensions.extension_finder import find_extensions
 
 
 logger = logging.getLogger(__name__)
@@ -89,21 +87,6 @@ class ExtensionDownloader:
         self.ext_db.commit()
 
         return remote.extension_id
-
-    @run_async(daemon=True)
-    def download_missing(self) -> None:
-        already_downloaded = {id for id, _ in find_extensions(EXTENSIONS_DIR)}
-        for id, ext in self.ext_db.get_records().items():
-            if id in already_downloaded:
-                continue
-
-            logger.info('Downloading missing extension %s', id)
-            try:
-                ext_id = self.download(ext['url'])
-                self.ext_runner.run(ext_id)
-            # pylint: disable=broad-except
-            except Exception as e:
-                logger.error('%s: %s', type(e).__name__, e)
 
     def remove(self, ext_id: str) -> None:
         try:

--- a/ulauncher/ui/windows/UlauncherWindow.py
+++ b/ulauncher/ui/windows/UlauncherWindow.py
@@ -16,14 +16,13 @@ from gi.repository import Gtk, Gdk, GLib, Keybinder
 from ulauncher.ui.ResultWidget import ResultWidget  # noqa: F401
 from ulauncher.ui.SmallResultWidget import SmallResultWidget   # noqa: F401
 
-from ulauncher.config import get_asset, get_options, FIRST_RUN
+from ulauncher.config import get_asset, FIRST_RUN
 from ulauncher.ui.AppIndicator import AppIndicator
 from ulauncher.ui.ItemNavigation import ItemNavigation
 from ulauncher.modes.ModeHandler import ModeHandler
 from ulauncher.modes.apps.AppResult import AppResult
 from ulauncher.modes.extensions.ExtensionRunner import ExtensionRunner
 from ulauncher.modes.extensions.ExtensionServer import ExtensionServer
-from ulauncher.modes.extensions.ExtensionDownloader import ExtensionDownloader
 from ulauncher.utils.Settings import Settings
 from ulauncher.utils.decorator.singleton import singleton
 from ulauncher.utils.timer import timer
@@ -86,8 +85,6 @@ class UlauncherWindow(Gtk.ApplicationWindow):
         ExtensionServer.get_instance().start()
         time.sleep(0.01)
         ExtensionRunner.get_instance().run_all()
-        if not get_options().no_extensions:
-            ExtensionDownloader.get_instance().download_missing()
 
     ######################################
     # GTK Signal Handlers


### PR DESCRIPTION
This was originally added as a fix for #177, because (as explained there) extensions were placed in `~/.cache/ulauncher_cache/extensions/`, and system cleaner apps like BleachBit clears `~/.cache/`.

Since then, extensions are no longer stored in `~/.cache/`, but in `XDG_DATA_HOME` (usually `~/.local/share/ulauncher`), so it shouldn't be needed for this purpose any more. I would argue was the real fix for that issue.

It could be argued that this is still a good thing to keep this functionality for when people are backing up their dotfiles, migrating to a new system and didn't back up the extension dir. But I think that by trying to solve this problem, we are creating worse problems. We shouldn't make changes to the extension directory unless users ask to. For example, you could be deleting an extension manually meaning to "uninstall" it. It's common for package managers to install plugins/extensions for other packages  directly like this for example. Or if a user forks an extension and installs from a local folder by copying it to the extension directory, they will have two extensions with the same name and icon, and if they want to remove the old one they could determine which one to remove more easily from the directory name than looking at our extension UI.

I wouldn't mind adding something like this back in another form, but not to run automatically, and also not by mixing concerns like this when the `ExtensionDownloader` handles a lot more than just downloading extensions (like starting them afterwards).

This feature was undocumented to begin with, so I think we don't need to add it to the change notes or documentation.