### PR TITLE
Add Info Window for displaying additional information from extensions

### DIFF
--- a/docs/extensions/actions.rst
+++ b/docs/extensions/actions.rst
@@ -56,6 +56,11 @@ SetUserQueryAction
 .. autoclass:: ulauncher.api.shared.action.SetUserQueryAction.SetUserQueryAction
 
 
+UpdateInfoAction
+----------------
+
+.. autoclass:: ulauncher.api.shared.action.UpdateInfoAction.UpdateInfoAction
+
 
 .. NOTE::
   Please take `a short survey <https://goo.gl/forms/wcIRCTjQXnO0M8Lw2>`_ to help us build greater API and documentation

--- a/docs/extensions/tutorial.rst
+++ b/docs/extensions/tutorial.rst
@@ -229,6 +229,48 @@ Custom Action on Item Enter
   Now this will be rendered when you click on any item
 
 
+Using Information Window
+------------------------
+The Information Window Feature provides the ability to display HTML content in an information window within Ulauncher.
+This allows you to provide a richer and more detailed context for your Ulauncher extension.
+
+.. figure:: https://i.imgur.com/fVGkSj5.png
+  :align: center
+
+  Information Window example
+
+To display HTML content in the information window, you can either use the **UpdateInfoAction** or add two
+parameters ``info`` and ``base_url`` after the result list when creating the **RenderResultListAction**.
+
+The UpdateInfoAction accepts the following parameters:
+
+UpdateInfoAction(info, base_url="file:///", keep_app_open=False):
+ - info (required): The HTML content you want to display in the information window.
+ - base_url (optional): The base URL for resolving relative URLs within the HTML content. Defaults to "file:///".
+ - keep_app_open (optional): Determines if the Ulauncher app window should stay open when the action is executed. Defaults to False.
+
+  ::
+
+    def on_event(self, event, ext):
+        query = event.get_argument()
+        if not query:
+            return
+
+        search_results = self.search_wikipedia(query)
+        if not search_results:
+            return
+
+        items = [ExtensionResultItem(icon="images/icon.svg",
+                                     name=result["title"],
+                                     description=result["snippet"],
+                                     on_enter=OpenUrlAction(result["url"]),
+                                     on_alt_enter=CopyToClipboardAction(result["url"]),
+                                     on_select=UpdateInfoAction(self.fetch_wikipedia_html(result["url"]),
+                                                                "https://en.wikipedia.org")) for result in search_results]
+
+        return items
+  Example of using UpdateInfoAction to show a preview of wikipedia page when an item is selected
+
 
 .. NOTE::
   Please take `a short survey <https://goo.gl/forms/wcIRCTjQXnO0M8Lw2>`_ to help us build greater API and documentation

--- a/tests/api/shared/action/test_RenderResultListAction.py
+++ b/tests/api/shared/action/test_RenderResultListAction.py
@@ -28,4 +28,11 @@ class TestRenderResultListAction:
 
     def test_run(self, action, result_list, GLib, UlauncherWindow):
         action.run()
-        GLib.idle_add.assert_called_with(UlauncherWindow.show_results, result_list)
+
+        assert GLib.idle_add.call_count == 2
+        calls = GLib.idle_add.call_args_list
+        expected_first_call_args = (UlauncherWindow.show_results, result_list)
+        assert calls[0] == mock.call(*expected_first_call_args)
+
+        expected_second_call_args = (UlauncherWindow.set_info, None, None)
+        assert calls[1] == mock.call(*expected_second_call_args)

--- a/ulauncher/api/result.py
+++ b/ulauncher/api/result.py
@@ -5,6 +5,7 @@ from ulauncher.api.shared.action.BaseAction import BaseAction
 from ulauncher.api.shared.query import Query
 
 OnEnterCallback = Optional[Callable[[Query], Optional[BaseAction]]]
+OnSelectCallback = Optional[Callable[[], Optional[BaseAction]]]
 
 
 # pylint: disable=too-many-instance-attributes
