### PR TITLE
Simplify logging (use name argument only for extensions)

### DIFF
--- a/ulauncher/api/client/Client.py
+++ b/ulauncher/api/client/Client.py
@@ -10,7 +10,7 @@ from ulauncher.api.shared.socket_path import get_socket_path
 from ulauncher.utils.framer import PickleFramer
 from ulauncher.utils.timer import timer
 
-logger = logging.getLogger(__name__)
+logger = logging.getLogger()
 
 
 class Client:

--- a/ulauncher/api/client/setup_logging.py
+++ b/ulauncher/api/client/setup_logging.py
@@ -1,26 +1,13 @@
 import os
-import sys
 import logging
-import random
 
-from ulauncher.utils.logging import color_highlight, ColoredFormatter, log_format
+from ulauncher.utils.logging import ColoredFormatter
 
 
 def setup_logging():
-    root = logging.getLogger()
-
-    ext_name = get_extension_name()
-    random.seed(ext_name)
-    colorized_ext_name = color_highlight(ext_name, ext_name, random.randint(32, 37), True)
     handler = logging.StreamHandler()
-    handler.setFormatter(ColoredFormatter(log_format.replace("%(message)s", f"{colorized_ext_name} %(message)s")))
-
-    root.addHandler(handler)
-    root.setLevel(logging.WARNING)
-
-    if os.getenv('VERBOSE'):
-        root.setLevel(logging.DEBUG)
-
-
-def get_extension_name():
-    return os.path.basename(os.path.dirname(sys.argv[0]))
+    handler.setFormatter(ColoredFormatter())
+    logging.basicConfig(
+        level=logging.DEBUG if os.getenv('VERBOSE') else logging.WARNING,
+        handlers=[handler]
+    )

--- a/ulauncher/api/extension.py
+++ b/ulauncher/api/extension.py
@@ -1,3 +1,4 @@
+import sys
 import os
 import json
 import logging
@@ -9,7 +10,7 @@ from ulauncher.api.shared.action.BaseAction import BaseAction
 from ulauncher.api.shared.event import KeywordQueryEvent, ItemEnterEvent, PreferencesUpdateEvent, UnloadEvent
 from ulauncher.api.client.EventListener import EventListener
 from ulauncher.api.client.Client import Client
-from ulauncher.api.client.setup_logging import setup_logging, get_extension_name
+from ulauncher.api.client.setup_logging import setup_logging
 
 
 class Extension:
@@ -19,8 +20,8 @@ class Extension:
 
     def __init__(self):
         setup_logging()
-        self.logger = logging.getLogger(__name__)
-        self.extension_id = get_extension_name()
+        self.extension_id = os.path.basename(os.path.dirname(sys.argv[0]))
+        self.logger = logging.getLogger(self.extension_id)
         self._listeners = defaultdict(list)
         self._client = Client(self)
         self.preferences = {}

--- a/ulauncher/api/shared/action/RunScriptAction.py
+++ b/ulauncher/api/shared/action/RunScriptAction.py
@@ -6,7 +6,7 @@ import tempfile
 from ulauncher.api.shared.action.BaseAction import BaseAction
 from ulauncher.utils.decorator.run_async import run_async
 
-logger = logging.getLogger(__name__)
+logger = logging.getLogger()
 
 
 class RunScriptAction(BaseAction):

--- a/ulauncher/main.py
+++ b/ulauncher/main.py
@@ -11,7 +11,7 @@ gi.require_version('Gtk', '3.0')
 from gi.repository import GLib, Gtk
 from ulauncher.config import API_VERSION, STATE_DIR, VERSION, get_options
 from ulauncher.utils.environment import DESKTOP_NAME, DISTRO, XDG_SESSION_TYPE, IS_X11_COMPATIBLE
-from ulauncher.utils.logging import ColoredFormatter, log_format
+from ulauncher.utils.logging import ColoredFormatter
 from ulauncher.ui.UlauncherApp import UlauncherApp
 
 
@@ -27,21 +27,20 @@ def main():
     options = get_options()
 
     # Set up global logging for stdout and file
-    root_log_handler = logging.getLogger()
-    root_log_handler.setLevel(logging.DEBUG)
-
+    file_handler = logging.FileHandler(f"{STATE_DIR}/last.log", mode='w+')
     stream_handler = logging.StreamHandler()
     stream_handler.setLevel(logging.DEBUG if options.verbose else logging.WARNING)
-    stream_handler.setFormatter(ColoredFormatter(log_format))
-    root_log_handler.addHandler(stream_handler)
+    stream_handler.setFormatter(ColoredFormatter())
 
