### PR TITLE
Test/flake8 bugbear

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,4 +4,5 @@ pytest-mock~=3.10.0
 pylint~=2.15.9
 mypy~=0.991
 flake8~=6.0.0
+flake8-bugbear~=22.12.6
 PyGObject-stubs~=2.1.0

--- a/tests/utils/test_json_data.py
+++ b/tests/utils/test_json_data.py
@@ -18,10 +18,10 @@ class TestJsonData:
         jd = JsonData()
         assert not hasattr(jd, "a")
         with pytest.raises(AttributeError):
-            getattr(jd, "a")
+            jd.a
         jd.a = False
         assert hasattr(jd, "a")
-        assert getattr(jd, "a") is False
+        assert jd.a is False
 
     def test_setting_and_comparison(self):
         jd = JsonData()

--- a/ulauncher/utils/fuzzy_search.py
+++ b/ulauncher/utils/fuzzy_search.py
@@ -18,7 +18,7 @@ try:
     def _get_matching_blocks(query, text):
         return matching_blocks(editops(query, text), query, text)
 
-except (ModuleNotFoundError, ImportError):
+except ImportError:
     logger.warning("Levenshtein is missing or outdated. Falling back to slower fuzzy-finding method.")
     _get_matching_blocks = _get_matching_blocks_native
 


### PR DESCRIPTION
Adds https://github.com/PyCQA/flake8-bugbear and fixes the problems it found

```
./tests/utils/test_json_data.py:21:13: B009 Do not call getattr with a constant attribute value, it is not any safer than normal property access.
./tests/utils/test_json_data.py:24:16: B009 Do not call getattr with a constant attribute value, it is not any safer than normal property access.
./ulauncher/utils/fuzzy_search.py:21:1: B014 Redundant exception types in `except (ModuleNotFoundError, ImportError):`.  Write `except ImportError:`, which catches exactly the same exceptions.
```

### Checklist
- [x] Verify that the test command `./ul test` is passing (the CI server will check this if you don't)
- [ ] Update the documentation according to your changes (when applicable)
- [ ] Write unit tests for your changes (when applicable)
