### PR TITLE
Pass custom arguments directly to extension's event listener methods

### DIFF
--- a/docs/extensions/tutorial.rst
+++ b/docs/extensions/tutorial.rst
@@ -173,7 +173,7 @@ Copy the following code to ``main.py``::
 
   class DemoExtension(Extension):
 
-      def on_query_change(self, event):
+      def on_query_change(self, query):
           items = []
           for i in range(5):
               items.append(ExtensionResult(
@@ -216,8 +216,8 @@ Basic API Concepts
 
     class DemoExtension(Extension):
 
-        def on_query_change(self, event):
-            # `event` will be an instance of :class:`KeywordQueryEvent`
+        def on_query_change(self, query):
+            # `query` will be an instance of :class:`Query`
 
             ...
 
@@ -232,7 +232,7 @@ Basic API Concepts
   ::
 
     class DemoExtension(Extension):
-        def on_query_change(self, event):
+        def on_query_change(self, query):
             items = []
             for i in range(5):
                 items.append(ExtensionResult(
@@ -285,14 +285,12 @@ Custom Action on Item Enter
 
     class DemoExtension(Extension):
 
-        def on_query_change(self, event):
+        def on_query_change(self, query):
             ...
 
-        def on_item_enter(self, event):
-            # event is instance of ItemEnterEvent
-
-            data = event.get_data()
-            # do additional actions here...
+        def on_item_enter(self, data):
+            # data is whatever you passed as the first argument to ExtensionCustomAction
+            # do any additional actions here...
 
             # you may want to return another list of results
             return [ExtensionResult(

--- a/ulauncher/api/extension.py
+++ b/ulauncher/api/extension.py
@@ -64,8 +64,8 @@ class Extension:
         for listener, method_name in listeners:
             method = getattr(listener, method_name or "on_event")
             # We can use method_name to determine if listener was added the old way or the new class method way
-            # When method_name is None, we should also pass self for backwards compatibility
-            action = method(event) if method_name else method(event, self)
+            # Pass the event args if method_name isn't None, otherwise event and self for backwards compatibility
+            action = method(*event.args) if method_name else method(event, self)
             if action:
                 assert isinstance(action, (list, BaseAction)), "on_event must return list of Results or a BaseAction"
                 self._client.send(Response(event, action))
@@ -77,16 +77,16 @@ class Extension:
         self.subscribe(PreferencesUpdateEvent, PreferencesUpdateEventListener())
         self._client.connect()
 
-    def on_query_change(self, event):
+    def on_query_change(self, query):
         pass
 
-    def on_item_enter(self, event):
+    def on_item_enter(self, data):
         pass
 
-    def on_preferences_update(self, event):
+    def on_preferences_update(self, id, value, previous_value):
         pass
 
-    def on_unload(self, event):
+    def on_unload(self):
         pass
 
 

--- a/ulauncher/api/extension.py
+++ b/ulauncher/api/extension.py
@@ -2,12 +2,12 @@ import sys
 import os
 import json
 import logging
+from typing import Type, Union
 from collections import defaultdict
-from inspect import signature
 
 from ulauncher.api.shared.Response import Response
 from ulauncher.api.shared.action.BaseAction import BaseAction
-from ulauncher.api.shared.event import KeywordQueryEvent, ItemEnterEvent, PreferencesUpdateEvent, UnloadEvent
+from ulauncher.api.shared.event import BaseEvent, KeywordQueryEvent, ItemEnterEvent, PreferencesUpdateEvent, UnloadEvent
 from ulauncher.api.client.EventListener import EventListener
 from ulauncher.api.client.Client import Client
 from ulauncher.api.client.setup_logging import setup_logging
@@ -35,48 +35,37 @@ class Extension:
 
         # subscribe with methods if user has added their own
         if self.__class__.on_query_change is not Extension.on_query_change:
-            self.subscribe(KeywordQueryEvent, self, 'on_query_change')
+            self.subscribe(KeywordQueryEvent, 'on_query_change')
         if self.__class__.on_item_enter is not Extension.on_item_enter:
-            self.subscribe(ItemEnterEvent, self, 'on_item_enter')
+            self.subscribe(ItemEnterEvent, 'on_item_enter')
         if self.__class__.on_unload is not Extension.on_unload:
-            self.subscribe(UnloadEvent, self, 'on_unload')
+            self.subscribe(UnloadEvent, 'on_unload')
         if self.__class__.on_preferences_update is not Extension.on_preferences_update:
-            self.subscribe(PreferencesUpdateEvent, self, 'on_preferences_update')
+            self.subscribe(PreferencesUpdateEvent, 'on_preferences_update')
 
-    def subscribe(self, event_type, event_listener, method='on_event'):
+    def subscribe(self, event_type: Type[BaseEvent], listener: Union[str, object]):
         """
-        Example:
+        Example: extension.subscribe(KeywordQueryEvent, "on_query_change")
+        """
+        method_name = None
+        if isinstance(listener, str):
+            method_name = listener
+            listener = self
 
-            extension.subscribe(KeywordQueryEvent, KeywordQueryEventListener())
+        self._listeners[event_type].append((listener, method_name))
 
-        :param type event_type:
-        :param ~ulauncher.api.client.EventListener.EventListener event_listener:
-        :param str method:
-        """
-        self._listeners[event_type].append((event_listener, method))
-
-    def get_listeners_for_event(self, event):
-        """
-        :param ~ulauncher.api.shared.event.BaseEvent event:
-        :rtype: ~ulauncher.api.client.EventListener.EventListener
-        """
-        return self._listeners[type(event)]
-
-    def trigger_event(self, event):
-        """
-        :param ~ulauncher.api.shared.event.BaseEvent event:
-        """
-        listeners = self.get_listeners_for_event(event)
+    def trigger_event(self, event: BaseEvent):
+        event_type = type(event)
+        listeners = self._listeners[event_type]
         if not listeners:
-            self.logger.debug('No listeners for event %s', type(event).__name__)
+            self.logger.debug('No listeners for event %s', event_type.__name__)
             return
 
-        for listener, method in listeners:
-            _method = getattr(listener, method)
-            param_count = len(signature(_method).parameters)
-            # method can and likely will be a member on self for new extensions, in which case
-            # it can access self. But for backward compatibility we need to pass self
-            action = _method(event) if param_count == 1 else _method(event, self)
+        for listener, method_name in listeners:
+            method = getattr(listener, method_name or "on_event")
+            # We can use method_name to determine if listener was added the old way or the new class method way
+            # When method_name is None, we should also pass self for backwards compatibility
+            action = method(event) if method_name else method(event, self)
             if action:
                 assert isinstance(action, (list, BaseAction)), "on_event must return list of Results or a BaseAction"
                 self._client.send(Response(event, action))

--- a/ulauncher/api/shared/event.py
+++ b/ulauncher/api/shared/event.py
@@ -1,7 +1,9 @@
 from pickle import loads, dumps
+from typing import Any, List
 
 
 class BaseEvent:
+    args: List[Any] = []
 
     def __eq__(self, other):
         return dumps(self) == dumps(other)
@@ -28,6 +30,7 @@ class KeywordQueryEvent(BaseEvent):
 
     def __init__(self, query):
         self.query = query
+        self.args = [query]
 
     def get_keyword(self):
         """
@@ -60,6 +63,7 @@ class ItemEnterEvent(BaseEvent):
 
     def __init__(self, data):
         self._data = data
+        self.args = [data]
 
     def get_data(self):
         """
@@ -90,10 +94,11 @@ class PreferencesUpdateEvent(BaseEvent):
     old_value = None
     new_value = None
 
-    def __init__(self, id, old_value, new_value):
+    def __init__(self, id, previous_value, value):
         self.id = id
-        self.old_value = old_value
-        self.new_value = new_value
+        self.old_value = previous_value
+        self.new_value = value
+        self.args = [id, value, previous_value]
 
 
 class PreferencesEvent(BaseEvent):
@@ -107,6 +112,7 @@ class PreferencesEvent(BaseEvent):
 
     def __init__(self, preferences):
         self.preferences = preferences
+        self.args = [preferences]
 
 
 # Alias of UnloadEvent for backward compatibility. In v6, please use UnloadEvent (or extension.on_unload) instead


### PR DESCRIPTION
Before this, we always passed the event, but the event is (at best) just a wrapper to get the arguments. This passes the argument directly.

This is only changes things we introduced in v6 and hence it's backwards compatible with v5.

### Checklist
- [x] Verify that the test command `./ul test` is passing (the CI server will check this if you don't)
- [x] Update the documentation according to your changes (when applicable)
- [ ] Write unit tests for your changes (when applicable)
