### PR TITLE
fix: Rewrite ExtensionDownloader to use git repo discover references

### DIFF
--- a/preferences-src/src/components/pages/ExtensionConfig.vue
+++ b/preferences-src/src/components/pages/ExtensionConfig.vue
@@ -26,11 +26,11 @@
           <b-dropdown-item v-if="extension.url" @click="reportIssue">Report issue</b-dropdown-item>
           <b-dropdown-item disabled v-if="extension.last_commit">
             <i class="fa fa-calendar fa-fw"></i>
-            {{ lastCommitDate }}
+            {{ extension.updated_at.slice(0, 10) }}
           </b-dropdown-item>
           <b-dropdown-item disabled v-if="extension.last_commit">
             <i class="fa fa-code-fork fa-fw"></i>
-            <span class="text-monospace">{{ extension.last_commit.substring(0, 7) }}</span>
+            <span class="text-monospace">{{ extension.last_commit.slice(0, 7) }}</span>
           </b-dropdown-item>
         </b-dropdown>
       </div>
@@ -127,12 +127,7 @@
           New version is available:
           &nbsp;&nbsp;&nbsp;
           <i class="fa fa-code-fork"></i>
-          {{ newVersionInfo.last_commit.slice(0, 7) }}
-          &nbsp;&nbsp;&nbsp;
-          <i
-            class="fa fa-calendar"
-          ></i>
-          {{ newVersionInfo.last_commit_time.slice(0, 10) }}
+          {{ commitHash.slice(0, 7) }}
         </p>
       </div>
       <div v-if="updateState == 'no-updates'">No new updates are available</div>
@@ -173,13 +168,10 @@ export default {
       showSavedMsg: false,
       updateError: null,
       updateState: null, // null | checking-updates | update-available | no-updates | updating | updated
-      newVersionInfo: null
+      commitHash: null
     }
   },
   computed: {
-    lastCommitDate() {
-      return  (this.$props.extension.last_commit_time || '').slice(0, 10)
-    },
     canSave() {
       const { preferences, triggers } = this.$props.extension
       return Boolean(Object.keys(triggers).length || Object.keys(preferences).length)
@@ -280,17 +272,13 @@ export default {
     checkUpdates() {
       this.updateError = null
       this.updateExtModal = true
-      this.newVersionInfo = null
+      this.commitHash = null
       this.updateState = 'checking-updates'
       fetchData('prefs:///extension/check-update', this.extension.id)
         .then(
-          ([has_update, last_commit, last_commit_time]) => {
-            if (has_update) {
-              this.newVersionInfo = {last_commit, last_commit_time}
-              this.updateState = 'update-available'
-            } else {
-              this.updateState = 'no-updates'
-            }
+          ([hasUpdate, commitHash]) => {
+            this.commitHash = commitHash
+            this.updateState = hasUpdate ? 'update-available' : 'no-updates'
           },
           err => {
             this.updateState = null

--- a/tests/modes/apps/extensions/test_ExtensionDownloader.py
+++ b/tests/modes/apps/extensions/test_ExtensionDownloader.py
@@ -55,7 +55,6 @@ class TestExtensionDownloader:
                     "url": "https://github.com/Ulauncher/ulauncher-timer",
                     "updated_at": datetime.now.return_value.isoformat.return_value,
                     "last_commit": "64e106c",
-                    "last_commit_time": "2017-05-01T07:30:39",
                 }
             }
         )
@@ -68,7 +67,6 @@ class TestExtensionDownloader:
             "url": "https://github.com/Ulauncher/ulauncher-timer",
             "updated_at": "2017-01-01",
             "last_commit": "aDbc",
-            "last_commit_time": "2017-01-01",
         }
         os = mocker.patch("ulauncher.modes.extensions.ExtensionDownloader.os")
         os.path.exists.return_value = True
@@ -83,7 +81,6 @@ class TestExtensionDownloader:
             url="https://github.com/Ulauncher/ulauncher-timer",
             updated_at="2017-01-01",
             last_commit="aDbc",
-            last_commit_time="2017-01-01",
         )
 
         assert downloader.update(ext_id)
@@ -97,7 +94,6 @@ class TestExtensionDownloader:
                     "url": "https://github.com/Ulauncher/ulauncher-timer",
                     "updated_at": datetime.now.return_value.isoformat.return_value,
                     "last_commit": "64e106c",
-                    "last_commit_time": "2017-05-01T07:30:39",
                 }
             }
         )
