### PR TITLE
Load extension preferences directly in  __init__

### DIFF
--- a/docs/extensions/events.rst
+++ b/docs/extensions/events.rst
@@ -25,15 +25,6 @@ PreferencesUpdateEvent
   :members:
   :undoc-members:
 
-
-PreferencesEvent
-----------------
-
-.. autoclass:: ulauncher.api.shared.event.PreferencesEvent
-  :members:
-  :undoc-members:
-
-
 UnloadEvent
 ---------------
 

--- a/ulauncher/modes/extensions/ExtensionController.py
+++ b/ulauncher/modes/extensions/ExtensionController.py
@@ -40,6 +40,7 @@ class ExtensionController:
         self.controllers[extension_id] = self
         self._debounced_send_event = debounce(self.manifest.get_option('query_debounce', 0.05))(self._send_event)
 
+        # PreferencesEvent is candidate for future removal
         self._send_event(PreferencesEvent(self.preferences.get_dict()))
         logger.info('Extension "%s" connected', extension_id)
         self.framer.connect("message_parsed", self.handle_response)

--- a/ulauncher/modes/extensions/ExtensionRunner.py
+++ b/ulauncher/modes/extensions/ExtensionRunner.py
@@ -1,3 +1,4 @@
+import json
 import logging
 import os
 import sys
@@ -13,7 +14,7 @@ from ulauncher.config import EXTENSIONS_DIR, ULAUNCHER_APP_DIR, get_options
 from ulauncher.utils.mypy_extensions import TypedDict
 from ulauncher.utils.decorator.singleton import singleton
 from ulauncher.utils.timer import timer
-from ulauncher.modes.extensions.ExtensionManifest import ExtensionManifest
+from ulauncher.modes.extensions.ExtensionPreferences import ExtensionPreferences
 from ulauncher.modes.extensions.ProcessErrorExtractor import ProcessErrorExtractor
 from ulauncher.modes.extensions.extension_finder import find_extensions
 
@@ -68,9 +69,9 @@ class ExtensionRunner:
         * Runs extension in a new process
         """
         if not self.is_running(extension_id):
-            manifest = ExtensionManifest.open(extension_id)
-            manifest.validate()
-            manifest.check_compatibility()
+            preferences = ExtensionPreferences.create_instance(extension_id)
+            preferences.manifest.validate()
+            preferences.manifest.check_compatibility()
 
             cmd = [sys.executable, f"{EXTENSIONS_DIR}/{extension_id}/main.py"]
             env = {}
@@ -89,6 +90,7 @@ class ExtensionRunner:
                 return
 
             launcher = Gio.SubprocessLauncher.new(Gio.SubprocessFlags.STDERR_PIPE)
+            launcher.setenv("EXTENSION_PREFERENCES", json.dumps(preferences.get_dict()), True)
             for env_name, env_value in env.items():
                 launcher.setenv(env_name, env_value, True)
 


### PR DESCRIPTION
In v5, the way extension developers handle preferences being loaded initially was to subscribe to the `PreferencesEvent`. This PR adds a much better way (so we can remove this event in the future).

It's now done in the `Extension.__init__` method. This makes things less confusing for users, without multiple extension init events/methods, and this way the extension will be able to access the preferences as soon as it's created, without delays/waiting.

```py
class MyExtension(Extension):
    def __init__(self):
        super().__init__()
        value = self.preferences.get('my_preference_id')
```

It is sending the whole preferences object as stringified json in an environment variable, then loads it again. It might be inefficient, but the object is small and should be fast to format and parse.

### Checklist
- [x] Verify that the test command `./ul test` is passing (the CI server will check this if you don't)
- [ ] Update the documentation according to your changes (when applicable)
- [ ] Write unit tests for your changes (when applicable)
