### PR TITLE
feat(ext_remote): use git if installed to support any repo

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -403,7 +403,7 @@ missing-member-max-choices=1
 max-args=6
 
 # Maximum number of attributes for a class (see R0902).
-max-attributes=7
+max-attributes=10
 
 # Maximum number of boolean expressions in an if statement.
 max-bool-expr=5

--- a/docs/extensions/debugging.rst
+++ b/docs/extensions/debugging.rst
@@ -1,11 +1,12 @@
 Debugging & Logging
 ===================
 
-WIP
-------------------------
-
-We have removed the Extension debugging functionality from Ulauncher v6.
-We plan to do internal changes and then bring back a more convenient method to debug extensions without copying/installing them to the Ulauncher extension directory, then update this space.
+#. Install your extension using the path to your local git repo rather than the public URL.
+#. Commit your changes in the local repo.
+#. Update the extension in Ulauncher's preferences to pull in the changes from your local repo.
+#. To get verbose log output, stop Ulauncher and start it in a terminal ``ulauncher -v``.
+#. Once you are done with your changes, stop Ulaunchar and start it normally again
+#. Push your changes to your public remote (GitHub, GitLab or other) if you want to make them available to others.
 
 
 Set up Logger

--- a/docs/extensions/tutorial.rst
+++ b/docs/extensions/tutorial.rst
@@ -6,20 +6,18 @@ Creating a Project
 
 Ulauncher runs all extensions from ``~/.local/share/ulauncher/extensions/``.
 
-Create a new directory there (name it as you wish) with the following structure::
+Create a new local git repository::
 
-  .
-  ├── images
-  │   └── icon.png
-  ├── manifest.json
-  └── main.py
+  # you can also create a repo online on github for example and then clone it locally
+  git init demo-extension
+  cd demo-extension
+  # example .gitignore (you likely will want to use your own)
+  printf "*tmp*\n__pycache__\n.cache\n.mypy_cache\n*.pyc\n*.pyo" > .gitignore
+  touch manifest.json main.py
 
+* :file:`.gitignore` is for ignoring file paths for common cached files and similar that you don't want to add to your repo.
 * :file:`manifest.json` contains all necessary metadata
 * :file:`main.py` is an entry point for your extension
-* :file:`images/` contains at least an icon of you extension
-
-
-Check out :doc:`debugging` to learn how to test and debug your extension.
 
 manifest.json
 -------------
@@ -30,7 +28,7 @@ Create :file:`manifest.json` using the following template::
     "api_version": "3",
     "authors": "John Doe",
     "name": "Demo extension",
