### PR TITLE
fix: failure to launch with GDK_BACKEND=wayland

### DIFF
--- a/ulauncher/utils/wm.py
+++ b/ulauncher/utils/wm.py
@@ -1,8 +1,13 @@
 import logging
-from gi.repository import Gdk, GdkX11, Gio, Wnck
+from gi.repository import Gdk, GdkX11, Gio
+from ulauncher.utils.environment import IS_X11
+
 
 logger = logging.getLogger()
-wnck_screen = Wnck.Screen.get_default()
+if IS_X11:
+    from gi.repository import Wnck
+
+    wnck_screen = Wnck.Screen.get_default()
 
 
 def get_monitor(use_mouse_position=False):


### PR DESCRIPTION
by only loading/calling wnck when running under X11.

### Checklist
- [x] Verify that the test command `./ul test` is passing (the CI server will check this if you don't)
- [ ] Update the documentation according to your changes (when applicable)
- [ ] Write unit tests for your changes (when applicable)

Fixes: #1168 