### PR TITLE
add "Show Ulauncher" menu item to tray menu and set it as secondary target

### DIFF
--- a/ulauncher/ui/AppIndicator.py
+++ b/ulauncher/ui/AppIndicator.py
@@ -30,6 +30,8 @@ class AppIndicator:
 
     def __init__(self, app):
         if AppIndicator3:
+            show_menu_item = create_menu_item("Show Ulauncher", lambda *_: app.do_activate())
+            self.menu.append(show_menu_item)    
             self.menu.append(create_menu_item("Preferences", lambda *_: app.show_preferences()))
             self.menu.append(create_menu_item("About", lambda *_: app.show_preferences("about")))
             self.menu.append(Gtk.SeparatorMenuItem())
@@ -41,6 +43,7 @@ class AppIndicator:
                 AppIndicator3.IndicatorCategory.APPLICATION_STATUS
             )
             self.indicator.set_menu(self.menu)
+            self.indicator.set_secondary_activate_target(show_menu_item)
 
     def switch(self, enable=False):
         if AppIndicator3:


### PR DESCRIPTION
Implements https://github.com/Ulauncher/Ulauncher/issues/1068

It's not possible to distinguish left or right click with libindicator, so the next best option is to add a menu item and also set it as secondary target, which means that it is called when a middle click is received


### Checklist
- [ ] Verify that the test command `./ul test` is passing (the CI server will check this if you don't)
- [ ] Update the documentation according to your changes (when applicable)
- [ ] Write unit tests for your changes (when applicable)