-    "icon": "images/icon.png",
+    "icon": "system-run",
     "instructions": "You need to install <code>examplecommand</code> to run this extension",
     "triggers": {
       "dm": {
@@ -44,7 +42,7 @@ Create :file:`manifest.json` using the following template::
 * ``api_version`` - the version(s) of the Ulauncher Extension API (not the main app version) that the extension requires. See above for more information.
 * ``authors`` - the name(s) or user name(s) of the extension authors and maintainers
 * ``name`` can be anything you like but not an empty string
-* ``icon`` - relative path to an extension icon, or the name of a `themed icon <https://specifications.freedesktop.org/icon-naming-spec/icon-naming-spec-latest.html#names>`_, for example "edit-paste".
+* ``icon`` - relative path to an extension icon, or the name of a `themed icon <https://specifications.freedesktop.org/icon-naming-spec/icon-naming-spec-latest.html#names>`_, for example "system-run" or "edit-paste".
 * ``triggers`` - User triggers to activate your extension (see below for details).
 * ``preferences`` - Optional user preferences (see below for details).
 * ``instructions`` - Optional installation instructions that is shown in the extension preferences view.
@@ -122,8 +120,10 @@ Copy the following code to ``main.py``::
 .. TIP:: If you don't want to use ``yield``, you can also return a list of Results.
 
 
-Now exit Ulauncher and run ``ulauncher -v`` from command line to see the verbose output.
-
+To test your extension, install your extension using the system path as the url. Ex ``file:///home/me/mycode/demo-extension`` or just ``/home/me/mycode/demo-extension``
+Ulauncher only installs from git repositories, so you need to commit your changes.
+To update an extension you installed this way, you simply use the regular update functionality.
+For testing purposes we highly recommend you exit ulauncher and run ``ulauncher -v`` in a terminal for verbose output.
 
 .. figure:: https://i.imgur.com/GlEfHjA.png
   :align: center

--- a/preferences-src/src/components/pages/ExtensionConfig.vue
+++ b/preferences-src/src/components/pages/ExtensionConfig.vue
@@ -23,7 +23,7 @@
           <b-dropdown-item @click="openRemoveModal">Remove</b-dropdown-item>
           <b-dropdown-divider v-if="extension.url"/>
           <b-dropdown-item v-if="extension.url" @click="openRepo">Open repository</b-dropdown-item>
-          <b-dropdown-item v-if="extension.url" @click="reportIssue">Report issue</b-dropdown-item>
+          <b-dropdown-item v-if="extension.url && extension.url.includes('https://')" @click="reportIssue">Report issue</b-dropdown-item>
           <b-dropdown-item disabled v-if="extension.last_commit">
             <i class="fa fa-calendar fa-fw"></i>
             {{ extension.updated_at.slice(0, 10) }}

--- a/preferences-src/src/components/pages/Extensions.vue
+++ b/preferences-src/src/components/pages/Extensions.vue
@@ -65,7 +65,7 @@
             class="repo-url-input"
             ref="repoUrl"
             type="text"
-            placeholder="https://github.com/org-name/project-name"
+            placeholder="https://github.com/user/repo.git"
           ></b-form-input>
         </b-form>
 

--- a/preferences-src/src/components/widgets/ExtensionErrorExplanation.vue
+++ b/preferences-src/src/components/widgets/ExtensionErrorExplanation.vue
@@ -4,8 +4,8 @@
       <small>
         <p
           v-if="errorName === 'InvalidExtensionUrlWarning'"
-        >The URL should be a GitHub, GitLab or Gitea-compatible extension repository link.
-        <br>Examples: https://github.com/user/repo or https://codeberg.org/user/repo</p>
+        >The URL should be a HTTPS git repository link or a path to a local git repository.
+        <br>Examples: https://github.com/user/repo.git or https://codeberg.org/user/repo.git</p>
         <p v-else-if="errorName === 'ExtensionManifestError'">
           There's an error in manifest.json:
           <br>

--- a/tests/modes/apps/extensions/test_ExtensionRemote.py
+++ b/tests/modes/apps/extensions/test_ExtensionRemote.py
@@ -12,10 +12,13 @@ class TestExtensionRemote:
     def test_valid_urls_ext_id(self):
         assert ExtensionRemote("https://host.tld/user/repo").extension_id == "tld.host.user.repo"
         assert ExtensionRemote("http://host/user/repo").extension_id == "host.user.repo"
-        assert ExtensionRemote("https://host.org/user/repo.git").extension_id == "org.host.user.repo"
-        assert ExtensionRemote("http://host/user/repo.git").extension_id == "host.user.repo"
-        assert ExtensionRemote("git@host.com:user/repo.git").extension_id == "com.host.user.repo"
-        assert ExtensionRemote("https://host/user/repo/tree/master").extension_id == "host.user.repo"
+        assert ExtensionRemote("https://host.org/user/repo.git").extension_id == "org.host.user.repo.git"
+        assert ExtensionRemote("http://host/user/repo.git").extension_id == "host.user.repo.git"
+        assert ExtensionRemote("git@host.com:user/repo").extension_id == "com.host.user.repo"
+        # verify sanitizing github/gitlab/codeberg urls, but leave all others
+        assert ExtensionRemote("https://github.com/user/repo/tree/HEAD").extension_id == "com.github.user.repo"
+        assert ExtensionRemote("https://gitlab.com/user/repo.git").extension_id == "com.gitlab.user.repo"
+        assert ExtensionRemote("https://other.host/a/b/c/d").extension_id == "host.other.a.b.c.d"
 
     def test_invalid_url(self):
         with pytest.raises(InvalidExtensionUrlWarning):

--- a/ulauncher/modes/extensions/ExtensionDownloader.py
+++ b/ulauncher/modes/extensions/ExtensionDownloader.py
@@ -2,7 +2,6 @@ import os
 import logging
 from functools import lru_cache
 from shutil import rmtree
-from datetime import datetime
 from typing import Tuple
 
 from ulauncher.config import PATHS
@@ -29,22 +28,7 @@ class ExtensionDownloader:
 
     def download(self, url: str) -> str:
         remote = ExtensionRemote(url)
-        commit_hash = remote.get_compatible_hash()
-        remote.download(commit_hash)
-        ext_mtime = os.path.getmtime(f"{PATHS.EXTENSIONS}/{remote.extension_id}")
-
-        self.ext_db.save(
-            {
-                remote.extension_id: {
-                    "id": remote.extension_id,
-                    "url": url,
-                    "updated_at": datetime.now().isoformat(),
-                    "last_commit": commit_hash,
-                    "last_commit_time": datetime.fromtimestamp(ext_mtime).isoformat(),
-                }
-            }
-        )
-
+        remote.download()
         return remote.extension_id
 
     def remove(self, ext_id: str) -> None:
@@ -68,16 +52,6 @@ class ExtensionDownloader:
 
         remote = ExtensionRemote(ext.url)
         remote.download(commit_hash, overwrite=True)
-        ext_mtime = os.path.getmtime(f"{PATHS.EXTENSIONS}/{remote.extension_id}")
-
-        ext.update(
-            updated_at=datetime.now().isoformat(),
-            last_commit=commit_hash,
-            last_commit_time=datetime.fromtimestamp(ext_mtime).isoformat(),
-        )
-
-        self.ext_db.save({ext_id: ext})
-
         return True
 
     def check_update(self, ext_id: str) -> Tuple[bool, str]:

--- a/ulauncher/modes/extensions/ExtensionRemote.py
+++ b/ulauncher/modes/extensions/ExtensionRemote.py
@@ -1,6 +1,6 @@
 import logging
 import os
-from os.path import basename, exists, getmtime
+from os.path import basename, getmtime, isdir
 from datetime import datetime
 from urllib.parse import urlparse
 from urllib.request import urlopen, urlretrieve
@@ -120,7 +120,7 @@ class ExtensionRemote:
             commit_hash = self.get_compatible_hash()
         url = self._get_download_url(commit_hash)
         output_dir = f"{PATHS.EXTENSIONS}/{self.extension_id}"
-        output_dir_exists = exists(output_dir)
+        output_dir_exists = isdir(output_dir)
 
         if output_dir_exists and not overwrite:
             raise ExtensionAlreadyInstalledWarning(f'Extension with URL "{url}" is already installed.')


### PR DESCRIPTION
While #1196 solved the issue with hitting GitHubs API rate limits, and also made the code simpler and more standardized, it still assumed that:
1. All repos are in the form of `https://host.tld/user/repo`
2. All repos have a tarball download endpoint

This was true for all the hosts we supported, and with this PR if the host is github, gitlab or codeberg or if the user doesn't have git installed it, it keeps using the old (tarball) install, as that's faster.

But if the user has git installed and trying to install from any other host it will instead use `git clone --bare` and `checkout`, which should work for any git host. This includes local paths such as `file:///home/me/my-code/my-ulauncher-extensions` (the `file://` prefix is optional, so you can use just `/path/to/dir`. It will store the url with the `file://`-protocol either way).

This has also been documented as a replacement from the debugging instructions we removed (63fc112). I think this is a good enough substitute and arguably fixes #818. While not as powerful as using `ipdb` I think that was way too complicated ("leaky" abstraction). Extensions are not complicated enough to need that.

The recommended/supported url format now is the HTTPS git repo you use for cloning (so `https://github.com/user/repo.git` rather than just `https://github.com/user/repo`). Either ones will work for github, gitlab or codeberg, but for other hosts we need the exact HTTPS GIT remote URL.

Unfortunarely ExtensionRemote has now become quite complex and hard to test again, and I want to merge the remote and downloader classes (downloader is just a thin layer over remote now). So I don't want to add lots of tests and then have to rewrite them anyway.