-    file_handler = logging.FileHandler(f"{STATE_DIR}/last.log", mode='w+')
-    file_handler.setLevel(logging.DEBUG)
-    file_handler.setFormatter(logging.Formatter(log_format))
-    root_log_handler.addHandler(file_handler)
+    logging.root.handlers = []
+    logging.basicConfig(
+        level=logging.DEBUG,
+        format="%(asctime)s | %(levelname)s | %(message)s | %(module)s.%(funcName)s():%(lineno)s",
+        handlers=[file_handler, stream_handler]
+    )
 
     # Logger for actual use in this file
-    logger = logging.getLogger('ulauncher')
+    logger = logging.getLogger()
 
     logger.info('Ulauncher version %s', VERSION)
     logger.info('Extension API version %s', API_VERSION)

--- a/ulauncher/modes/ModeHandler.py
+++ b/ulauncher/modes/ModeHandler.py
@@ -9,7 +9,7 @@ from ulauncher.modes.file_browser.FileBrowserMode import FileBrowserMode
 from ulauncher.modes.calc.CalcMode import CalcMode
 from ulauncher.utils.decorator.singleton import singleton
 
-logger = logging.getLogger(__name__)
+logger = logging.getLogger()
 
 
 class ModeHandler:

--- a/ulauncher/modes/apps/launch_app.py
+++ b/ulauncher/modes/apps/launch_app.py
@@ -8,7 +8,7 @@ from ulauncher.utils.Settings import Settings
 from ulauncher.utils.launch_detached import launch_detached
 from ulauncher.utils.wm import get_windows_stacked, get_xserver_time
 
-logger = logging.getLogger(__name__)
+logger = logging.getLogger()
 settings = Settings.get_instance()
 
 

--- a/ulauncher/modes/extensions/DeferredResultRenderer.py
+++ b/ulauncher/modes/extensions/DeferredResultRenderer.py
@@ -7,7 +7,7 @@ from ulauncher.api.shared.action.RenderResultListAction import RenderResultListA
 from ulauncher.utils.decorator.singleton import singleton
 from ulauncher.utils.timer import timer
 
-logger = logging.getLogger('DeferredResultRenderer')
+logger = logging.getLogger()
 
 
 class DeferredResultRenderer:

--- a/ulauncher/modes/extensions/ExtensionController.py
+++ b/ulauncher/modes/extensions/ExtensionController.py
@@ -6,7 +6,7 @@ from ulauncher.modes.extensions.DeferredResultRenderer import DeferredResultRend
 from ulauncher.modes.extensions.ExtensionPreferences import ExtensionPreferences
 from ulauncher.modes.extensions.ExtensionManifest import ExtensionManifestError
 
-logger = logging.getLogger(__name__)
+logger = logging.getLogger()
 
 
 class ExtensionController:

--- a/ulauncher/modes/extensions/ExtensionDownloader.py
+++ b/ulauncher/modes/extensions/ExtensionDownloader.py
@@ -14,7 +14,7 @@ from ulauncher.modes.extensions.ExtensionDb import ExtensionDb, ExtensionRecord
 from ulauncher.modes.extensions.ExtensionRemote import ExtensionRemote
 
 
-logger = logging.getLogger(__name__)
+logger = logging.getLogger()
 
 
 class ExtensionDownloaderError(UlauncherAPIError):

--- a/ulauncher/modes/extensions/ExtensionPreferences.py
+++ b/ulauncher/modes/extensions/ExtensionPreferences.py
@@ -7,7 +7,7 @@ from ulauncher.utils.db.KeyValueJsonDb import KeyValueJsonDb
 from ulauncher.utils.mypy_extensions import TypedDict
 from ulauncher.modes.extensions.ExtensionManifest import ExtensionManifest, OptionItems
 
