### PR TITLE
Move gi version declaration to __init__.py to avoid having to declare repeatedly

### DIFF
--- a/tests/ui/windows/test_HotkeyDialog.py
+++ b/tests/ui/windows/test_HotkeyDialog.py
@@ -1,7 +1,5 @@
 from unittest import mock
 import pytest
-import gi
-gi.require_version('Gtk', '3.0')
 from gi.repository import Gtk
 from ulauncher.ui.windows.HotkeyDialog import HotkeyDialog
 

--- a/tests/ui/windows/test_UlauncherWindow.py
+++ b/tests/ui/windows/test_UlauncherWindow.py
@@ -1,8 +1,5 @@
 from unittest import mock
 import pytest
-import gi
-gi.require_version('Gtk', '3.0')
-# pylint: disable=wrong-import-position
 from gi.repository import Gtk
 
 from ulauncher.api import Result

--- a/ulauncher/__init__.py
+++ b/ulauncher/__init__.py
@@ -1,5 +1,6 @@
 from configparser import ConfigParser
 from pathlib import Path
+import gi
 
 # This file is overwritten by the build_wrapper script in setup.py
 # IF YOU EDIT THIS FILE make sure your changes are reflected there
@@ -14,3 +15,12 @@ config.read(f"{_PROJECT_ROOT}/setup.cfg")
 ASSETS = f"{_PROJECT_ROOT}/data"
 VERSION = config["metadata"]["version"]
 DESCRIPTION = config["metadata"]["description"]
+
+gi.require_versions({
+    "Gtk": "3.0",
+    "Gdk": "3.0",
+    "GdkX11": "3.0",
+    "GdkPixbuf": "2.0",
+    "Keybinder": "3.0",
+    "Wnck": "3.0",
+})

--- a/ulauncher/api/shared/action/CopyToClipboardAction.py
+++ b/ulauncher/api/shared/action/CopyToClipboardAction.py
@@ -1,9 +1,4 @@
-import gi
-# pylint: disable=wrong-import-position
-gi.require_version('Gtk', '3.0')
-gi.require_version('Gdk', '3.0')
 from gi.repository import Gtk, Gdk
-
 from ulauncher.api.shared.action.BaseAction import BaseAction
 
 

--- a/ulauncher/main.py
+++ b/ulauncher/main.py
@@ -6,8 +6,6 @@ from functools import partial
 # pylint: disable=wrong-import-position,wrong-import-order,ungrouped-imports,unused-import
 import ulauncher.utils.xinit  # noqa: F401
 import gi
-gi.require_version('Gtk', '3.0')
-# pylint: disable=wrong-import-position
 from gi.repository import GLib, Gtk
 from ulauncher.config import API_VERSION, PATHS, VERSION, get_options
 from ulauncher.utils.migrate import v5_to_v6

--- a/ulauncher/modes/file_browser/FileBrowserMode.py
+++ b/ulauncher/modes/file_browser/FileBrowserMode.py
@@ -1,9 +1,6 @@
 import os
 from pathlib import Path
 from typing import List
-import gi
-gi.require_version('Gdk', '3.0')
-# pylint: disable=wrong-import-position
 from gi.repository import Gdk
 from ulauncher.utils.fuzzy_search import get_score
 from ulauncher.api.shared.action.DoNothingAction import DoNothingAction

--- a/ulauncher/ui/AppIndicator.py
+++ b/ulauncher/ui/AppIndicator.py
@@ -1,7 +1,5 @@
 import gi
 
-gi.require_version('Gtk', '3.0')
-
 # Status icon support is optional. It'll work if you install XApp or AppIndicator3
 # Only XApp supports activating the launcher on left click and showing the menu on right click
 # pylint: disable=wrong-import-position

--- a/ulauncher/ui/ResultWidget.py
+++ b/ulauncher/ui/ResultWidget.py
@@ -1,10 +1,6 @@
 import logging
 from typing import Any
-import gi
-gi.require_version('Gtk', '3.0')
-# pylint: disable=wrong-import-position
 from gi.repository import Gtk
-
 from ulauncher.utils.Settings import Settings
 from ulauncher.utils.wm import get_text_scaling_factor
 from ulauncher.utils.icon import load_icon_surface

--- a/ulauncher/ui/UlauncherApp.py
+++ b/ulauncher/ui/UlauncherApp.py
@@ -1,13 +1,7 @@
 import time
 import argparse
 import logging
