### PR TITLE
feat: default to pure wayland on wayland

### DIFF
--- a/bin/ulauncher
+++ b/bin/ulauncher
@@ -19,9 +19,6 @@ if IS_DEV:
     sys.path.insert(0, str(PROJECT_ROOT))
     os.environ["PYTHONPATH"] = ":".join(list(filter(None, [PYTHONPATH, str(PROJECT_ROOT)])))
 
-if not os.environ.get("GDK_BACKEND"):
-    os.environ["GDK_BACKEND"] = "x11"
-
 from ulauncher.main import main
 
 main(IS_DEV)


### PR DESCRIPTION
I have done some tests and XWayland by default without workarounds is arguably more broken, or at least broken in more critical ways than pure Wayland. It will ultimately depend on your setup. For example XWayland works good if you don't use multiple displays, disable focus stealing prevention and disable display scaling (use text scaling instead). But if you do use multiple displays there's no workaround.

The only really bad issue for Xwayland is lack of positioning, but the window manager can sometimes handle that ok enough either by defaulting to center, center all windows (ex on gnome: `gsettings set org.gnome.mutter center-new-windows true`) or center Ulauncher specifically.

Movable window and "Always on top" is not nearly as important imo.

It may be possible to fix the focus stealing issue, but not multi-display support. You can't get the pointer position for security reasons and there's no API to get the "active" display (just the "[primary](https://lazka.github.io/pgi-docs/#Gdk-3.0/classes/Display.html#Gdk.Display.get_primary_monitor)", "first" or "default" display/screen/monitor which is the same as the only one for the screen or the one with the status bar for the display) 

See #1184