### PR TITLE
Rename "required_api_version" back to "api_version"

### DIFF
--- a/docs/extensions/tutorial.rst
+++ b/docs/extensions/tutorial.rst
@@ -27,7 +27,7 @@ manifest.json
 Create :file:`manifest.json` using the following template::
 
   {
-    "required_api_version": "2",
+    "api_version": "3",
     "name": "Demo extension",
     "developer_name": "John Doe",
     "icon": "images/icon.png",
@@ -42,7 +42,7 @@ Create :file:`manifest.json` using the following template::
     }
   }
 
-* ``required_api_version`` - the version(s) of the Ulauncher Extension API (not the main app version) that the extension requires. See above for more information.
+* ``api_version`` - the version(s) of the Ulauncher Extension API (not the main app version) that the extension requires. See above for more information.
 * ``name`` and ``developer_name`` can be anything you like but not an empty string
 * ``icon`` - relative path to an extension icon, or the name of a `themed icon <https://specifications.freedesktop.org/icon-naming-spec/icon-naming-spec-latest.html#names>`_, for example "edit-paste".
 * ``preferences`` - Preferences available for users to override (see below for details).

--- a/tests/modes/apps/extensions/test_ExtensionManifest.py
+++ b/tests/modes/apps/extensions/test_ExtensionManifest.py
@@ -9,7 +9,7 @@ class TestExtensionManifest:
     @pytest.fixture
     def valid_manifest(self):
         return {
-            "required_api_version": "1",
+            "api_version": "1",
             "name": "Timer",
             "developer_name": "Aleksandr Gornostal",
             "icon": "images/timer.png",
@@ -28,7 +28,7 @@ class TestExtensionManifest:
         assert manifest.name == "Test Extension"
 
     def test_validate__name_empty__exception_raised(self):
-        manifest = ExtensionManifest({"required_api_version": "1"})
+        manifest = ExtensionManifest({"api_version": "1"})
         with pytest.raises(ExtensionManifestError) as e:
             manifest.validate()
         assert e.value.error_name == ExtensionError.InvalidManifest.value
@@ -73,19 +73,19 @@ class TestExtensionManifest:
         manifest.validate()
 
     def test_check_compatibility__manifest_version_3__exception_raised(self):
-        manifest = ExtensionManifest({"name": "Test", "required_api_version": "3"})
+        manifest = ExtensionManifest({"name": "Test", "api_version": "3"})
         with pytest.raises(ExtensionManifestError) as e:
             manifest.check_compatibility()
         assert e.value.error_name == ExtensionError.Incompatible.value
 
     def test_check_compatibility__manifest_version_0__exception_raised(self):
-        manifest = ExtensionManifest({"name": "Test", "required_api_version": "0"})
+        manifest = ExtensionManifest({"name": "Test", "api_version": "0"})
         with pytest.raises(ExtensionManifestError) as e:
             manifest.check_compatibility()
         assert e.value.error_name == ExtensionError.Incompatible.value
 
     def test_check_compatibility__api_version__no_exceptions(self):
-        manifest = ExtensionManifest({"name": "Test", "required_api_version": "2"})
+        manifest = ExtensionManifest({"name": "Test", "api_version": "2"})
         manifest.check_compatibility()
 
     def test_defaults_not_included_in_stringify(self):
@@ -101,6 +101,15 @@ class TestExtensionManifest:
         assert manifest.get_user_preferences() == {"txt": "asdf", "num": 11}
 
     def test_manifest_backwards_compatibility(self):
-        em = ExtensionManifest(options={"query_debounce": 5}, preferences=[{"id": "asdf", "name": "ghjk"}])
-        assert em.query_debounce == 5
+        em = ExtensionManifest(
+            required_api_version="3",
+            manifest_version="1",
+            description="asdf",
+            options={"query_debounce": 0.555},
+            preferences=[{"id": "asdf", "name": "ghjk"}]
+        )
+        assert em.get("options") is None
+        assert em.get("required_api_version") is None
+        assert em.api_version == "3"
+        assert em.query_debounce == 0.555
         assert em.preferences.get("asdf").name == "ghjk"

--- a/tests/modes/apps/extensions/test_ExtensionRemote.py
+++ b/tests/modes/apps/extensions/test_ExtensionRemote.py
@@ -5,7 +5,7 @@ import pytest
 
 from ulauncher.modes.extensions.ExtensionRemote import ExtensionRemote, ExtensionRemoteError
 
-manifest_example = {'required_api_version': '1',
+manifest_example = {'api_version': '1',
                     'developer_name': 'Aleksandr Gornostal',
                     'icon': 'images/timer.png',
                     'name': 'Timer',

--- a/ulauncher/modes/extensions/ExtensionManifest.py
+++ b/ulauncher/modes/extensions/ExtensionManifest.py
@@ -27,10 +27,10 @@ class Preference(JsonData):
 
 @json_data_class
 class ExtensionManifest(JsonData):
+    api_version = ""
     name = ""
     developer_name = ""
     icon = ""
-    required_api_version = ""
     preferences: Dict[str, Preference] = {}
     instructions: Optional[str] = None
     query_debounce: Optional[float] = None
@@ -38,6 +38,9 @@ class ExtensionManifest(JsonData):
     __json_value_blacklist__: List[Any] = [[], {}, None, ""]  # pylint: disable=dangerous-default-value
 
     def __setitem__(self, key, value):
+        # Rename "required_api_version" back to "api_version"
+        if key == "required_api_version":
+            key = "api_version"
         # Flatten manifest v2 API "options"
         if key == "options":
             key = "query_debounce"
@@ -57,7 +60,7 @@ class ExtensionManifest(JsonData):
         Ensure that the manifest is valid (or raise error)
         """
         try:
-            assert self.required_api_version, "required_api_version is not provided"
+            assert self.api_version, "api_version is not provided"
             assert self.name, "name is not provided"
             assert self.developer_name, "developer_name is not provided"
             assert self.icon, "icon is not provided"
@@ -105,9 +108,9 @@ class ExtensionManifest(JsonData):
         """
         Ensure the extension is compatible with the Ulauncher API (or raise error)
         """
-        if not satisfies(API_VERSION, self.required_api_version):
+        if not satisfies(API_VERSION, self.api_version):
             err_msg = (
-                f'Extension "{self.name}" requires API version {self.required_api_version}, '
+                f'Extension "{self.name}" requires API version {self.api_version}, '
                 f'but the current API version is: {API_VERSION})'
             )
             raise ExtensionManifestError(err_msg, ExtensionError.Incompatible)

--- a/ulauncher/modes/extensions/ExtensionRemote.py
+++ b/ulauncher/modes/extensions/ExtensionRemote.py
@@ -10,6 +10,7 @@ from typing import Optional, Tuple
 from ulauncher.config import API_VERSION
 from ulauncher.utils.version import satisfies, valid_range
 from ulauncher.api.shared.errors import ExtensionError, UlauncherAPIError
+from ulauncher.modes.extensions.ExtensionManifest import ExtensionManifest
 
 logger = logging.getLogger()
 
@@ -165,11 +166,11 @@ class ExtensionRemote:
         Returns a commit hash and datetime.
         """
         try:
-            manifest = json.loads(self.fetch_file("manifest.json") or "{}")
+            manifest = ExtensionManifest(json.loads(self.fetch_file("manifest.json") or "{}"))
         except URLError as e:
             raise ExtensionRemoteError("Could not access repository", ExtensionError.Network) from e
 
-        if satisfies(API_VERSION, manifest.get("required_api_version")):
+        if satisfies(API_VERSION, manifest.api_version):
             return self.get_commit("HEAD")
 
         commit = self.get_compatible_commit_from_tags() or self.get_compatible_commit_from_versions_json()


### PR DESCRIPTION
I don't know why this was originally changed from `api_version` to `required_api_version`. The V1 format was actually compatible for the V2 parser to read. It wasn't really adding anything. If anything, the wording which would be correct would be `supported_api_versions` (plural). But there's no need to be so specific/verbose imo.

This PR changes it back **for the manifest**. For versions.json it's still `required_api_version`, but versions.json will eventually be dropped for a [better solution](https://github.com/Ulauncher/Ulauncher/commit/ac138ef3eda498b7b0ecd2aa652984f5e0dc49c1).

This change is fully backwards compatible. `ExtensionManifest` reformats the manifest as it loads it (this is something that I plan to let extension developers use to migrate extensions).

### Checklist
- [x] Verify that the test command `./ul test` is passing (the CI server will check this if you don't)
- [x] Update the documentation according to your changes (when applicable)
- [x] Write unit tests for your changes (when applicable)
