### PR TITLE
refactor!: remove render-on-screen

### DIFF
--- a/preferences-src/src/components/pages/Preferences.vue
+++ b/preferences-src/src/components/pages/Preferences.vue
@@ -57,20 +57,6 @@
 
       <tr>
         <td>
-          <label for="render-on-screen">Screen to show on</label>
-        </td>
-        <td>
-          <b-form-select style="min-width:380px"
-            id="render-on-screen"
-            class="render-on-screen-select"
-            :options="renderOnScreenOptions"
-            v-model="render_on_screen"
-          ></b-form-select>
-        </td>
-      </tr>
-
-      <tr>
-        <td>
           <label for="show-recent-apps">Number of frequent apps to show</label>
         </td>
         <td>
@@ -193,11 +179,7 @@ export default {
 
   data() {
     return {
-      changed : {},
-      renderOnScreenOptions: [
-        { value: 'mouse-pointer-monitor', text: 'The screen with the mouse pointer' },
-        { value: 'default-monitor', text: 'The default screen' },
-      ]
+      changed : {}
     }
   },
 
@@ -216,7 +198,6 @@ export default {
       'grab_mouse_pointer',
       'jump_keys',
       'raise_if_started',
-      'render_on_screen',
       'show_indicator_icon',
       'max_recent_apps',
       'terminal_command',

--- a/ulauncher/ui/windows/UlauncherWindow.py
+++ b/ulauncher/ui/windows/UlauncherWindow.py
@@ -11,7 +11,7 @@ from ulauncher.ui.ItemNavigation import ItemNavigation
 from ulauncher.modes.ModeHandler import ModeHandler
 from ulauncher.modes.apps.AppResult import AppResult
 from ulauncher.utils.Settings import Settings
-from ulauncher.utils.wm import get_monitor
+from ulauncher.utils.wm import get_active_monitor
 from ulauncher.utils.icon import load_icon_surface
 from ulauncher.utils.environment import IS_X11_COMPATIBLE
 from ulauncher.utils.Theme import Theme
@@ -228,7 +228,7 @@ class UlauncherWindow(Gtk.ApplicationWindow, LayerShellOverlay):
             self.set_visual(visual)
 
     def position_window(self):
-        monitor = get_monitor(self.settings.render_on_screen != "default-monitor")
+        monitor = get_active_monitor()
         geo = monitor.get_geometry()
         max_height = geo.height - (geo.height * 0.15) - 100  # 100 is roughly the height of the text input
         window_width = 750

--- a/ulauncher/utils/Settings.py
+++ b/ulauncher/utils/Settings.py
@@ -11,7 +11,6 @@ class Settings(JsonData):
     jump_keys = "1234567890abcdefghijklmnopqrstuvwxyz"
     max_recent_apps = 0
     raise_if_started = False
-    render_on_screen = "mouse-pointer-monitor"
     show_indicator_icon = True
     terminal_command = ""
     theme_name = "light"

--- a/ulauncher/utils/wm.py
+++ b/ulauncher/utils/wm.py
@@ -11,13 +11,13 @@ if IS_X11:
     wnck_screen = Wnck.Screen.get_default()
 
 
-def get_monitor(use_mouse_position=False):
+def get_active_monitor():
     """
     :rtype: class:Gdk.Monitor
     """
     display = Gdk.Display.get_default()
 
-    if use_mouse_position:
+    if IS_X11:
         try:
             x11_display = GdkX11.X11Display.get_default()
             seat = x11_display.get_default_seat()


### PR DESCRIPTION
Remove the choice of screen to show the Ulauncher window on added in #437 / #445.

The problem with this setting is it's impossible to support in Wayland. In Wayland the window manager is responsible for placing your window on the screen, and GTK decided that this means applications are not allowed to do that any more, and "it's not the tookits job" to support this (to quote a GTK lead dev).

Furthermore, the default screen is basically the one with the menu bar etc, and the active screen the one with the cursor, but What if you want Ulauncher to appear on a fixed screen number which is neither? What if you want this when your laptop is connected to some specific screens, but then bring your laptop home from work, work without any external screen on the train home, then connect the laptop to your home desktop screens, and then you have different screens. I think it would be great to cover scenarios like this in an app launcher, if it was possible to do for Wayland, but [since it's not](https://discourse.gnome.org/t/get-monitor-number-size-and-scale-with-gtk-and-wayland/2776),this makes things harder. Although maybe we should consider Wayland as not being a desktop protocol (because it isn't) and only fully support wlroots?

The default behavior in Wayland is what we want though: open new windows on the active screen. This is what we were doing anyway in Ulauncher's default behavior since before this option was added, and what makes most sense. So by removing this feature which only works in X11 (not XWayland or Wayland) we can get consistent behavior for X11 and pure Wayland (but not XWayland since the workaround for X11 to get the active screen relies on getting the mouse position, which only X11 reports).

Removing row 20 in wm.py (`if IS_X11:`) would make it occasionally work in XWayland also, but only if your mouse is over an XWayland window.