### PR TITLE
Refactor base classes

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -425,7 +425,7 @@ max-returns=6
 max-statements=50
 
 # Minimum number of public methods for a class (see R0903).
-min-public-methods=2
+min-public-methods=1
 
 
 [CLASSES]

--- a/tests/ui/windows/test_UlauncherWindow.py
+++ b/tests/ui/windows/test_UlauncherWindow.py
@@ -44,24 +44,12 @@ class TestUlauncherWindow:
         return mocker.patch('ulauncher.ui.windows.UlauncherWindow.load_icon')
 
     @pytest.fixture(autouse=True)
-    def show_notification(self, mocker):
-        return mocker.patch('ulauncher.ui.windows.UlauncherWindow.show_notification')
-
-    @pytest.fixture(autouse=True)
     def AppResult(self, mocker):
         return mocker.patch('ulauncher.ui.windows.UlauncherWindow.AppResult.get_most_frequent').return_value
 
     @pytest.fixture(autouse=True)
     def settings(self, mocker):
         return mocker.patch('ulauncher.ui.windows.UlauncherWindow.Settings.get_instance').return_value
-
-    @pytest.fixture(autouse=True)
-    def extRunner(self, mocker):
-        return mocker.patch('ulauncher.ui.windows.UlauncherWindow.ExtensionRunner.get_instance').return_value
-
-    @pytest.fixture(autouse=True)
-    def extServer(self, mocker):
-        return mocker.patch('ulauncher.ui.windows.UlauncherWindow.ExtensionServer.get_instance').return_value
 
     @pytest.fixture(autouse=True)
     def get_scr_geometry(self, mocker):

--- a/ulauncher/ui/AppIndicator.py
+++ b/ulauncher/ui/AppIndicator.py
@@ -1,113 +1,48 @@
-from functools import wraps
-import logging
-
 import gi
+
 gi.require_version('Gtk', '3.0')
 
 # AppIndicator support is optional. It'll work if you install
 # gir1.2-ayatanaappindicator3-0.1 or an equivalent package for your distro
 # pylint: disable=wrong-import-position
-appIndicatorSupported = False
 try:
     gi.require_version('AppIndicator3', '0.1')
-    appIndicatorSupported = True
-except ValueError:
-    pass
-
-try:
-    gi.require_version('AyatanaAppIndicator3', '0.1')
-    appIndicatorSupported = True
-except ValueError:
-    pass
-
-try:
     from gi.repository import AppIndicator3
-except ImportError:
-    pass
-
-try:
-    from gi.repository import AyatanaAppIndicator3 as AppIndicator3  # noqa: F811
-except ImportError:
-    pass
+except (ImportError, ValueError):
+    try:
+        gi.require_version('AyatanaAppIndicator3', '0.1')
+        from gi.repository import AyatanaAppIndicator3 as AppIndicator3  # noqa: F811
+    except (ImportError, ValueError):
+        AppIndicator3 = None
 
 from gi.repository import Gtk
-from ulauncher.utils.decorator.singleton import singleton
-
-logger = logging.getLogger(__name__)
 
 
-def onlyIfAppindicatorIsSupported(func):
-    @wraps(func)
-    def wrapped(*args, **kwargs):
-        if appIndicatorSupported:
-            return func(*args, **kwargs)
-        return None
-    return wrapped
+def create_menu_item(title, command):
+    menu_item = Gtk.MenuItem(title)
+    menu_item.connect("activate", command)
+    return menu_item
 
 
 class AppIndicator:
+    menu = Gtk.Menu()
+    indicator = None
 