-logger = logging.getLogger(__name__)
+logger = logging.getLogger()
 
 ValueType = Union[str, int]  # Bool is a subclass of int
 PreferenceItem = TypedDict('PreferenceItem', {

--- a/ulauncher/modes/extensions/ExtensionRemote.py
+++ b/ulauncher/modes/extensions/ExtensionRemote.py
@@ -11,7 +11,7 @@ from ulauncher.config import API_VERSION
 from ulauncher.utils.version import satisfies, valid_range
 from ulauncher.api.shared.errors import ExtensionError, UlauncherAPIError
 
-logger = logging.getLogger(__name__)
+logger = logging.getLogger()
 
 Commit = Tuple[str, datetime]
 

--- a/ulauncher/modes/extensions/ExtensionRunner.py
+++ b/ulauncher/modes/extensions/ExtensionRunner.py
@@ -18,7 +18,7 @@ from ulauncher.modes.extensions.ExtensionPreferences import ExtensionPreferences
 from ulauncher.modes.extensions.ProcessErrorExtractor import ProcessErrorExtractor
 from ulauncher.modes.extensions.extension_finder import find_extensions
 
-logger = logging.getLogger(__name__)
+logger = logging.getLogger()
 
 ExtRunError = TypedDict('ExtRunError', {
     'name': str,

--- a/ulauncher/modes/extensions/ExtensionServer.py
+++ b/ulauncher/modes/extensions/ExtensionServer.py
@@ -9,7 +9,7 @@ from ulauncher.api.shared.event import RegisterEvent
 from ulauncher.utils.decorator.singleton import singleton
 from ulauncher.utils.framer import PickleFramer
 
-logger = logging.getLogger(__name__)
+logger = logging.getLogger()
 
 
 class ExtensionServer:

--- a/ulauncher/ui/ResultWidget.py
+++ b/ulauncher/ui/ResultWidget.py
@@ -11,7 +11,7 @@ from ulauncher.utils.icon import load_icon
 from ulauncher.utils.Theme import Theme
 from ulauncher.modes.Query import Query
 
-logger = logging.getLogger(__name__)
+logger = logging.getLogger()
 
 
 class ResultWidget(Gtk.EventBox):

--- a/ulauncher/ui/UlauncherApp.py
+++ b/ulauncher/ui/UlauncherApp.py
@@ -18,7 +18,7 @@ from ulauncher.ui.windows.UlauncherWindow import UlauncherWindow
 from ulauncher.modes.extensions.ExtensionRunner import ExtensionRunner
 from ulauncher.modes.extensions.ExtensionServer import ExtensionServer
 
-logger = logging.getLogger('ulauncher')
+logger = logging.getLogger()
 
 
 class UlauncherApp(Gtk.Application):

--- a/ulauncher/ui/windows/HotkeyDialog.py
+++ b/ulauncher/ui/windows/HotkeyDialog.py
@@ -7,7 +7,7 @@ from gi.repository import Gtk, Gdk, GObject
 from ulauncher.config import get_asset
 
 
-logger = logging.getLogger('ulauncher')
+logger = logging.getLogger()
 
 FORBIDDEN_ACCEL_KEYS = ('Delete', 'Page_Down', 'Page_Up', 'Home', 'End', 'Up', 'Down', 'Left', 'Right', 'Return',
                         'BackSpace', 'Alt_L', 'Alt_R', 'Shift_L', 'Shift_R', 'Control_L', 'Control_R', 'space',

--- a/ulauncher/ui/windows/PreferencesWindow.py
+++ b/ulauncher/ui/windows/PreferencesWindow.py
@@ -36,7 +36,7 @@ from ulauncher.utils.AutostartPreference import AutostartPreference
 from ulauncher.modes.shortcuts.ShortcutsDb import ShortcutsDb
 from ulauncher.config import get_asset, get_options, API_VERSION, VERSION, EXTENSIONS_DIR
 
-logger = logging.getLogger(__name__)
+logger = logging.getLogger()
 rt = Router()
 
 

--- a/ulauncher/ui/windows/UlauncherWindow.py
+++ b/ulauncher/ui/windows/UlauncherWindow.py
@@ -28,7 +28,7 @@ from ulauncher.utils.environment import IS_X11_COMPATIBLE
 from ulauncher.utils.Theme import Theme, load_available_themes
 from ulauncher.modes.Query import Query
 
-logger = logging.getLogger(__name__)
+logger = logging.getLogger()
 
 
 @Gtk.Template(filename=get_asset("ui/ulauncher_window.ui"))

--- a/ulauncher/utils/Settings.py
+++ b/ulauncher/utils/Settings.py
@@ -6,7 +6,7 @@ from gi.repository import GObject
 from ulauncher.utils.decorator.singleton import singleton
 from ulauncher.config import SETTINGS_FILE_PATH
 
-logger = logging.getLogger(__name__)
+logger = logging.getLogger()
 
 GPROPERTIES = {
     "hotkey-show-app": (str,  # type

--- a/ulauncher/utils/Theme.py
+++ b/ulauncher/utils/Theme.py
@@ -8,7 +8,7 @@ from ulauncher.config import ASSETS_DIR, CONFIG_DIR, CACHE_DIR
 from ulauncher.utils.Settings import Settings
 
 themes = {}  # type: Dict[str, Any]
-logger = logging.getLogger(__name__)
+logger = logging.getLogger()
 user_theme_dir = os.path.join(CONFIG_DIR, 'user-themes')
 
 

--- a/ulauncher/utils/desktop/notification.py
+++ b/ulauncher/utils/desktop/notification.py
@@ -5,7 +5,7 @@ gi.require_version('Notify', '0.7')
 from gi.repository import Notify
 
 Notify.init('ulauncher')
-logger = logging.getLogger(__name__)
+logger = logging.getLogger()
 
 
 def show_notification(summary, body, icon='ulauncher'):

--- a/ulauncher/utils/framer.py
+++ b/ulauncher/utils/framer.py
@@ -6,7 +6,7 @@ from gi.repository import GLib, Gio, GObject
 
 INTSZ = 4
 
-log = logging.getLogger(__name__)
+log = logging.getLogger()
 
 
 class InvalidStateError(RuntimeError):

--- a/ulauncher/utils/icon.py
+++ b/ulauncher/utils/icon.py
@@ -11,7 +11,7 @@ from gi.repository import Gtk, GdkPixbuf
 from ulauncher.config import get_asset
 
 icon_theme = Gtk.IconTheme.get_default()
-logger = logging.getLogger(__name__)
+logger = logging.getLogger()
 
 DEFAULT_EXE_ICON = get_asset("icons/executable.png")
 

--- a/ulauncher/utils/launch_detached.py
+++ b/ulauncher/utils/launch_detached.py
@@ -3,7 +3,7 @@ import os
 from shutil import which
 from gi.repository import GLib
 
-logger = logging.getLogger(__name__)
+logger = logging.getLogger()
 use_systemd_run = which("systemd-run") and os.system("systemd-run --user --scope true  2> /dev/null") == 0
 
 if not use_systemd_run:

--- a/ulauncher/utils/logging.py
+++ b/ulauncher/utils/logging.py
@@ -1,21 +1,11 @@
 import logging
-
-# Great reference for terminal colors: https://chrisyeh96.github.io/2020/03/28/terminal-colors.html
-
-log_format = "%(asctime)s | %(levelname)s | %(message)s | %(name)s.%(funcName)s():%(lineno)s"
+import random
 
 
 def mkcolor(color, bold=False):
     if bold:
         color = f"1;{color}"
     return f"\x1b[{color}m"
-
-
-def color_highlight(input, highlight, color, bold=False, symbol="", replace=None):
-    if symbol:
-        symbol = f"{symbol}  "
-
-    return input.replace(highlight, f"{symbol}{mkcolor(color, bold)}{replace or highlight}{mkcolor(0)}")
 
 
 class ColoredFormatter(logging.Formatter):
@@ -28,9 +18,14 @@ class ColoredFormatter(logging.Formatter):
     }
 
     def format(self, record):
-        symbol, color = self.formats.get(record.levelno, ("", 0))
-        fmt_colorized_level = color_highlight(self._fmt, "| %(levelname)s |", color, True, symbol, "%(levelname)s")
-        fmt_colorized = color_highlight(fmt_colorized_level, "%(name)s.%(funcName)s():%(lineno)s", 2)  # 2 means faded
-
-        formatter = logging.Formatter(fmt_colorized)
+        # Great reference for terminal colors: https://chrisyeh96.github.io/2020/03/28/terminal-colors.html
+        symbol, level_color = self.formats.get(record.levelno, ("", 0))
+        prefix = f"{symbol}  {mkcolor(level_color, True)}{record.levelname}{mkcolor(0)}"
+        if record.name != "root":
+            # Ensure the same name gets the same color every time
+            random.seed(record.name)
+            name_color = random.randint(32, 37)
+            prefix += f"{mkcolor(name_color, True)} {record.name}{mkcolor(0)}:"
+        suffix = f"{mkcolor(2)}{record.module}.{record.funcName}:{record.lineno}{mkcolor(0)}"  # 2 means faded
+        formatter = logging.Formatter(f"%(asctime)s {prefix} %(message)s {suffix}")
         return formatter.format(record)

--- a/ulauncher/utils/wm.py
+++ b/ulauncher/utils/wm.py
@@ -8,7 +8,7 @@ gi.require_versions({
 # pylint: disable=wrong-import-position
 from gi.repository import Gdk, GdkX11, Gio, Wnck
 
-logger = logging.getLogger(__name__)
+logger = logging.getLogger()
 wnck_screen = Wnck.Screen.get_default()
 
 


### PR DESCRIPTION
This improves/simplifies the solution in #1046 by getting rid of the generic use of "name" (the argument passed to `logging.getLogger()`) and using "module" instead, freeing up "name" for when it's significant (extensions).

This way was a lot cleaner.

Also fixed an issue with duplicated logging.

### Checklist
- [x] Verify that the test command `./ul test` is passing (the CI server will check this if you don't)
- [ ] Update the documentation according to your changes (when applicable)
- [ ] Write unit tests for your changes (when applicable)