@@ -18,7 +19,7 @@ class Result:
     icon: Optional[str] = None
     _on_enter: Optional[OnEnterCallback] = None
     _on_alt_enter: Optional[OnEnterCallback] = None
-    _on_select: Optional[OnEnterCallback] = None
+    _on_select: Optional[OnSelectCallback] = None
 
     # pylint: disable=too-many-arguments
     def __init__(
@@ -32,7 +33,7 @@ class Result:
         on_alt_enter: OnEnterCallback = None,
         searchable: Optional[bool] = None,
         compact: Optional[bool] = None,
-        on_select: OnEnterCallback = None
+        on_select: OnSelectCallback = None,
     ):
         if not isinstance(name, str):
             raise TypeError(f'"name" must be of type "str", "{type(name).__name__}" given.')

--- a/ulauncher/api/result.py
+++ b/ulauncher/api/result.py
@@ -18,6 +18,7 @@ class Result:
     icon: Optional[str] = None
     _on_enter: Optional[OnEnterCallback] = None
     _on_alt_enter: Optional[OnEnterCallback] = None
+    _on_select: Optional[OnEnterCallback] = None
 
     # pylint: disable=too-many-arguments
     def __init__(
@@ -31,6 +32,7 @@ class Result:
         on_alt_enter: OnEnterCallback = None,
         searchable: Optional[bool] = None,
         compact: Optional[bool] = None,
+        on_select: OnEnterCallback = None
     ):
         if not isinstance(name, str):
             raise TypeError(f'"name" must be of type "str", "{type(name).__name__}" given.')
@@ -50,6 +52,7 @@ class Result:
             self.highlightable = highlightable
         self._on_enter = on_enter
         self._on_alt_enter = on_alt_enter
+        self._on_select = on_select
 
         # This part only runs when initialized from an extensions
         ext_path = os.environ.get("EXTENSION_PATH")
@@ -95,6 +98,11 @@ class Result:
         if isinstance(self._on_alt_enter, BaseAction):  # For extensions
             return self._on_alt_enter
         return self._on_alt_enter(query) if callable(self._on_alt_enter) else None
+
+    def on_select(self) -> Optional[BaseAction]:
+        if isinstance(self._on_select, BaseAction):  # For extensions
+            return self._on_select
+        return self._on_select() if callable(self._on_select) else None
 
     def get_searchable_fields(self):
         return [(self.name, 1), (self.description, 0.8)]

--- a/ulauncher/api/shared/action/RenderResultListAction.py
+++ b/ulauncher/api/shared/action/RenderResultListAction.py
@@ -14,9 +14,10 @@ class RenderResultListAction(BaseAction):
 
     keep_app_open = True
 
-    def __init__(self, result_list, info=None):
+    def __init__(self, result_list, info=None, base_url=None):
         self.result_list = result_list
         self._info = info
+        self.base_url = base_url
 
     def run(self):
         # pylint: disable=import-outside-toplevel
@@ -29,4 +30,4 @@ class RenderResultListAction(BaseAction):
         else:
             # update UI in the main thread to avoid race conditions
             GLib.idle_add(app.window.show_results, self.result_list)
-            GLib.idle_add(app.window.set_info, self._info)
+            GLib.idle_add(app.window.set_info, self._info, self.base_url)

--- a/ulauncher/api/shared/action/UpdateInfoAction.py
+++ b/ulauncher/api/shared/action/UpdateInfoAction.py
@@ -1,12 +1,11 @@
-from ulauncher.api.shared.action.BaseAction import BaseAction
-from gi.repository import Gio, GLib
 import logging
+from gi.repository import Gio, GLib
+from ulauncher.api.shared.action.BaseAction import BaseAction
 
 logger = logging.getLogger()
 
 
 class UpdateInfoAction(BaseAction):
-
     def __init__(self, info, base_url="file:///", keep_app_open=False):
         self._info = info
         self.base_url = base_url
@@ -17,9 +16,9 @@ class UpdateInfoAction(BaseAction):
         app = Gio.Application.get_default()
 
         if not app:
