### PR TITLE
fix: mypy 0.990+

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -18,6 +18,7 @@ For the v6 branch you need the the following to setup the local build environmen
 * [Yarn](https://classic.yarnpkg.com/en/docs/install)
 * python3-setuptools (if you have pip, you have it already)
 * Application runtime dependencies (if you already installed Ulauncher you should have most of these, but **wnck is new for v6**)
+* Optionally install [pygobject-stubs](https://github.com/pygobject/pygobject-stubs). Note that pygobject-stubs can only be installed for Gtk3 OR Gtk4. The only way to switch is to reinstall. Ulauncher uses Gtk3, but Gtk4 is the default. Rather than requiring users to install it for Gtk3 we are currently ignoring the mypy errors for all the incompatible places.
 
 #### Distro specific instructions
 

--- a/ulauncher/api/result.py
+++ b/ulauncher/api/result.py
@@ -11,32 +11,32 @@ OnEnterCallback = Optional[Callable[[Query], Optional[BaseAction]]]
 # pylint: disable=too-many-instance-attributes
 class Result:
     compact = False
-    name = None  # type: str
-    description = None  # type: str
-    keyword = None  # type: str
-    icon = None  # type: Optional[str]
-    _on_enter = None  # type: OnEnterCallback
-    _on_alt_enter = None  # type: OnEnterCallback
-    highlightable = False  # type: bool
-    searchable = False  # type: bool
+    highlightable = False
+    searchable = False
+    name: str = ""
+    description: str = ""
+    keyword: str = ""
+    icon: Optional[str] = None
+    _on_enter: Optional[OnEnterCallback] = None
+    _on_alt_enter: Optional[OnEnterCallback] = None
 
     # pylint: disable=too-many-arguments
     def __init__(self,
-                 name: str = '',
-                 description: str = '',
-                 keyword: str = '',
-                 icon: str = None,
-                 highlightable: bool = None,
+                 name: str = "",
+                 description: str = "",
+                 keyword: str = "",
+                 icon: str = "",
+                 highlightable: bool = False,
                  on_enter: OnEnterCallback = None,
                  on_alt_enter: OnEnterCallback = None,
-                 searchable: bool = None,
-                 compact: bool = None):
+                 searchable: Optional[bool] = None,
+                 compact: Optional[bool] = None):
         if not isinstance(name, str):
-            raise TypeError(f'"name" must be of type "str", "{type(name).__name__}" given')
+            raise TypeError(f'"name" must be of type "str", "{type(name).__name__}" given.')
         if not isinstance(description, str):
-            raise TypeError(f'"description" must be of type "str", "{type(description).__name__}" given')
+            raise TypeError(f'"description" must be of type "str", "{type(description).__name__}" given.')
         if not isinstance(keyword, str):
-            raise TypeError(f'"keyword" must be of type "str", "{type(keyword).__name__}" given')
+            raise TypeError(f'"keyword" must be of type "str", "{type(keyword).__name__}" given.')
         self.name = name
         self.description = description
         self.keyword = keyword

--- a/ulauncher/modes/calc/CalcResult.py
+++ b/ulauncher/modes/calc/CalcResult.py
@@ -1,3 +1,4 @@
+from typing import Optional
 from decimal import Decimal
 from ulauncher.api.result import Result
 from ulauncher.api.shared.action.CopyToClipboardAction import CopyToClipboardAction
@@ -8,7 +9,7 @@ from ulauncher.config import PATHS
 class CalcResult(Result):
 
     # pylint: disable=super-init-not-called
-    def __init__(self, result: Decimal = None, error: str = 'Unknown error'):
+    def __init__(self, result: Optional[Decimal] = None, error: str = 'Unknown error'):
         self.result = result
         self.error = error
         self.name = f'{Decimal(self.result):n}' if self.result is not None else 'Error!'

--- a/ulauncher/modes/extensions/ExtensionController.py
+++ b/ulauncher/modes/extensions/ExtensionController.py
@@ -26,7 +26,7 @@ class ExtensionController:
             raise RuntimeError("No extension_id provided")
         self.controllers = controllers
         self.framer = framer
-        self.result_renderer = DeferredResultRenderer.get_instance()  # type: DeferredResultRenderer
+        self.result_renderer = DeferredResultRenderer.get_instance()
         self.extension_id = extension_id
         self.manifest = ExtensionManifest.load_from_extension_id(extension_id)
         try:

--- a/ulauncher/ui/AppIndicator.py
+++ b/ulauncher/ui/AppIndicator.py
@@ -5,7 +5,7 @@ import gi
 # pylint: disable=wrong-import-position
 try:
     gi.require_version('XApp', '1.0')
-    from gi.repository import XApp
+    from gi.repository import XApp  # type: ignore[attr-defined]
     # Older versions of XApp doesn't have StatusIcon
     assert hasattr(XApp, 'StatusIcon')
     AyatanaIndicator = None
@@ -13,12 +13,12 @@ except (AssertionError, ImportError, ValueError):
     XApp = None
     try:
         gi.require_version('AppIndicator3', '0.1')
-        from gi.repository import AppIndicator3
+        from gi.repository import AppIndicator3  # type: ignore[attr-defined]
         AyatanaIndicator = AppIndicator3
     except (ImportError, ValueError):
         try:
             gi.require_version('AyatanaAppIndicator3', '0.1')
-            from gi.repository import AyatanaAppIndicator3 as AppIndicator3  # noqa: F811
+            from gi.repository import AyatanaAppIndicator3 as AppIndicator3  # type: ignore[attr-defined, no-redef] # noqa: F811,E501
             AyatanaIndicator = AppIndicator3
         except (ImportError, ValueError):
             pass

--- a/ulauncher/ui/ResultWidget.py
+++ b/ulauncher/ui/ResultWidget.py
@@ -11,7 +11,7 @@ from ulauncher.api.shared.query import Query
 logger = logging.getLogger()
 
 
-class ResultWidget(Gtk.EventBox):
+class ResultWidget(Gtk.EventBox):  # type: ignore[name-defined]
     __gtype_name__ = "ResultWidget"
 
     index: int = 0
@@ -62,7 +62,7 @@ class ResultWidget(Gtk.EventBox):
         self.set_description(result.get_description(query))  # need to run even if there is no descr
         self.set_name_highlighted()
 
-    def set_index(self, index):
+    def set_index(self, index: int):
         """
         Set index for the item and assign shortcut
         """

--- a/ulauncher/ui/ResultWidget.py
+++ b/ulauncher/ui/ResultWidget.py
@@ -14,12 +14,12 @@ logger = logging.getLogger()
 class ResultWidget(Gtk.EventBox):
     __gtype_name__ = "ResultWidget"
 
-    index = 0  # type: int
-    builder = None  # type: Any
-    name = ''  # type: str
-    query = Query('')  # type: Query
-    result = None  # type: Any
-    item_box = None  # type: Any
+    index: int = 0
+    builder: Any
+    name: str
+    query: Query
+    result: Any
+    item_box: Any
     compact = False
 
     def initialize(self, builder: Any, result: Any, index: int, query: Query) -> None:

--- a/ulauncher/ui/UlauncherApp.py
+++ b/ulauncher/ui/UlauncherApp.py
@@ -2,7 +2,7 @@ import time
 import logging
 from functools import lru_cache
 from typing import Optional
-from gi.repository import Gio, GLib, Gtk, Keybinder
+from gi.repository import Gio, GLib, Gtk, Keybinder  # type: ignore[attr-defined]
 from ulauncher.config import FIRST_RUN
 from ulauncher.utils.environment import IS_X11
 from ulauncher.utils.Settings import Settings

--- a/ulauncher/ui/UlauncherApp.py
+++ b/ulauncher/ui/UlauncherApp.py
@@ -1,6 +1,7 @@
 import time
 import logging
 from functools import lru_cache
+from typing import Optional
 from gi.repository import Gio, GLib, Gtk, Keybinder
 from ulauncher.config import FIRST_RUN
 from ulauncher.utils.environment import IS_X11
@@ -25,9 +26,9 @@ class UlauncherApp(Gtk.Application):
     # new instances sends the signals to the registered one
     # So all methods except __init__ runs on the main app
     _query = ""
-    window = None  # type: UlauncherWindow
-    preferences = None  # type: PreferencesWindow
-    _appindicator = None  # type: AppIndicator
+    window: Optional[UlauncherWindow] = None
+    preferences: Optional[PreferencesWindow] = None
+    _appindicator: Optional[AppIndicator] = None
     _current_accel_name = None
 
     def __init__(self, *args, **kwargs):

--- a/ulauncher/ui/windows/UlauncherWindow.py
+++ b/ulauncher/ui/windows/UlauncherWindow.py
@@ -1,6 +1,6 @@
 # -*- Mode: Python; coding: utf-8; indent-tabs-mode: nil; tab-width: 4 -*-
 import logging
-from gi.repository import Gtk, Gdk, Keybinder
+from gi.repository import Gtk, Gdk, Keybinder  # type: ignore[attr-defined]
 
 # pylint: disable=unused-import
 # these imports are needed for Gtk to find widget classes

--- a/ulauncher/utils/WebKit2.py
+++ b/ulauncher/utils/WebKit2.py
@@ -10,4 +10,4 @@ try:
 except ValueError:
     gi.require_version("WebKit2", "4.0")
 # pylint: disable=wrong-import-position,unused-import
-from gi.repository import WebKit2  # noqa: F401
+from gi.repository import WebKit2  # type: ignore[attr-defined] # noqa: F401

--- a/ulauncher/utils/decorator/singleton.py
+++ b/ulauncher/utils/decorator/singleton.py
@@ -1,7 +1,6 @@
 from typing import Dict, Callable, Any
 
-CachedInstances = Dict[Callable, Any]
-objects = {}  # type: CachedInstances
+objects: Dict[Callable, Any] = {}
 
 
 def singleton(fn):

--- a/ulauncher/utils/desktop/notification.py
+++ b/ulauncher/utils/desktop/notification.py
@@ -6,7 +6,7 @@ except ValueError:
     gi.require_version("Notify", "0.8")
 
 # pylint: disable=wrong-import-position
-from gi.repository import Notify
+from gi.repository import Notify  # type: ignore[attr-defined]
 
 Notify.init('ulauncher')
 logger = logging.getLogger()

--- a/ulauncher/utils/icon.py
+++ b/ulauncher/utils/icon.py
@@ -5,7 +5,7 @@ from functools import lru_cache
 from gi.repository import Gdk, Gtk, GdkPixbuf
 from ulauncher import ASSETS
 
-icon_theme = Gtk.IconTheme.get_default()
+icon_theme = Gtk.IconTheme.get_default()  # type: ignore[attr-defined]
 logger = logging.getLogger()
 
 DEFAULT_EXE_ICON = f"{ASSETS}/icons/executable.png"

--- a/ulauncher/utils/wm.py
+++ b/ulauncher/utils/wm.py
@@ -1,11 +1,11 @@
 import logging
-from gi.repository import Gdk, GdkX11, Gio
+from gi.repository import Gdk, GdkX11, Gio  # type: ignore[attr-defined]
 from ulauncher.utils.environment import IS_X11
 
 
 logger = logging.getLogger()
 if IS_X11:
-    from gi.repository import Wnck
+    from gi.repository import Wnck  # type: ignore[attr-defined]
 
     wnck_screen = Wnck.Screen.get_default()
 
@@ -33,7 +33,7 @@ def get_text_scaling_factor() -> int:
     # GTK seems to already compensate for monitor scaling, so this just returns font scaling
     # GTK doesn't seem to allow different scaling factors on different displays
     # Text_scaling allow fractional scaling
-    return Gio.Settings.new("org.gnome.desktop.interface").get_double('text-scaling-factor')
+    return Gio.Settings.new("org.gnome.desktop.interface").get_double("text-scaling-factor")  # type: ignore[arg-type]
 
 
 def get_windows_stacked():


### PR DESCRIPTION
Gobject/Gtk now works even worse with Mypy (0.990+) than it does with Pylint.

Gobject is a FFI integration and an anomaly, and modern more strictly typed Python doesn't like what it can't understand.

Also fixes PEP 484 / implicit optionals error that was added (correctly so) in 0.990, and removes/updates outdated type annotations comments.

### Checklist
- [x] Verify that the test command `./ul test` is passing (the CI server will check this if you don't)
- [x] Update the documentation according to your changes (when applicable)
- [ ] Write unit tests for your changes (when applicable)