@@ -109,7 +105,6 @@ class TestExtensionDownloader:
             url="https://github.com/Ulauncher/ulauncher-timer",
             updated_at="2017-01-01",
             last_commit="a8827b723",
-            last_commit_time="2017-01-01",
         )
 
         assert downloader.check_update(ext_id) == (True, "64e106c", "2017-05-01T07:30:39")

--- a/tests/modes/apps/extensions/test_ExtensionDownloader.py
+++ b/tests/modes/apps/extensions/test_ExtensionDownloader.py
@@ -2,7 +2,7 @@ from unittest import mock
 import pytest
 
 from ulauncher.modes.extensions.ExtensionDb import ExtensionDb, ExtensionRecord
-from ulauncher.modes.extensions.ExtensionDownloader import ExtensionDownloader, ExtensionAlreadyInstalledWarning
+from ulauncher.modes.extensions.ExtensionDownloader import ExtensionDownloader
 
 
 class TestExtensionDownloader:
@@ -15,96 +15,19 @@ class TestExtensionDownloader:
         return ExtensionDownloader(ext_db)
 
     @pytest.fixture(autouse=True)
-    def gh_ext(self, mocker):
-        gh_ext = mocker.patch("ulauncher.modes.extensions.ExtensionDownloader.ExtensionRemote").return_value
-        gh_ext.extension_id = "com.github.ulauncher.ulauncher-timer"
-        gh_ext.get_download_url.return_value = "https://github.com/Ulauncher/ulauncher-timer/archive/master.tar.gz"
-        gh_ext.get_latest_compatible_commit.return_value = ("64e106c", "2017-05-01T07:30:39")
-        return gh_ext
+    def remote(self, mocker):
+        remote = mocker.patch("ulauncher.modes.extensions.ExtensionDownloader.ExtensionRemote").return_value
+        remote.extension_id = "com.github.ulauncher.ulauncher-timer"
+        remote.get_download_url.return_value = "https://github.com/Ulauncher/ulauncher-timer/archive/master.tar.gz"
+        remote.get_compatible_hash.return_value = "64e106c"
+        return remote
 
-    @pytest.fixture(autouse=True)
-    def download_tarball(self, mocker):
-        return mocker.patch("ulauncher.modes.extensions.ExtensionDownloader.download_tarball")
-
-    @pytest.fixture(autouse=True)
-    def ExtensionRemote(self, mocker):
-        return mocker.patch("ulauncher.modes.extensions.ExtensionDownloader.ExtensionRemote")
-
-    @pytest.fixture(autouse=True)
-    def untar(self, mocker):
-        return mocker.patch("ulauncher.modes.extensions.ExtensionDownloader.untar")
-
-    @pytest.fixture(autouse=True)
-    def datetime(self, mocker):
-        return mocker.patch("ulauncher.modes.extensions.ExtensionDownloader.datetime")
-
-    # pylint: disable=unused-argument,too-many-arguments
-    def test_download(self, downloader, mocker, untar, ext_db, download_tarball, datetime):
-        os = mocker.patch("ulauncher.modes.extensions.ExtensionDownloader.os")
-        os.path.exists.return_value = False
-        assert (
-            downloader.download("https://github.com/Ulauncher/ulauncher-timer")
-            == "com.github.ulauncher.ulauncher-timer"
-        )
-
-        untar.assert_called_with(download_tarball.return_value, mock.ANY, strip=1)
-        ext_db.save.assert_called_with(
-            {
-                "com.github.ulauncher.ulauncher-timer": {
-                    "id": "com.github.ulauncher.ulauncher-timer",
-                    "url": "https://github.com/Ulauncher/ulauncher-timer",
-                    "updated_at": datetime.now.return_value.isoformat.return_value,
-                    "last_commit": "64e106c",
-                }
-            }
-        )
-
-    # pylint: disable=unused-argument
-    def test_download_raises_AlreadyDownloadedError(self, downloader, ext_db, mocker):
-        ext_id = "com.github.ulauncher.ulauncher-timer"
-        ext_db.get.return_value = {
-            "id": ext_id,
-            "url": "https://github.com/Ulauncher/ulauncher-timer",
-            "updated_at": "2017-01-01",
-            "last_commit": "aDbc",
-        }
-        os = mocker.patch("ulauncher.modes.extensions.ExtensionDownloader.os")
-        os.path.exists.return_value = True
-
-        with pytest.raises(ExtensionAlreadyInstalledWarning):
-            downloader.download("https://github.com/Ulauncher/ulauncher-timer")
-
-    def test_update(self, downloader, ext_db, gh_ext, download_tarball, untar, datetime):
+    def test_check_update__returns_new_version(self, downloader, ext_db):
         ext_id = "com.github.ulauncher.ulauncher-timer"
         ext_db.get.return_value = ExtensionRecord(
             id=ext_id,
             url="https://github.com/Ulauncher/ulauncher-timer",
             updated_at="2017-01-01",
-            last_commit="aDbc",
         )
 