-            logger.error("RenderResultListAction.run() should only be called by Ulauncher")
+            logger.error("UpdateInfoAction.run() should only be called by Ulauncher")
         elif not hasattr(app, "window") or not app.window.is_visible():
-            logger.warning("RenderResultListAction called, but no Ulauncher window is open")
+            logger.warning("UpdateInfoAction called, but no Ulauncher window is open")
         else:
             # update UI in the main thread to avoid race conditions
             GLib.idle_add(app.window.set_info, self._info, self.base_url)

--- a/ulauncher/api/shared/action/UpdateInfoAction.py
+++ b/ulauncher/api/shared/action/UpdateInfoAction.py
@@ -7,8 +7,9 @@ logger = logging.getLogger()
 
 class UpdateInfoAction(BaseAction):
 
-    def __init__(self, info, keep_app_open=False):
+    def __init__(self, info, base_url="file:///", keep_app_open=False):
         self._info = info
+        self.base_url = base_url
         self.keep_app_open = keep_app_open
 
     def run(self):
@@ -21,4 +22,4 @@ class UpdateInfoAction(BaseAction):
             logger.warning("RenderResultListAction called, but no Ulauncher window is open")
         else:
             # update UI in the main thread to avoid race conditions
-            GLib.idle_add(app.window.set_info, self._info)
+            GLib.idle_add(app.window.set_info, self._info, self.base_url)

--- a/ulauncher/api/shared/action/UpdateInfoAction.py
+++ b/ulauncher/api/shared/action/UpdateInfoAction.py
@@ -1,22 +1,15 @@
-import logging
-from gi.repository import Gio, GLib
 from ulauncher.api.shared.action.BaseAction import BaseAction
+from gi.repository import Gio, GLib
+import logging
 
 logger = logging.getLogger()
 
 
-class RenderResultListAction(BaseAction):
-    """
-    Renders list of result items
+class UpdateInfoAction(BaseAction):
 
-    :param list result_list: list of :class:`~ulauncher.api.result.Result` objects
-    """
-
-    keep_app_open = True
-
-    def __init__(self, result_list, info=None):
-        self.result_list = result_list
+    def __init__(self, info, keep_app_open=False):
         self._info = info
+        self.keep_app_open = keep_app_open
 
     def run(self):
         # pylint: disable=import-outside-toplevel
@@ -28,5 +21,4 @@ class RenderResultListAction(BaseAction):
             logger.warning("RenderResultListAction called, but no Ulauncher window is open")
         else:
             # update UI in the main thread to avoid race conditions
-            GLib.idle_add(app.window.show_results, self.result_list)
             GLib.idle_add(app.window.set_info, self._info)

--- a/ulauncher/ui/ItemNavigation.py
+++ b/ulauncher/ui/ItemNavigation.py
@@ -41,6 +41,9 @@ class ItemNavigation:
 
         self.selected = index
         self.result_widgets[index].select()
+        action = self.result_widgets[index].result.on_select()
+        if action:
+            action.run()
 
     def go_up(self):
         self.select((self.selected or len(self.result_widgets)) - 1)

--- a/ulauncher/ui/windows/InfoWindow.py
+++ b/ulauncher/ui/windows/InfoWindow.py
@@ -1,5 +1,5 @@
-import logging
 from gi.repository import Gtk, Gdk, WebKit2  # type: ignore[attr-defined]
+
 
 class InfoWindow(Gtk.ApplicationWindow):
     def __init__(self, *args, **kwargs):
@@ -24,10 +24,10 @@ class InfoWindow(Gtk.ApplicationWindow):
     def set_info(self, info: str, base_url="file:///"):
         if info:
             if not self.visible:
-                self.show_all()
+                self.show_all()  # type: ignore[attr-defined]
             self.webview.load_html(info, base_url)
         else:
-            self.hide()
+            self.hide()  # type: ignore[attr-defined]
 
     @property
     def visible(self):

