### PR TITLE
feat: use begin_move_drag for moving window

### DIFF
--- a/ulauncher/ui/windows/UlauncherWindow.py
+++ b/ulauncher/ui/windows/UlauncherWindow.py
@@ -69,9 +69,9 @@ class UlauncherWindow(Gtk.ApplicationWindow, LayerShellOverlay):
         )
         window_frame.pack_start(window_container, True, True, 0)
 
-        self.event_box = Gtk.EventBox()
+        event_box = Gtk.EventBox()
         input_box = Gtk.Box()
-        self.event_box.add(input_box)
+        event_box.add(input_box)
 
         self.input = Gtk.Entry(
             can_default=True,
@@ -109,7 +109,7 @@ class UlauncherWindow(Gtk.ApplicationWindow, LayerShellOverlay):
         self.result_box = Gtk.Box(orientation=Gtk.Orientation.VERTICAL)
         self.scroll_container.add(self.result_box)
 
-        window_container.pack_start(self.event_box, True, True, 0)
+        window_container.pack_start(event_box, True, True, 0)
         window_container.pack_end(self.scroll_container, True, True, 0)
 
         window_container.get_style_context().add_class("app")
@@ -123,7 +123,7 @@ class UlauncherWindow(Gtk.ApplicationWindow, LayerShellOverlay):
 
         self.connect("focus-in-event", self.on_focus_in)
         self.connect("focus-out-event", self.on_focus_out)
-        self.event_box.connect("button-press-event", self.on_mouse_down)
+        event_box.connect("button-press-event", self.on_mouse_down)
         self.input.connect("changed", self.on_input_changed)
         self.input.connect("key-press-event", self.on_input_key_press)
         prefs_btn.connect("clicked", lambda *_: self.app.show_preferences())

--- a/ulauncher/ui/windows/UlauncherWindow.py
+++ b/ulauncher/ui/windows/UlauncherWindow.py
@@ -124,8 +124,6 @@ class UlauncherWindow(Gtk.ApplicationWindow, LayerShellOverlay):
         self.connect("focus-in-event", self.on_focus_in)
         self.connect("focus-out-event", self.on_focus_out)
         self.event_box.connect("button-press-event", self.on_mouse_down)
-        self.connect("button-release-event", self.on_mouse_up)
-        self.connect("motion_notify_event", self.on_mouse_move)
         self.input.connect("changed", self.on_input_changed)
         self.input.connect("key-press-event", self.on_input_key_press)
         prefs_btn.connect("clicked", lambda *_: self.app.show_preferences())
@@ -189,27 +187,10 @@ class UlauncherWindow(Gtk.ApplicationWindow, LayerShellOverlay):
 
     def on_mouse_down(self, _, event):
         """
-        Prepare moving the window if the user drags
+        Move the window on drag
         """
         if event.button == 1:
-            self.set_cursor("grab")
-            x, y = self.event_box.translate_coordinates(self, event.x, event.y)
-            self._drag_start_coords = {"x": x, "y": y}
-
-    def on_mouse_up(self, *_):
-        """
-        Clear drag to move event data
-        """
-        self._drag_start_coords = None
-        self.set_cursor("default")
-
-    def on_mouse_move(self, _, event):
-        """
-        Move window if cursor is held
-        """
-        start = self._drag_start_coords
-        if start and event.state == Gdk.ModifierType.BUTTON1_MASK:
-            self.move(event.x_root - start["x"], event.y_root - start["y"])
+            self.begin_move_drag(event.button, event.x_root, event.y_root, event.time)
 
     ######################################
     # Helpers
@@ -274,10 +255,6 @@ class UlauncherWindow(Gtk.ApplicationWindow, LayerShellOverlay):
         super().hide(*args, **kwargs)
         if self.settings.clear_previous_query:
             self.app.query = ""
-
-    def set_cursor(self, cursor_name):
-        cursor = Gdk.Cursor.new_from_name(self.get_display(), cursor_name)
-        self.get_window().set_cursor(cursor)
 
     def select_result(self, index):
         self.results_nav.select(index)


### PR DESCRIPTION
As per discussion in https://github.com/Ulauncher/Ulauncher/pull/1172#issuecomment-1371922928

I don't remember why I couldn't use this before. It may have been related to other changes we have made since.

### Checklist
- [x] Verify that the test command `./ul test` is passing (the CI server will check this if you don't)
- [ ] Update the documentation according to your changes (when applicable)
- [ ] Write unit tests for your changes (when applicable)
