### PR TITLE
Change manifest.preferences to a dictionary

### DIFF
--- a/docs/extensions/tutorial.rst
+++ b/docs/extensions/tutorial.rst
@@ -32,21 +32,20 @@ Create :file:`manifest.json` using the following template::
     "developer_name": "John Doe",
     "icon": "images/icon.png",
     "instructions": "You need to install <code>examplecommand</code> to run this extension",
-    "preferences": [
-      {
-        "id": "demo_kw",
+    "preferences": {
+      "main_keyword": {
         "type": "keyword",
         "name": "Demo",
         "description": "Demo extension",
         "default_value": "dm"
       }
-    ]
+    }
   }
 
 * ``required_api_version`` - the version(s) of the Ulauncher Extension API (not the main app version) that the extension requires. See above for more information.
 * ``name`` and ``developer_name`` can be anything you like but not an empty string
 * ``icon`` - relative path to an extension icon, or the name of a `themed icon <https://specifications.freedesktop.org/icon-naming-spec/icon-naming-spec-latest.html#names>`_, for example "edit-paste".
-* ``preferences`` - list of preferences available for users to override.
+* ``preferences`` - Preferences available for users to override (see below for details).
 * ``instructions`` - Optional installation instructions that is shown in the extension preferences view.
 * ``query_debounce`` - Default: ``0.05``. Delay (in seconds) to avoid running queries while the user is typing. Raise to higher values like ``1`` for slow I/O operations like network requests.
   They are rendered in Ulauncher preferences in the same order they are listed in manifest.
@@ -55,13 +54,10 @@ Create :file:`manifest.json` using the following template::
 .. NOTE:: All fields except ``instructions`` and ``query_debounce`` are required and cannot be empty.
 
 
-Preference Object Fields
-^^^^^^^^^^^^^^^^^^^^^^^^
-The values of the preferences are forwarded to the ``on_event`` method of the ``KeywordQueryEventListener`` class as an attribute of extension. For example the value of the keyword with ``id = 'id'`` and ``value = 'val'`` is obtained with the line ``value = extension.preferences['id']`` which  assigns the string ``'val'`` to value. An example of the use of preferences can be found in the `ulauncher demo extension <https://github.com/Ulauncher/ulauncher-demo-ext>`_
+Preferences
+^^^^^^^^^^^
 
-
-``id`` (required)
-  Key that is used to retrieve value for a certain preference
+.. NOTE:: The key for the preferences should be a unique identifier that never changes. It's what Ulauncher uses to associate your preferences with user preferences. It was previously named ``id``.
 
 ``type`` (required)
   Can be "keyword", "checkbox", "number", "input", "text", or "select"

--- a/preferences-src/src/components/pages/ExtensionConfig.vue
+++ b/preferences-src/src/components/pages/ExtensionConfig.vue
@@ -69,15 +69,15 @@
     </b-alert>
 
     <div class="ext-form" v-if="!extension.error && extension.is_running" ref="ext-form">
-      <template v-for="pref in extension.preferences">
+      <template v-for="(pref, id) in extension.preferences">
         <b-form-group
-          :key="pref.id"
+          :key="id"
           v-if="pref.type == 'keyword'"
           :label="`${pref.name} keyword`"
           class="keyword-input"
           :description="pref.description"
         >
-          <b-form-input :ref="pref.id" :value="pref.value"></b-form-input>
+          <b-form-input :ref="id" :value="pref.value"></b-form-input>
         </b-form-group>
 
         <b-form-group
