### PR TITLE
Migrate v5 data files to v6

### DIFF
--- a/ulauncher/config.py
+++ b/ulauncher/config.py
@@ -3,6 +3,7 @@ import os
 from functools import lru_cache
 from gettext import gettext
 from ulauncher import ASSETS, VERSION
+from ulauncher.utils.migrate import v5_to_v6
 
 API_VERSION = "3.0"
 # spec: https://specifications.freedesktop.org/menu-spec/latest/ar01s02.html
@@ -31,6 +32,7 @@ class _PATHS_CLASS:
 PATHS = _PATHS_CLASS()
 
 FIRST_RUN = not os.path.exists(PATHS.CONFIG)  # If there is no config dir, assume it's the first run
+FIRST_V6_RUN = not os.path.exists(PATHS.STATE)
 
 if not os.path.exists(PATHS.ASSETS):
     raise OSError(PATHS.ASSETS)
@@ -39,6 +41,8 @@ os.makedirs(PATHS.CACHE, exist_ok=True)
 os.makedirs(PATHS.CONFIG, exist_ok=True)
 os.makedirs(PATHS.STATE, exist_ok=True)
 os.makedirs(PATHS.EXTENSIONS, exist_ok=True)
+
+v5_to_v6(PATHS, FIRST_V6_RUN)
 
 
 @lru_cache()

--- a/ulauncher/utils/migrate.py
+++ b/ulauncher/utils/migrate.py
@@ -1,0 +1,116 @@
+import logging
+import json
+import os
+import pickle
+import sys
+from pathlib import Path
+from configparser import ConfigParser
+from types import ModuleType
+from ulauncher.utils.systemd_controller import UlauncherSystemdController
+
+_logger = logging.getLogger()
+
+
+def _load_legacy(path: Path):
+    try:
+        if path.suffix == ".db":
+            return pickle.loads(path.read_bytes())
+        if path.suffix == ".json":
+            return json.loads(path.read_text())
+    except Exception as e:
+        _logger.warning('Could not migrate file "%s": %s', str(path), e)
+    return None
+
+
+def _storeJSON(path, data):
+    try:
+        Path(path).write_text(json.dumps(data, indent=4))
+        return True
+    except Exception as e:
+        _logger.warning('Could not store JSON file "%s": %s', path, e)
+        return False
+
+
+def _migrate_file(from_path, to_path, transform=None):
+    if not os.path.exists(to_path) and os.path.isfile(from_path):
+        data = _load_legacy(Path(from_path))
+        if data:
+            _logger.info('Migrating %s to %s', from_path, to_path)
+            if callable(transform):
+                data = transform(data)
+            _storeJSON(to_path, data)
+
+
+def _migrate_app_state(old_format):
+    new_format = {}
+    for app_path, starts in old_format.items():
+        # Was changed to use app ids instead of paths as keys
+        new_format[os.path.basename(app_path)] = starts
+    return new_format
+
+
+def v5_to_v6(PATHS, is_first_run):
+    # Convert extension prefs to JSON
+    for file in Path(f"{PATHS.CONFIG}/ext_preferences").iterdir():
+        if file.suffix in [".db", ".json"]:
+            _migrate_file(str(file), f"{file.parent}/{file.stem}.json")
+
+    # Convert app_stat.db to JSON and put in STATE_DIR
+    _migrate_file(f"{PATHS.DATA}/app_stat_v2.db", f"{PATHS.STATE}/app_starts.json", _migrate_app_state)
+
+    # Convert query_history.db to JSON and put in STATE_DIR
+    # Needs a module hack for pickle because v5 stored these as the "ulauncher.search.Query" type
+    MockQuery = ModuleType("Query")
+    MockQuery.Query = str
+    sys.modules["ulauncher.search.Query"] = MockQuery
+    _migrate_file(f"{PATHS.DATA}/query_history.db", f"{PATHS.STATE}/query_history.json")
+    del sys.modules["ulauncher.search.Query"]  # <-- Don't want this hack to remain in the runtime afterwards
+
+    # Migrate autostart conf from XDG autostart file to systemd
+    if is_first_run:
+        try:
+            systemd_unit = UlauncherSystemdController()
+            AUTOSTART_FILE = Path(f"{PATHS.CONFIG}/../autostart/ulauncher.desktop").resolve()
+            if os.path.exists(AUTOSTART_FILE) and systemd_unit.is_allowed():
+                autostart_config = ConfigParser()
+                autostart_config.read(AUTOSTART_FILE)
+                if autostart_config["Desktop Entry"]["X-GNOME-Autostart-enabled"] == "true":
+                    systemd_unit.switch(True)
+            _logger.info("Applied autostart settings to systemd")
+        except Exception as e:
+            _logger.warning("Couldn't migrate autostart: %s", e)
+
+
+def v5_to_v6_destructive(PATHS):
+    # Currently optional changes that breaks your conf if you want to revert back to v5 for some reason
+    # We probably want to run these later as part of the v7 migration instead.
+
+    # Delete old unused files
+    cleanup_list = [
+        *Path(PATHS.CONFIG).parent.rglob("autostart/ulauncher.desktop"),
+        *Path(PATHS.CACHE).rglob("*.db"),
+        *Path(PATHS.DATA).rglob("*.db"),
+        *Path(PATHS.DATA).rglob("last.log"),
+    ]
+    if cleanup_list:
+        print("Removing deprecated data files:")
+        print("\n".join(map(str, cleanup_list)))
+        for file in cleanup_list:
+            file.unlink()
+
+    # Update icon locations for shortcuts.json generated before v6
+    # (v6 created symlinks for them for backwards compatibility, but when v6 comes we should delete the symlinks)
+    shortcuts_conf = Path(f"{PATHS.CONFIG}/shortcuts.json")
+    shortcuts_text = shortcuts_conf.read_text()
+    shortcuts_replace = {
+        "/media/google-search-icon.png": "/icons/google-search.png",
+        "/media/stackoverflow-icon.svg": "/icons/stackoverflow.svg",
+        "/media/wikipedia-icon.png": "/icons/wikipedia.png",
+    }
+
+    for old_path, new_path in shortcuts_replace.items():
+        if old_path in shortcuts_text:
+            _logger.info('Updating shortcut icon from "%s" to "%s"', old_path, new_path)
+            shortcuts_text.replace(old_path, new_path)
+
+    shortcuts_conf.write_text(shortcuts_text)


### PR DESCRIPTION
Implements #845, but without deleting any files you would want to keep if you run into issues with v6 and want to revert.

If you want to delete those you have to drop into a python relp and run
```py
from ulauncher.utils.migrate import v5_to_v6_destructive
from ulauncher.config import PATHS
v5_to_v6_destructive(PATHS)
```

This script doesn't touch the settings.json file. It's handled by the Settings class to convert dash to underscore in the key names. If you run v6 and never change the settings in the first (main) page they will still work for v5, but if you do change them you have to set them up again (only takes seconds) or replace the underscores with dash. Ex: `sed -i 's/_/-/g' ~/.config/ulauncher/settings.json`. Note that this example replaces ALL underscores by dash, including the keys. But it's unlikely that you will have them elsewhere.

### Checklist
- [x] Verify that the test command `./ul test` is passing (the CI server will check this if you don't)
- [ ] Update the documentation according to your changes (when applicable)
- [ ] Write unit tests for your changes (when applicable)