-# This xinit import must happen before any GUI libraries are initialized.
-# pylint: disable=wrong-import-position,wrong-import-order,ungrouped-imports,unused-import
-import gi
-gi.require_versions({'Gtk': '3.0', 'Keybinder': '3.0'})
-# pylint: disable=wrong-import-position
 from gi.repository import Gio, GLib, Gtk, Keybinder
-
 from ulauncher.config import FIRST_RUN
 from ulauncher.utils.environment import IS_X11
 from ulauncher.utils.Settings import Settings

--- a/ulauncher/ui/preferences_server.py
+++ b/ulauncher/ui/preferences_server.py
@@ -2,12 +2,8 @@ import os
 import logging
 import json
 import mimetypes
-from urllib.parse import unquote, urlparse
 import traceback
-
-import gi
-gi.require_version("Gtk", "3.0")
-# pylint: disable=wrong-import-position
+from urllib.parse import unquote, urlparse
 from gi.repository import Gio, Gtk
 from ulauncher.api.shared.action.OpenAction import OpenAction
 from ulauncher.ui.windows.HotkeyDialog import HotkeyDialog

--- a/ulauncher/ui/windows/HotkeyDialog.py
+++ b/ulauncher/ui/windows/HotkeyDialog.py
@@ -1,8 +1,4 @@
 import logging
-import gi
-gi.require_version('Gtk', '3.0')
-gi.require_version('Gdk', '3.0')
-# pylint: disable=wrong-import-position
 from gi.repository import Gtk, Gdk, GObject
 from ulauncher.config import PATHS
 

--- a/ulauncher/ui/windows/PreferencesWindow.py
+++ b/ulauncher/ui/windows/PreferencesWindow.py
@@ -1,7 +1,4 @@
 import os
-import gi
-gi.require_version("Gtk", "3.0")
-# pylint: disable=wrong-import-position
 from gi.repository import Gtk
 from ulauncher.config import PATHS, get_options
 from ulauncher.utils.WebKit2 import WebKit2

--- a/ulauncher/ui/windows/UlauncherWindow.py
+++ b/ulauncher/ui/windows/UlauncherWindow.py
@@ -1,13 +1,6 @@
 # -*- Mode: Python; coding: utf-8; indent-tabs-mode: nil; tab-width: 4 -*-
 import os
 import logging
-
-import gi
-gi.require_version('Gtk', '3.0')
-gi.require_version('Gdk', '3.0')
-gi.require_version('Keybinder', '3.0')
-
-# pylint: disable=wrong-import-position, unused-argument
 from gi.repository import Gtk, Gdk, Keybinder
 
 # pylint: disable=unused-import

--- a/ulauncher/utils/icon.py
+++ b/ulauncher/utils/icon.py
@@ -2,12 +2,6 @@ import logging
 import mimetypes
 from os.path import join
 from functools import lru_cache
-
-import gi
-gi.require_version('Gdk', '3.0')
-gi.require_version('Gtk', '3.0')
-gi.require_version('GdkPixbuf', '2.0')
-# pylint: disable=wrong-import-position
 from gi.repository import Gdk, Gtk, GdkPixbuf
 from ulauncher import ASSETS
 

--- a/ulauncher/utils/wm.py
+++ b/ulauncher/utils/wm.py
@@ -1,11 +1,4 @@
 import logging
-import gi
-gi.require_versions({
-    "Gdk": "3.0",
-    "GdkX11": "3.0",
-    "Wnck": "3.0",
-})
-# pylint: disable=wrong-import-position
 from gi.repository import Gdk, GdkX11, Gio, Wnck
 
 logger = logging.getLogger()


### PR DESCRIPTION
I always found these `gi.require_version(s)` statements to be super messy and non-standard, adding a lot of verbosity so I moved them all to `__init__.py`

It's faster to set `gi._version = {}` directly instead of using `gi.require_versions({})`, but it's not an official API. So I didn't do it. But after this is effectively all that `gi.require_version(s)` does besides validation: https://gitlab.gnome.org/GNOME/pygobject/-/blob/master/gi/__init__.py#L132

### Checklist
- [x] Verify that the test command `./ul test` is passing (the CI server will check this if you don't)
- [ ] Update the documentation according to your changes (when applicable)
- [ ] Write unit tests for your changes (when applicable)