-        assert downloader.update(ext_id)
-
-        download_tarball.assert_called_with(gh_ext.get_download_url.return_value)
-        untar.assert_called_with(download_tarball.return_value, mock.ANY, strip=1)
-        ext_db.save.assert_called_with(
-            {
-                ext_id: {
-                    "id": ext_id,
-                    "url": "https://github.com/Ulauncher/ulauncher-timer",
-                    "updated_at": datetime.now.return_value.isoformat.return_value,
-                    "last_commit": "64e106c",
-                }
-            }
-        )
-
-    def test_check_update__returns_new_version(self, downloader, ext_db, gh_ext):
-        ext_id = "com.github.ulauncher.ulauncher-timer"
-        ext_db.get.return_value = ExtensionRecord(
-            id=ext_id,
-            url="https://github.com/Ulauncher/ulauncher-timer",
-            updated_at="2017-01-01",
-            last_commit="a8827b723",
-        )
-
-        assert downloader.check_update(ext_id) == (True, "64e106c", "2017-05-01T07:30:39")
+        assert downloader.check_update(ext_id) == (True, "64e106c")

--- a/ulauncher/modes/extensions/ExtensionDb.py
+++ b/ulauncher/modes/extensions/ExtensionDb.py
@@ -8,7 +8,6 @@ class ExtensionRecord(JsonData):
     url = ""
     updated_at = ""
     last_commit = ""
-    last_commit_time = ""
 
 
 class ExtensionDb(JsonData):

--- a/ulauncher/modes/extensions/ExtensionDb.py
+++ b/ulauncher/modes/extensions/ExtensionDb.py
@@ -8,6 +8,7 @@ class ExtensionRecord(JsonData):
     url = ""
     updated_at = ""
     last_commit = ""
+    last_commit_time = ""
 
 
 class ExtensionDb(JsonData):

--- a/ulauncher/modes/extensions/ExtensionDownloader.py
+++ b/ulauncher/modes/extensions/ExtensionDownloader.py
@@ -31,6 +31,7 @@ class ExtensionDownloader:
         remote = ExtensionRemote(url)
         commit_hash = remote.get_compatible_hash()
         remote.download(commit_hash)
+        ext_mtime = os.path.getmtime(f"{PATHS.EXTENSIONS}/{remote.extension_id}")
 
         self.ext_db.save(
             {
@@ -39,6 +40,7 @@ class ExtensionDownloader:
                     "url": url,
                     "updated_at": datetime.now().isoformat(),
                     "last_commit": commit_hash,
+                    "last_commit_time": datetime.fromtimestamp(ext_mtime).isoformat(),
                 }
             }
         )
@@ -66,10 +68,12 @@ class ExtensionDownloader:
 
         remote = ExtensionRemote(ext.url)
         remote.download(commit_hash, overwrite=True)
+        ext_mtime = os.path.getmtime(f"{PATHS.EXTENSIONS}/{remote.extension_id}")
 
         ext.update(
             updated_at=datetime.now().isoformat(),
             last_commit=commit_hash,
+            last_commit_time=datetime.fromtimestamp(ext_mtime).isoformat(),
         )
 
         self.ext_db.save({ext_id: ext})

