### PR TITLE
Fix clion crash (#1110)

### DIFF
--- a/ulauncher/utils/launch_detached.py
+++ b/ulauncher/utils/launch_detached.py
@@ -31,8 +31,7 @@ def launch_detached(cmd):
             argv=cmd,
             envp=envp,
             flags=GLib.SpawnFlags.SEARCH_PATH_FROM_ENVP | GLib.SpawnFlags.SEARCH_PATH,
-            # setsid is really only needed if systemd-run is missing, but doesn't hurt to have.
-            child_setup=os.setsid
+            child_setup=None if use_systemd_run else os.setsid
         )
     except Exception as e:
         logger.error('%s: %s', type(e).__name__, e)


### PR DESCRIPTION
This PR fixes issue #1110 which is caused by the presence of os.setsid. I assume this could be useful on systems missing systemd-run so this PR keeps that functionality intact in that case while disabling it when systemd-run is present (where os.setsid shouldn't have an impact). I did test this and apps started by ulauncher don't stop when ulauncher is stopped. 

### Checklist
- [x] Verify that the test command `./ul test` is passing (the CI server will check this if you don't)
- [ ] Update the documentation according to your changes (when applicable)
- [ ] Write unit tests for your changes (when applicable)