@@ -217,7 +217,7 @@ export default {
     canSave() {
       const { preferences } = this.$props.extension
       const isRunning = this.$props.extension.is_running
-      return isRunning && !this.$props.extension.error && preferences && !!preferences.length
+      return isRunning && !this.$props.extension.error && preferences && !!Object.keys(preferences).length
     },
     canCheckUpdates() {
       return !!this.$props.extension.url
@@ -257,9 +257,8 @@ export default {
     },
     save() {
       let data = {}
-      for (let i = 0; i < this.extension.preferences.length; i++) {
-        let pref = this.extension.preferences[i]
-        let { $el } = this.$refs[pref.id][0]
+      Object.entries(this.extension.preferences).forEach(([id, pref]) => {
+        let { $el } = this.$refs[id][0]
         let value = $el.value
         if (pref.type === 'checkbox') {
           value = $el.firstChild.checked
@@ -267,8 +266,8 @@ export default {
         if (pref.type === 'keyword') {
           value = value.trim()
         }
-        data[pref.id] = value
-      }
+        data[id] = value
+      })
       jsonp('prefs:///extension/update-prefs', {data, id: this.extension.id}).then(
         () => {
           this.showSavedMsg = true

--- a/tests/modes/apps/extensions/test_ExtensionController.py
+++ b/tests/modes/apps/extensions/test_ExtensionController.py
@@ -42,7 +42,7 @@ class TestExtensionController:
 
     def test_configure__typical(self, controller, controllers, manifest, PreferencesEvent):
         # configure() is called implicitly when constructing the controller.
-        manifest.get_preferences_dict.return_value = {}
+        manifest.get_user_preferences.return_value = {}
         assert controller.extension_id == TEST_EXT_ID
         assert controllers[TEST_EXT_ID] == controller
         controller.manifest.validate.assert_called_once()

--- a/ulauncher/modes/extensions/ExtensionController.py
+++ b/ulauncher/modes/extensions/ExtensionController.py
@@ -42,7 +42,7 @@ class ExtensionController:
         self._debounced_send_event = debounce(self.manifest.query_debounce or 0.05)(self._send_event)
 
         # PreferencesEvent is candidate for future removal
-        self._send_event(PreferencesEvent(self.manifest.get_preferences_dict()))
+        self._send_event(PreferencesEvent(self.manifest.get_user_preferences()))
         logger.info('Extension "%s" connected', extension_id)
         self.framer.connect("message_parsed", self.handle_response)
         self.framer.connect("closed", self.handle_close)
@@ -58,7 +58,7 @@ class ExtensionController:
         :returns: :class:`BaseAction` object
         """
         # Normalize the query to the extension default keyword, not the custom user keyword
-        for pref in self.manifest.preferences:
+        for pref in self.manifest.preferences.values():
             if pref.type == "keyword" and pref.value == query.keyword:
                 query = Query(query.replace(pref.value, pref.default_value, 1))
 

--- a/ulauncher/modes/extensions/ExtensionMode.py
+++ b/ulauncher/modes/extensions/ExtensionMode.py
@@ -44,7 +44,7 @@ class ExtensionMode(BaseMode):
         :rtype: Iterable[:class:`~ulauncher.api.Result`]
         """
         for controller in self.extensionServer.get_controllers():
-            for pref in controller.manifest.preferences:
+            for pref in controller.manifest.preferences.values():
                 if pref.type == "keyword" and pref.value:
                     yield ExtensionKeywordResult(
                         name=html.escape(pref.name),

--- a/ulauncher/modes/extensions/ExtensionRunner.py
+++ b/ulauncher/modes/extensions/ExtensionRunner.py
@@ -71,7 +71,7 @@ class ExtensionRunner:
             env = {
                 "VERBOSE": str(int(self.verbose)),
                 "PYTHONPATH": ":".join(filter(bool, [ULAUNCHER_APP_DIR, os.getenv("PYTHONPATH")])),
-                "EXTENSION_PREFERENCES": json.dumps(manifest.get_preferences_dict(), separators=(',', ':'))
+                "EXTENSION_PREFERENCES": json.dumps(manifest.get_user_preferences(), separators=(',', ':'))
             }
 
             if self.dont_run_extensions:

--- a/ulauncher/modes/extensions/ExtensionServer.py
+++ b/ulauncher/modes/extensions/ExtensionServer.py
@@ -98,8 +98,9 @@ class ExtensionServer:
         :rtype: ~ulauncher.modes.extensions.ExtensionController.ExtensionController
         """
         for _, controller in self.controllers.items():
-            if keyword and controller.manifest.get_preference(type="keyword", value=keyword):
-                return controller
+            for pref in controller.manifest.preferences.values():
+                if keyword and pref.type == "keyword" and pref.value == keyword:
+                    return controller
 
         return None
 

--- a/ulauncher/ui/preferences_context_server.py
+++ b/ulauncher/ui/preferences_context_server.py
@@ -332,7 +332,7 @@ class PreferencesContextServer():
         logger.info('Update extension preferences: %s', query)
         controller = ExtensionServer.get_instance().controllers.get(query['id'])
         for pref_id, value in query['data'].items():
-            preference = controller.manifest.get_preference(id=pref_id)
+            preference = controller.manifest.preferences.get(pref_id)
             old_value = preference.value
             preference.value = value
             controller.manifest.save_user_preferences(query['id'])


### PR DESCRIPTION
This changes manifest.preferences to a dictionary, which makes more sense:
1. Dictionary keys have the same constraints as what we need for the id (unique, non-empty strings), removing the need for some tests, validation and documentation.
2. Easier to declare/read (less code).
3. We can find the preference with `preferences.get(id)` instead of looping through all of them (slower and more code needed).

This change is fully backwards compatible. `ExtensionManifest` reformats the manifest as it loads it (this is something that I plan to let extension developers use to migrate extensions).

### Checklist
- [x] Verify that the test command `./ul test` is passing (the CI server will check this if you don't)
- [x] Update the documentation according to your changes (when applicable)
- [x] Write unit tests for your changes (when applicable)