--- a/ulauncher/modes/extensions/ExtensionRemote.py
+++ b/ulauncher/modes/extensions/ExtensionRemote.py
@@ -1,5 +1,6 @@
 import re
 import logging
+import os
 from os.path import basename, exists
 from urllib.request import urlopen, urlretrieve
 from urllib.error import HTTPError, URLError
@@ -109,7 +110,11 @@ class ExtensionRemote:
         with NamedTemporaryFile(suffix=".tar.gz", prefix="ulauncher_dl_") as tmp_file:
             urlretrieve(url, tmp_file.name)
             with TemporaryDirectory(prefix="ulauncher_ext_") as tmp_dir:
-                untar(tmp_file.name, tmp_dir, strip=1)
+                untar(tmp_file.name, tmp_dir)
+                subdirs = os.listdir(tmp_dir)
+                if len(subdirs) != 1:
+                    raise ExtensionRemoteError(f"Invalid archive for {self.url}.")
+                tmp_dir = f"{tmp_dir}/{subdirs[0]}"
                 manifest = ExtensionManifest.new_from_file(f"{tmp_dir}/manifest.json")
                 if not satisfies(API_VERSION, manifest.api_version):
                     if not satisfies("2.0", manifest.api_version):

--- a/ulauncher/modes/extensions/ExtensionRemote.py
+++ b/ulauncher/modes/extensions/ExtensionRemote.py
@@ -14,16 +14,18 @@ class InvalidExtensionUrlWarning(Exception):
 
 
 class ExtensionRemote:
-    url_match_pattern = r"^(?:git@|https:\/\/)(?P<host>[^\/]+)\/(?P<user>[^\/]+)\/(?P<repo>[^\/]+)"
+    url_match_pattern = r"^(?:git@|https?:\/\/)(?P<host>[^\/\:]+)[\/\:](?P<user>[^\/]+)\/(?P<repo>[^\/]+)"
 
     def __init__(self, url):
         match = re.match(self.url_match_pattern, url.lower(), re.I)
         if not match:
             raise InvalidExtensionUrlWarning(f"Invalid URL: {url}")
 
+        self.host = match.group("host")
         self.user = match.group("user")
         self.repo = match.group("repo")
-        self.host = match.group("host")
+        if self.repo.endswith(".git"):
+            self.repo = self.repo[:-4]
         self.url = f"https://{self.host}/{self.user}/{self.repo}"
 
         if "." not in self.host:


### PR DESCRIPTION
The GitHub API have too strict rate limits.

The discover references is what the git client uses internally to fetch from the server, so it's like using git but without the extra dependency. It also has the benefit of working the same for all git servers.

Unfortunately you can't get timestamps for the commits this way. Just the references and hashes. To get timestamps you need to clone the actual repo locally. It's possible to use the old way to fetch only the date when we know there is an update available and hence it would avoid the rate limits, but I think it doesn't justify adding all that old complexity back.

Effectively the difference is:
1. This solution requires less code, and less requests, and should be easier to support for more git hosts (assuming we can still get a tar download link from them)
2. It doesn't use the API so it can't hit API rate limits (but it can possibly hit other rate limits, and I think overall the idea of using git repos as a extension hosts like this is still not sustainable).
3. It no longer shows commit dates. They were only useful to see information on the update before you download an extension, but now we only get them after downloading and extracting the extension. (it still stores them by checking the MTIME from the tar file later)
4. The check to see if the manifest api_version is compatible now has to happen after it's downloaded and extracted, and the version resolution is dumber/more predictable/faster, because it can't know if the main branch is compatible:
    *  If you have a branch/tag matching the current API version it uses that (it my tests it's preferring tags over branches if both exists with the same name, but this is only due to the order the git server responds).
    * If not it uses the main branch, not knowing if it's compatible.

4 can be tested with https://github.com/qw623577789/ulauncher-haici-dict (before this PR it would not download before showing the error)

Fixes #1162 (but without adding git).

I think Git servers (GitHub and others) might still rate limit these, but with more vague limits ([GitHub example, but for clones](https://github.com/orgs/community/discussions/24841#discussioncomment-3245596), [non-GitHub example](https://forum.unity.com/threads/cant-clone-example-project-github-says-rate-limit-exceeded.751505/)).