### PR TITLE
ci: checks improvements

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -1,5 +1,8 @@
 name: Checks
-on: [push]
+on:
+  push:
+    branches-ignore:
+      - v5
 
 jobs:
   build:

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -14,11 +14,12 @@ jobs:
         python-version: [3.8, 3.11]
     name: Checks
     steps:
+    - name: Install system dependencies
+      run: |
+        echo 'debconf debconf/frontend select Noninteractive' | sudo debconf-set-selections
+        sudo apt update &&
+        sudo apt install -y -q xvfb libgirepository1.0-dev libcairo2-dev gir1.2-glib-2.0 gir1.2-gtk-3.0 gir1.2-keybinder-3.0 gir1.2-notify-0.7 gir1.2-webkit2-4.0 gir1.2-wnck-3.0
     - uses: actions/checkout@v3
-    - uses: awalsh128/cache-apt-pkgs-action@v1
-      with:
-        packages: xvfb libgirepository1.0-dev libcairo2-dev gir1.2-glib-2.0 gir1.2-gtk-3.0 gir1.2-keybinder-3.0 gir1.2-notify-0.7 gir1.2-webkit2-4.0 gir1.2-wnck-3.0
-        version: 1.0
     - uses: actions/setup-python@v4
       with:
         python-version: ${{ matrix.python-version }}

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -24,6 +24,7 @@ jobs:
       with:
         python-version: ${{ matrix.python-version }}
         cache: 'pip'
+    # In pip 22.1 and newer you can ignore the sudo warning by adding --root-user-action=ignore
     - run: pip install --upgrade pip
     - run: pip install -r requirements.txt
     - run: pip install PyGObject


### PR DESCRIPTION
Small improvements to checks workflow.

* Don't want to run it for v5 branch (not sure if it will run on PRs for v5 though, but I usually push directly to v5 if there's anything)
* Switched from cache-apt-pkgs-action to just `apt`. apt packages are pre-built so it's already like having a free cache, and overall it seems faster, and `cache-apt-pkgs-action` also didn't work with https://github.com/nektos/act (although act fails at a later point anyway)

### Checklist
- [x] Verify that the test command `./ul test` is passing (the CI server will check this if you don't)
- [ ] Update the documentation according to your changes (when applicable)
- [ ] Write unit tests for your changes (when applicable)