-    @classmethod
-    @singleton
-    def get_instance(cls, window):
-        indicator = cls("ulauncher")
-        indicator.set_icon('ulauncher-indicator')
-        indicator.add_menu_item(lambda *_: window.show_preferences(), "Preferences")
-        indicator.add_menu_item(lambda *_: window.show_preferences("about"), "About")
-        indicator.add_seperator()
-        indicator.add_menu_item(lambda *_: window.get_application().quit(), "Exit")
-        return indicator
-
-    def __init__(self, iconname):
-        if appIndicatorSupported:
-            self.__menu = Gtk.Menu()
-            self.__indicator = AppIndicator3.Indicator.new(
-                iconname,
-                "",
+    def __init__(self, app):
+        if AppIndicator3:
+            self.menu.append(create_menu_item("Preferences", lambda *_: app.show_preferences()))
+            self.menu.append(create_menu_item("About", lambda *_: app.show_preferences("about")))
+            self.menu.append(Gtk.SeparatorMenuItem())
+            self.menu.append(create_menu_item("Exit", lambda *_: app.quit()))
+            self.menu.show_all()
+            self.indicator = AppIndicator3.Indicator.new(
+                "ulauncher",
+                "ulauncher-indicator",
                 AppIndicator3.IndicatorCategory.APPLICATION_STATUS
             )
-            self.__indicator.set_menu(self.__menu)
+            self.indicator.set_menu(self.menu)
 
-    @onlyIfAppindicatorIsSupported
-    def set_icon(self, path):
-        self.__indicator.set_icon(path)
-
-    @onlyIfAppindicatorIsSupported
-    def switch(self, on=False):
-        if on:
-            self.show()
-        else:
-            self.hide()
-
-    @onlyIfAppindicatorIsSupported
-    def add_menu_item(self, command, title):
-        menu_item = Gtk.MenuItem()
-        menu_item.set_label(title)
-        menu_item.connect("activate", command)
-        self.__menu.append(menu_item)
-
-    @onlyIfAppindicatorIsSupported
-    def add_seperator(self):
-        menu_item = Gtk.SeparatorMenuItem()
-        self.__menu.append(menu_item)
-
-    @onlyIfAppindicatorIsSupported
-    def show(self):
-        self.__indicator.set_status(AppIndicator3.IndicatorStatus.ACTIVE)
-        self.__menu.show_all()
-
-    @onlyIfAppindicatorIsSupported
-    def hide(self):
-        self.__indicator.set_status(AppIndicator3.IndicatorStatus.PASSIVE)
-
-    @onlyIfAppindicatorIsSupported
-    def right_click_event_statusicon(self, icon, button, time):
-        self._get_tray_menu()
-
-        def pos(menu, aicon):
-            return Gtk.StatusIcon.position_menu(menu, aicon)
-
-        self.__menu.popup(None, None, pos, icon, button, time)
-
-    def _get_tray_menu(self):
-        return self.__menu
+    def switch(self, enable=False):
+        if AppIndicator3:
+            status = getattr(AppIndicator3.IndicatorStatus, "ACTIVE" if enable else "PASSIVE")
+            self.indicator.set_status(status)

--- a/ulauncher/ui/UlauncherApp.py
+++ b/ulauncher/ui/UlauncherApp.py
@@ -1,0 +1,133 @@
+import time
+import argparse
+import logging
+# This xinit import must happen before any GUI libraries are initialized.
+# pylint: disable=wrong-import-position,wrong-import-order,ungrouped-imports,unused-import
+import gi
+gi.require_versions({'Gtk': '3.0', 'Keybinder': '3.0'})
+# pylint: disable=wrong-import-position
+from gi.repository import Gio, GLib, Gtk, Keybinder
+
+from ulauncher.config import FIRST_RUN
+from ulauncher.utils.environment import IS_X11
+from ulauncher.utils.Settings import Settings
+from ulauncher.utils.desktop.notification import show_notification
+from ulauncher.ui.AppIndicator import AppIndicator
+from ulauncher.ui.windows.PreferencesWindow import PreferencesWindow
+from ulauncher.ui.windows.UlauncherWindow import UlauncherWindow
+from ulauncher.modes.extensions.ExtensionRunner import ExtensionRunner
+from ulauncher.modes.extensions.ExtensionServer import ExtensionServer
+
+logger = logging.getLogger('ulauncher')
+
+
+class UlauncherApp(Gtk.Application):
+    # Gtk.Applications check if the app is already registered and if so,
+    # new instances sends the signals to the registered one
+    # So all methods except __init__ runs on the main app
+    settings = Settings.get_instance()
+    preferences = None  # type: PreferencesWindow
+    window = None  # type: UlauncherWindow
+    appindicator = None  # type: AppIndicator
+    _current_accel_name = None
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(
+            *args,
+            application_id="net.launchpad.ulauncher",
+            flags=Gio.ApplicationFlags.HANDLES_COMMAND_LINE,
+            **kwargs
+        )
+        self.connect("startup", self.setup)  # runs only once on the main instance
+
+    def do_before_emit(self, data):
+        query = data.lookup_value("query", GLib.VariantType("s"))
+        if query:
+            self.window.initial_query = query.unpack()
+
+    def do_activate(self, *args, **kwargs):
+        self.window.show_window()
+
+    def do_command_line(self, *args, **kwargs):
+        # This is where we handle "--no-window" which we need to get from the remote call
+        # All other aguments are persistent and handled in config.get_options()
+        parser = argparse.ArgumentParser(prog='gui')
+        parser.add_argument("--no-window", action="store_true")
+        args, _ = parser.parse_known_args(args[0].get_arguments()[1:])
+
+        if not args.no_window:
+            self.activate()
+
+        return 0
+
+    def setup(self, _):
+        self.hold()  # Keep the app running even without a window
+        self.window = window = UlauncherWindow.get_instance()
+        window.set_application(self)
+        window.set_keep_above(True)
+        window.position_window()
+        window.init_theme()
+
+        # this will trigger to show frequent apps if necessary
+        window.show_results([])
+
+        if self.settings.get_property('show-indicator-icon'):
+            self.appindicator = AppIndicator(self)
+            self.appindicator.switch(True)
+
+        if IS_X11:
+            # bind hotkey
+            Keybinder.init()
+            accel_name = self.settings.get_property('hotkey-show-app')
+            # bind in the main thread
+            GLib.idle_add(self.bind_hotkey, accel_name)
+
+        ExtensionServer.get_instance().start()
+        time.sleep(0.01)
+        ExtensionRunner.get_instance().run_all()
+
+    def toggle_appindicator(self, enable):
+        if not self.appindicator:
+            self.appindicator = AppIndicator(self)
+        self.appindicator.switch(enable)
+
+    def bind_hotkey(self, accel_name):
+        if not IS_X11 or self._current_accel_name == accel_name:
+            return
+
+        if self._current_accel_name:
+            Keybinder.unbind(self._current_accel_name)
+            self._current_accel_name = None
+
+        logger.info("Trying to bind app hotkey: %s", accel_name)
+        Keybinder.bind(accel_name, lambda _: self.window.show_window())
+        self._current_accel_name = accel_name
+        if FIRST_RUN:
+            (key, mode) = Gtk.accelerator_parse(accel_name)
+            display_name = Gtk.accelerator_get_label(key, mode)
+            show_notification("Ulauncher", f"Hotkey is set to {display_name}")
+
+    def show_preferences(self, page=None):
+        self.window.hide()
+        if not str or not isinstance(page, str):
+            page = 'preferences'
+
+        if self.preferences is not None:
+            logger.debug('Show existing preferences window')
+            self.preferences.present(page=page)
+        else:
+            logger.debug('Create new preferences window')
+            self.preferences = PreferencesWindow()
+            self.preferences.set_application(self)
+            self.preferences.connect('destroy', self.on_preferences_destroyed)
+            self.preferences.show(page=page)
+        # destroy command moved into dialog to allow for a help button
+
+    def on_preferences_destroyed(self, *_):
+        '''only affects GUI
+
+        logically there is no difference between the user closing,
+        minimizing or ignoring the preferences dialog'''
+        logger.debug('on_preferences_destroyed')
+        # to determine whether to create or present preferences
+        self.preferences = None

--- a/ulauncher/ui/windows/PreferencesWindow.py
+++ b/ulauncher/ui/windows/PreferencesWindow.py
@@ -13,7 +13,7 @@ gi.require_version('Gtk', '3.0')
 gi.require_version('WebKit2', '4.0')
 
 # pylint: disable=wrong-import-position,unused-argument
-from gi.repository import Gio, Gdk, Gtk, WebKit2, GLib
+from gi.repository import Gio, Gdk, Gtk, WebKit2
 
 from ulauncher.api.shared.action.OpenAction import OpenAction
 from ulauncher.ui.windows.HotkeyDialog import HotkeyDialog
@@ -34,7 +34,6 @@ from ulauncher.utils.environment import IS_X11
 from ulauncher.utils.Settings import Settings
 from ulauncher.utils.Router import Router
 from ulauncher.utils.AutostartPreference import AutostartPreference
-from ulauncher.ui.AppIndicator import AppIndicator
 from ulauncher.modes.shortcuts.ShortcutsDb import ShortcutsDb
 from ulauncher.config import get_asset, get_options, API_VERSION, VERSION, EXTENSIONS_DIR
 
@@ -243,10 +242,7 @@ class PreferencesWindow(Gtk.ApplicationWindow):
         self.settings.set_property(property, value)
 
         if property == 'show-indicator-icon':
-            # pylint: disable=import-outside-toplevel
-            from ulauncher.ui.windows.UlauncherWindow import UlauncherWindow
-            ulauncher_window = UlauncherWindow.get_instance()
-            GLib.idle_add(AppIndicator.get_instance(ulauncher_window).switch, value)
+            self.get_application().toggle_appindicator(value)
         if property == 'theme-name':
             self.prefs_apply_theme()
 
@@ -261,20 +257,14 @@ class PreferencesWindow(Gtk.ApplicationWindow):
             raise PrefsApiError(f'Caught an error while switching "autostart": {err}') from err
 
     def prefs_apply_theme(self):
-        # pylint: disable=import-outside-toplevel
-        from ulauncher.ui.windows.UlauncherWindow import UlauncherWindow
-        ulauncher_window = UlauncherWindow.get_instance()
-        ulauncher_window.init_theme()
+        self.get_application().window.init_theme()
 
     @rt.route('/set/hotkey-show-app')
     @glib_idle_add
     def prefs_set_hotkey_show_app(self, query):
         hotkey = query['value']
         # Bind a new key
-        # pylint: disable=import-outside-toplevel
-        from ulauncher.ui.windows.UlauncherWindow import UlauncherWindow
-        ulauncher_window = UlauncherWindow.get_instance()
-        ulauncher_window.bind_hotkey(hotkey)
+        self.get_application().bind_hotkey(hotkey)
         self.settings.set_property('hotkey-show-app', hotkey)
 
     @rt.route('/show/hotkey-dialog')


### PR DESCRIPTION
In v5 UlauncherWindow is the root instance and works as a global data storage. In v6 we've changed that so we also have an application instance.

This PR primarily moves the stuff from UlauncherWindow that doesn't concern the window out to the UlauncherApp or main.py. UlauncherApp handles the initialization of the UlauncherWindow, PreferencesWindow, AppIndicator, ExtensionServer/Runnner and the callbacks/communication between these windows is handled via the Application also, so there's no circular imports where UlauncherWindow imports PreferencesWindow that imports UlauncherWindow.

I also completely rewrote the AppIndicator class since it was overly complicated for what it did.

This will allow further improvements to the logic and reduce resource usage.

### Checklist
- [x] Verify that the test command `./ul test` is passing (the CI server will check this if you don't)
- [ ] Update the documentation according to your changes (when applicable)
- [ ] Write unit tests for your changes (when applicable)