--- a/ulauncher/ui/windows/InfoWindow.py
+++ b/ulauncher/ui/windows/InfoWindow.py
@@ -1,0 +1,34 @@
+import logging
+from gi.repository import Gtk, Gdk, WebKit2  # type: ignore[attr-defined]
+
+class InfoWindow(Gtk.ApplicationWindow):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+
+        self.set_decorated(False)
+        self.set_deletable(False)
+        self.set_can_focus(False)
+        self.set_skip_taskbar_hint(True)
+        self.set_type_hint(Gdk.WindowTypeHint.UTILITY)
+        self.set_keep_above(True)
+
+        self.webview = WebKit2.WebView()
+        self.webview.set_size_request(500, 500)
+        self.webview.show()
+        self.webview.load_html("", "file:///")
+        self.add(self.webview)
+
+        self.show_all()
+        self.hide()
+
+    def set_info(self, info: str):
+        if info:
+            if not self.visible:
+                self.show_all()
+            self.webview.load_html(info, "file:///")
+        else:
+            self.hide()
+
+    @property
+    def visible(self):
+        return self.get_property("visible")

--- a/ulauncher/ui/windows/InfoWindow.py
+++ b/ulauncher/ui/windows/InfoWindow.py
@@ -21,11 +21,11 @@ class InfoWindow(Gtk.ApplicationWindow):
         self.show_all()
         self.hide()
 
-    def set_info(self, info: str):
+    def set_info(self, info: str, base_url="file:///"):
         if info:
             if not self.visible:
                 self.show_all()
-            self.webview.load_html(info, "file:///")
+            self.webview.load_html(info, base_url)
         else:
             self.hide()
 

--- a/ulauncher/ui/windows/UlauncherWindow.py
+++ b/ulauncher/ui/windows/UlauncherWindow.py
@@ -261,8 +261,8 @@ class UlauncherWindow(Gtk.ApplicationWindow, LayerShellOverlay):
         else:
             self.move(pos_x, pos_y)
 
-    def set_info(self, info):
-        self.info_window.set_info(info)
+    def set_info(self, info, base_url="file:///"):
+        self.info_window.set_info(info, base_url)
         self.position_window()
 
     # pylint: disable=arguments-differ; https://gitlab.gnome.org/GNOME/pygobject/-/issues/231

--- a/ulauncher/utils/Settings.py
+++ b/ulauncher/utils/Settings.py
@@ -15,6 +15,7 @@ class Settings(JsonData):
     show_indicator_icon = True
     terminal_command = ""
     theme_name = "light"
+    move_window_when_open_info = False
 
     # Convert dash to underscore
     def __setitem__(self, key, value):


### PR DESCRIPTION
<!--
Thank you for submitting a PR to Ulauncher!

Please read our contribution instructions if you haven't:
  https://github.com/Ulauncher/Ulauncher#code-contribution

* Explain the changes in this PR and link to related issue(s) if applicable
* When applicable, please update the documentation according to your changes.
* Ensure that the PR doesn't break existing tests, and please add your own if applicable.

A git action will verify your PR, but you can also test locally with `./ul test`

-->

This pull request introduces a new feature: the Info Window. The Info Window is a non-focusable, borderless window that can be displayed alongside search results. It is designed to provide additional information for selected search results, such as previews, descriptions, or other relevant details.

The Info Window can be utilized by extensions to display custom HTML content related to the selected search result. As a demonstration of this new functionality, I have implemented an extension that searches Wikipedia. When a user selects a Wikipedia search result, a preview of the Wikipedia page is displayed in the Info Window, allowing the user to quickly review the content before opening the full page in a web browser.

Here's a screenshot showcasing the Info Window with the Wikipedia search extension:

![2023-04-08_02-14](https://user-images.githubusercontent.com/19591977/230730263-ec779754-d381-484e-a013-5317abb807c0.png)


This feature will enhance the user experience by allowing them to access more information without needing to open a separate application.

Please review the changes and let me know if you have any suggestions or concerns.