### PR TITLE
Rework extension keyword

### DIFF
--- a/tests/modes/apps/extensions/test_DeferredResultRenderer.py
+++ b/tests/modes/apps/extensions/test_DeferredResultRenderer.py
@@ -49,7 +49,7 @@ class TestDeferredResultRenderer:
 
     def test_handle_response__action__is_ran(self, renderer, controller):
         response = mock.Mock()
-        response.event = KeywordQueryEvent(Query('test'), {})
+        response.event = KeywordQueryEvent(Query('test'))
         renderer.active_event = response.event
         renderer.active_controller = controller
         renderer.handle_response(response, controller)
@@ -58,7 +58,7 @@ class TestDeferredResultRenderer:
     def test_handle_response__keep_app_open_is_False__hide_is_called(self, renderer, controller, GLib, mocker):
         UlauncherWindow = mocker.patch('ulauncher.ui.windows.UlauncherWindow.UlauncherWindow')
         response = mock.Mock()
-        response.event = KeywordQueryEvent(Query('test'), {})
+        response.event = KeywordQueryEvent(Query('test'))
         response.action.keep_app_open.return_value = False
         renderer.active_event = response.event
         renderer.active_controller = controller

--- a/ulauncher/api/shared/event.py
+++ b/ulauncher/api/shared/event.py
@@ -24,30 +24,14 @@ class KeywordQueryEvent(BaseEvent):
     Is triggered when user enters query that starts with your keyword + Space
 
     :param ~ulauncher.modes.Query.Query query:
-    :param ~ulauncher.modes.extensions.ExtensionPreferences preferences:
     """
 
-    def __init__(self, query, preferences):
+    def __init__(self, query):
         self.query = query
-        self.preferences = preferences
-
-    def get_keyword_id(self):
-        """
-        :rtype: str
-        :returns: the keyword id, as specified in the manifest
-        """
-        keyword = self.query.get_keyword()
-        keyword_id = ""
-
-        for pref in self.preferences.get_items():
-            if pref['type'] == "keyword" and pref['value'] == keyword:
-                keyword_id = pref['id']
-        return keyword_id
 
     def get_keyword(self):
         """
         :rtype: str
-        :returns: the keyword the user entered (you likely want the get_keyword_id() instead)
         """
         return self.query.get_keyword()
 

--- a/ulauncher/modes/extensions/ExtensionController.py
+++ b/ulauncher/modes/extensions/ExtensionController.py
@@ -2,6 +2,7 @@ import logging
 from ulauncher.utils.decorator.debounce import debounce
 from ulauncher.api.shared.Response import Response
 from ulauncher.api.shared.event import KeywordQueryEvent, PreferencesEvent, PreferencesUpdateEvent
+from ulauncher.modes.Query import Query
 from ulauncher.modes.extensions.DeferredResultRenderer import DeferredResultRenderer
 from ulauncher.modes.extensions.ExtensionPreferences import ExtensionPreferences
 from ulauncher.modes.extensions.ExtensionManifest import ExtensionManifestError
@@ -56,6 +57,12 @@ class ExtensionController:
 
         :returns: :class:`BaseAction` object
         """
+        # Normalize the query to the extension default keyword, not the custom user keyword
+        user_keyword = query.get_keyword()
+        for pref in self.preferences.get_items():
+            if pref['type'] == "keyword" and pref['value'] == user_keyword:
+                query = Query(query.replace(pref['value'], pref['default_value'], 1))
+
         event = KeywordQueryEvent(query)
         return self.trigger_event(event)
 

--- a/ulauncher/modes/extensions/ExtensionController.py
+++ b/ulauncher/modes/extensions/ExtensionController.py
@@ -56,7 +56,7 @@ class ExtensionController:
 
         :returns: :class:`BaseAction` object
         """
-        event = KeywordQueryEvent(query, self.preferences)
+        event = KeywordQueryEvent(query)
         return self.trigger_event(event)
 
     def trigger_event(self, event):


### PR DESCRIPTION
This is a different solution instead of #287 (which was merged into the v6 branch but never released and now reverted) 

This solution is better and will fix the issue without requiring extension devs to change their code. Extensions will receive a normalized user query where `get_keyword()` returns the default they specified, regardless of what users changed the keyword to.

It also removes the need to pass preferences to the event, and this will me simplify the API a bit more in another place.

### Checklist
- [x] Verify that the test command `./ul test` is passing (the CI server will check this if you don't)
- [ ] Update the documentation according to your changes (when applicable)
- [ ] Write unit tests for your changes (when applicable)
