### PR TITLE
Completely remove versions.json support

### DIFF
--- a/preferences-src/src/components/widgets/ExtensionErrorExplanation.vue
+++ b/preferences-src/src/components/widgets/ExtensionErrorExplanation.vue
@@ -6,11 +6,6 @@
           v-if="errorName === 'InvalidUrl'"
         >The URL should be a GitHub, GitLab or Gitea-compatible extension repository link.
         <br>Examples: https://github.com/user/repo or https://codeberg.org/user/repo</p>
-        <p v-else-if="errorName === 'InvalidVersionDeclaration'">
-          There's an error in versions.json:
-          <br>
-          <b>{{ errorMessage }}</b>
-        </p>
         <p v-else-if="errorName === 'InvalidManifest'">
           There's an error in manifest.json:
           <br>
@@ -78,7 +73,7 @@ export default {
     extUrl: String
   },
   data: () => ({
-    reportableErrors: ['Incompatible', 'InvalidVersionDeclaration', 'InvalidManifest']
+    reportableErrors: ['Incompatible', 'InvalidManifest']
   }),
   methods: {
     openUrlInBrowser(url) {

--- a/ulauncher/api/shared/errors.py
+++ b/ulauncher/api/shared/errors.py
@@ -6,7 +6,6 @@ class ExtensionError(Enum):
     Incompatible = 'Incompatible'
     InvalidManifest = 'InvalidManifest'
     InvalidUrl = 'InvalidUrl'
-    InvalidVersionDeclaration = 'InvalidVersionDeclaration'
     Network = 'Network'
     Other = 'Other'
 


### PR DESCRIPTION
Already removed it from the documentation before.

We have a much better solution in place: ac138ef3eda498b7b0ecd2aa652984f5e0dc49c1. You can make a git tag named `apiv3` or `apiv3.1` etc. This is easier for everyone. You don't need to make updates in mulitiple repos and unlike versions.json it can't fail (it's impossible to make a tag that points to an invalid reference) and you don't need a whole page of documention 256a495428e50e2c39184360788c88509d148362. I haven't actually added how to use the tags yet, because that won't come in effect until updating to API v4. For updating to v3 all you need is to bump the api version in the manifest.json in your main branch. If you don't want your main branch to be for the current version, then you can tag the current version instead.

Going to focus first on how to migrate from v2 to v3 without breaking the v2 compatibility first in the migration guide (need to be rewritten completely).

This also made error handling for the internal helper `json_fetch()` easier, because it's unlikely to fail now, and if it does it's because the repo doesn't exist, isn't a Ulauncher extension or that the git host is down/broken or changed their API in a backward incompatible way (very unlikely to happen). Previously it would most likely have been due to versions.json pointing to an invalid ref.

### Checklist
- [x] Verify that the test command `./ul test` is passing (the CI server will check this if you don't)
- [x] Update the documentation according to your changes (when applicable)
- [ ] Write unit tests for your changes (when applicable)
