### PR TITLE
Remove the no-shadow setting

### DIFF
--- a/data/styles/preferences.css
+++ b/data/styles/preferences.css
@@ -3,7 +3,3 @@
 .app-box {
     box-shadow: 0 0 7px rgba(0, 0, 0, 0.4);
 }
-
-.no-window-shadow {
-    margin: -20px;
-}

--- a/data/themes/adwaita/theme.css
+++ b/data/themes/adwaita/theme.css
@@ -82,7 +82,3 @@
 .prefs-btn:hover {
     background-color: @prefs_backgroud;
 }
-
-.no-window-shadow {
-    margin: -20px;
-}

--- a/data/themes/dark/theme.css
+++ b/data/themes/dark/theme.css
@@ -79,7 +79,3 @@
 .prefs-btn:hover {
     background-color: @prefs_backgroud;
 }
-
-.no-window-shadow {
-    margin: -20px;
-}

--- a/data/themes/light/theme.css
+++ b/data/themes/light/theme.css
@@ -100,7 +100,3 @@
 .prefs-btn:hover {
     background-color: @prefs_backgroud;
 }
-
-.no-window-shadow {
-    margin: -20px;
-}

--- a/data/themes/ubuntu/theme.css
+++ b/data/themes/ubuntu/theme.css
@@ -79,7 +79,3 @@
 .prefs-btn:hover {
     background-color: @prefs_backgroud;
 }
-
-.no-window-shadow {
-    margin: -20px;
-}

--- a/preferences-src/src/components/pages/Preferences.vue
+++ b/preferences-src/src/components/pages/Preferences.vue
@@ -144,23 +144,6 @@
 
       <tr>
         <td>
-          <label for="disable-window-shadow">Disable window shadow</label>
-          <small>
-            <p>
-              Try this if you see a box or border instead of shadows.
-            </p>
-            <p v-if="changed.disable_window_shadow">
-              <i class="fa fa-warning"></i> Restart Ulauncher for this to take effect.
-            </p>
-          </small>
-        </td>
-        <td>
-          <b-form-checkbox id="disable-window-shadow" v-model="disable_window_shadow"></b-form-checkbox>
-        </td>
-      </tr>
-
-      <tr>
-        <td>
           <label for="jump-keys">Jump keys</label>
           <small>
             <p>Set the keys to use for quickly jumping to results</p>
