### PR TITLE
Remove unused property "description" from manifest

### DIFF
--- a/docs/extensions/tutorial.rst
+++ b/docs/extensions/tutorial.rst
@@ -76,7 +76,6 @@ Create :file:`manifest.json` using the following template::
   {
     "required_api_version": "2",
     "name": "Demo extension",
-    "description": "Extension Description",
     "developer_name": "John Doe",
     "icon": "images/icon.png",
     "instructions": "You need to install <code>examplecommand</code> to run this extension",
@@ -92,7 +91,7 @@ Create :file:`manifest.json` using the following template::
   }
 
 * ``required_api_version`` - the version(s) of the Ulauncher Extension API (not the main app version) that the extension requires. See above for more information.
-* ``name``, ``description`` and ``developer_name`` can be anything you like but not an empty string
+* ``name`` and ``developer_name`` can be anything you like but not an empty string
 * ``icon`` - relative path to an extension icon, or the name of a `themed icon <https://specifications.freedesktop.org/icon-naming-spec/icon-naming-spec-latest.html#names>`_, for example "edit-paste".
 * ``preferences`` - list of preferences available for users to override.
 * ``instructions`` - Optional installation instructions that is shown in the extension preferences view.

--- a/preferences-src/src/api/fixture.js
+++ b/preferences-src/src/api/fixture.js
@@ -214,7 +214,6 @@ function generateExtensionRecord(config) {
     name: config.name,
     updated_at: '2017-07-21T20:50:44.850738',
     icon: placeholderImage,
-    description: 'My extension description',
     developer_name: 'John Doe',
     version: '1.2.3',
     last_commit: 'abc234fd23425234a2',

--- a/tests/modes/apps/extensions/test_ExtensionManifest.py
+++ b/tests/modes/apps/extensions/test_ExtensionManifest.py
@@ -11,7 +11,6 @@ class TestExtensionManifest:
         return {
             "required_api_version": "1",
             "name": "Timer",
-            "description": "Countdown timer with notifications",
             "developer_name": "Aleksandr Gornostal",
             "icon": "images/timer.png",
             "preferences": [{

--- a/tests/modes/apps/extensions/test_ExtensionRemote.py
+++ b/tests/modes/apps/extensions/test_ExtensionRemote.py
@@ -6,7 +6,6 @@ import pytest
 from ulauncher.modes.extensions.ExtensionRemote import ExtensionRemote, ExtensionRemoteError
 
 manifest_example = {'required_api_version': '1',
-                    'description': 'Countdown timer with notifications',
                     'developer_name': 'Aleksandr Gornostal',
                     'icon': 'images/timer.png',
                     'name': 'Timer',

--- a/ulauncher/modes/extensions/ExtensionManifest.py
+++ b/ulauncher/modes/extensions/ExtensionManifest.py
@@ -29,7 +29,6 @@ class Preference(JsonData):
 @json_data_class
 class ExtensionManifest(JsonData):
     name = ""
-    description = ""
     developer_name = ""
     icon = ""
     required_api_version = ""
@@ -58,7 +57,6 @@ class ExtensionManifest(JsonData):
         try:
             assert self.required_api_version, "required_api_version is not provided"
             assert self.name, "name is not provided"
-            assert self.description, "description is not provided"
             assert self.developer_name, "developer_name is not provided"
             assert self.icon, "icon is not provided"
             assert self.preferences, "preferences is not provided"

--- a/ulauncher/ui/preferences_context_server.py
+++ b/ulauncher/ui/preferences_context_server.py
@@ -58,7 +58,6 @@ def get_extension_info(ext_id: str, manifest: ExtensionManifest, error: str = No
         'last_commit_time': ext_db_record.last_commit_time,
         'name': manifest.name,
         'icon': icon,
-        'description': manifest.description,
         'developer_name': manifest.developer_name,
         'instructions': manifest.instructions,
         'preferences': manifest.preferences,


### PR DESCRIPTION
The "description" field in the manifest is never actually used anywhere. It's not shown in the preferences view, and the description that is shown in the app for the keyword is the keyword description (as it should be).

GitHub repos have their own descriptions and also the readme. The extension database for https://ext.ulauncher.io/ uses it's own description input field when you submit descriptions.

If we at a later point need the description again I guess his would be a move in the wrong direction, but I see no reason to have it. We have "instructions" now for actually important messages about compatibility that will be shown in the preferences UI. In addition we could use the readme markdown (would require some dependency to format it. It is much longer, but also much more likely to contain helpful info.

### Checklist
- [x] Verify that the test command `./ul test` is passing (the CI server will check this if you don't)
- [x] Update the documentation according to your changes (when applicable)
- [ ] Write unit tests for your changes (when applicable)