@@ -230,7 +213,6 @@ export default {
       'autostart_enabled',
       'clear_previous_query',
       'disable_desktop_filters',
-      'disable_window_shadow',
       'grab_mouse_pointer',
       'jump_keys',
       'raise_if_started',

--- a/ulauncher/main.py
+++ b/ulauncher/main.py
@@ -56,7 +56,7 @@ def main():
     if options.no_extensions:
         logger.warning("The --no-extensions argument has been removed in Ulauncher v6")
     if options.no_window_shadow:
-        logger.warning("The --no-window-shadow argument has been moved to a user setting in Ulauncher v6")
+        logger.warning("The --no-window-shadow argument has been removed in Ulauncher v6")
     if options.hide_window:
         # Ulauncher's "Launch at Login" is now implemented with systemd, but originally
         # it was implemented using XDG autostart. To prevent files created the old way

--- a/ulauncher/ui/windows/UlauncherWindow.py
+++ b/ulauncher/ui/windows/UlauncherWindow.py
@@ -50,15 +50,21 @@ class UlauncherWindow(Gtk.ApplicationWindow):
 
         self.set_visual(visual)
 
-        self.window_body = Gtk.Box(
-            orientation=Gtk.Orientation.VERTICAL,
-            app_paintable=True,
+        # This box exists only for setting the margin conditionally, based on ^
+        # without the theme being able to override it
+        window_frame = Gtk.Box(
             margin_top=window_margin,
             margin_bottom=window_margin,
             margin_start=window_margin,
             margin_end=window_margin,
         )
-        self.add(self.window_body)
+        self.add(window_frame)
+
+        self.window_body = Gtk.Box(
+            orientation=Gtk.Orientation.VERTICAL,
+            app_paintable=True,
+        )
+        window_frame.add(self.window_body)
 
         self.input_box = Gtk.Box()
 

--- a/ulauncher/ui/windows/UlauncherWindow.py
+++ b/ulauncher/ui/windows/UlauncherWindow.py
@@ -42,20 +42,21 @@ class UlauncherWindow(Gtk.ApplicationWindow):
         # Try setting a transparent background
         screen = self.get_screen()
         visual = screen.get_rgba_visual()
-        self.supports_transparency = visual is not None
-        if not self.supports_transparency:
+        window_margin = 20
+        if visual is None:
             logger.debug("Screen does not support alpha channels")
             visual = screen.get_system_visual()
+            window_margin = 0
 
         self.set_visual(visual)
 
         self.window_body = Gtk.Box(
             orientation=Gtk.Orientation.VERTICAL,
             app_paintable=True,
-            margin_top=20,
-            margin_bottom=20,
-            margin_start=20,
-            margin_end=20,
+            margin_top=window_margin,
+            margin_bottom=window_margin,
+            margin_start=window_margin,
+            margin_end=window_margin,
         )
         self.add(self.window_body)
 
@@ -104,8 +105,6 @@ class UlauncherWindow(Gtk.ApplicationWindow):
         self.input.get_style_context().add_class("input")
         self.prefs_btn.get_style_context().add_class("prefs-btn")
         self.result_box.get_style_context().add_class("result-box")
-        if self.settings.disable_window_shadow or not self.supports_transparency:
-            self.window_body.get_style_context().add_class('no-window-shadow')
         self.show_all()
 
         self.connect("focus-in-event", self.on_focus_in)
@@ -232,9 +231,6 @@ class UlauncherWindow(Gtk.ApplicationWindow):
             widget.forall(self.apply_css)
 
     def apply_theme(self):
-        if self.settings.disable_window_shadow or not self.supports_transparency:
-            self.window_body.get_style_context().add_class('no-window-shadow')
-
         prefs_icon_surface = load_icon_surface(f"{PATHS.ASSETS}/icons/gear.svg", 16, self.get_scale_factor())
         self.prefs_btn.set_image(Gtk.Image.new_from_surface(prefs_icon_surface))
 

--- a/ulauncher/utils/Settings.py
+++ b/ulauncher/utils/Settings.py
@@ -5,7 +5,6 @@ from ulauncher.utils.json_data import JsonData, json_data_class
 @json_data_class
 class Settings(JsonData):
     disable_desktop_filters = False
-    disable_window_shadow = False
     clear_previous_query = True
     grab_mouse_pointer = False
     hotkey_show_app = "<Primary>space"


### PR DESCRIPTION
In 474ea7625ac4dad4cc68bdf0e35647526d6efde3 I managed to get the black border issue and solved it for myself by setting the "visuals" to rgba. I also noticed that if rgba is not supported (when not using a compositor) we can detect this and fallback. That solution looked like this:

https://github.com/Ulauncher/Ulauncher/blob/474ea7625ac4dad4cc68bdf0e35647526d6efde3/ulauncher/ui/windows/UlauncherWindow.py#L42-L50

https://github.com/Ulauncher/Ulauncher/blob/474ea7625ac4dad4cc68bdf0e35647526d6efde3/ulauncher/ui/windows/UlauncherWindow.py#L107-L108

I'm not sure this will work for everyone and in all scenarios, but I want to remove it while we're making a major release so we can get rid of this setting in case it does work and bring it back otherwise. [The documentation](https://lazka.github.io/pgi-docs/#Gdk-3.0/classes/Screen.html#Gdk.Screen.get_rgba_visual) says:
> The windowing system on which GTK+ is running may not support this capability, in which case None will be returned. Even if a non-None value is returned, its possible that the window’s alpha channel won’t be honored when displaying the window on the screen: in particular, for X an appropriate windowing manager and compositing manager must be running to provide appropriate display.

This also removes the `no-window-shadow` class and having to set this in every theme. If we bring the setting back, we should try not bring that back.

### Checklist
- [x] Verify that the test command `./ul test` is passing (the CI server will check this if you don't)
- [ ] Update the documentation according to your changes (when applicable)
- [ ] Write unit tests for your changes (when applicable)
