### PR TITLE
refactor!: make results json serializable

### DIFF
--- a/tests/modes/apps/extensions/test_DeferredResultRenderer.py
+++ b/tests/modes/apps/extensions/test_DeferredResultRenderer.py
@@ -1,3 +1,4 @@
+from types import MethodType
 from unittest import mock
 
 import pytest
@@ -31,7 +32,9 @@ class TestDeferredResultRenderer:
 
     @pytest.fixture
     def controller(self):
-        return mock.create_autospec(ExtensionController)
+        ctrl = mock.create_autospec(ExtensionController)
+        ctrl.get_normalized_icon_path = MethodType(lambda _: "/path/to/asdf.png", ctrl)
+        return ctrl
 
     @pytest.fixture
     def renderer(self):

--- a/ulauncher/api/result.py
+++ b/ulauncher/api/result.py
@@ -20,7 +20,9 @@ class Result(dict):
         for cls in reversed(self.__class__.__mro__):
             if cls in dict.__mro__:
                 continue
-            defaults = {k: v for k, v in vars(cls).items() if (not k.startswith("__") and not callable(v))}
+            defaults = {
+                k: v for k, v in vars(cls).items() if (not k.startswith("__") and not callable(getattr(cls, k)))
+            }
             self.update(defaults)
 
         # set values

--- a/ulauncher/api/result.py
+++ b/ulauncher/api/result.py
@@ -1,59 +1,30 @@
 import os
-from typing import Callable, Optional
 
 from ulauncher.api.shared.action.BaseAction import BaseAction
 from ulauncher.api.shared.query import Query
 from ulauncher.utils.fuzzy_search import get_score
 
-OnEnterCallback = Optional[Callable[[Query], Optional[BaseAction]]]
 
-
-# pylint: disable=too-many-instance-attributes
-class Result:
+class Result(dict):
     compact = False
     highlightable = False
     searchable = False
-    name: str = ""
-    description: str = ""
-    keyword: str = ""
-    icon: Optional[str] = None
-    _on_enter: Optional[OnEnterCallback] = None
-    _on_alt_enter: Optional[OnEnterCallback] = None
+    name = ""
+    description = ""
+    keyword = ""
+    icon = ""
 
-    # pylint: disable=too-many-arguments
-    def __init__(
-        self,
-        name: str = "",
-        description: str = "",
-        keyword: str = "",
-        icon: str = "",
-        highlightable: bool = False,
-        on_enter: OnEnterCallback = None,
-        on_alt_enter: OnEnterCallback = None,
-        searchable: Optional[bool] = None,
-        compact: Optional[bool] = None,
-    ):
-        if not isinstance(name, str):
-            msg = f'"name" must be of type "str", "{type(name).__name__}" given.'
-            raise TypeError(msg)
-        if not isinstance(description, str):
-            msg = f'"description" must be of type "str", "{type(description).__name__}" given.'
-            raise TypeError(msg)
-        if not isinstance(keyword, str):
-            msg = f'"keyword" must be of type "str", "{type(keyword).__name__}" given.'
-            raise TypeError(msg)
-        self.name = name
-        self.description = description
-        self.keyword = keyword
-        self.icon = icon
-        if compact is not None:
-            self.compact = compact
-        if searchable is not None:
-            self.searchable = searchable
-        if highlightable is not None:
-            self.highlightable = highlightable
-        self._on_enter = on_enter
-        self._on_alt_enter = on_alt_enter
+    def __init__(self, **kwargs):
+        super().__init__()
+        # add defaults from parent classes in inheritance order
+        for cls in reversed(self.__class__.__mro__):
+            if cls in dict.__mro__:
+                continue
+            defaults = {k: v for k, v in vars(cls).items() if (not k.startswith("__") and not callable(v))}
+            self.update(defaults)
+
+        # set values
+        self.update(**kwargs)
 
         # This part only runs when initialized from an extensions
         ext_path = os.environ.get("EXTENSION_PATH")
@@ -63,9 +34,33 @@ class Result:
             if self.icon and os.path.isfile(f"{ext_path}/{self.icon}"):
                 self.icon = f"{ext_path}/{self.icon}"
 
-            if self._on_enter and not isinstance(self._on_enter, (bool, str, BaseAction)):
-                msg = "Invalid on_enter argument. Expected bool, string or BaseAction"
-                raise TypeError(msg)
+    def __delattr__(self, name):
+        del self[name]
+
+    def __dir__(self):  # For IDE autocompletion
+        return dir(type(self)) + list(self.keys())
+
+    def __getattribute__(self, key):
+        try:
+            return self[key]
+        except KeyError:
+            return super().__getattribute__(key)
+
+    def __setattr__(self, key, value):
+        self[key] = value
+
+    def __setitem__(self, key, value):
+        if key in ["name", "description", "keyword", "icon"] and not isinstance(value, str):
+            msg = f'"{key}" must be of type "str", "{type(value).__name__}" given.'
+            raise TypeError(msg)
+        if key in ["compact", "highlightable", "searchable"] and not isinstance(value, int):
+            msg = f'"{key}" must be of type "str", "{type(value).__name__}" given.'
+            raise TypeError(msg)
+        if key in ["on_enter", "on_alt_enter"] and not isinstance(value, (bool, str, BaseAction)):
+            msg = f"Invalid {key} argument. Expected bool, string or BaseAction"
+            raise TypeError(msg)
+
+        super().__setitem__(key, value)
 
     def get_highlightable_input(self, query: Query):
         if self.keyword and self.keyword == query.keyword:
@@ -76,11 +71,11 @@ class Result:
     def get_description(self, _query: Query) -> str:
         return self.description
 
-    def on_activation(self, query: Query, alt=False) -> Optional[BaseAction]:
+    def on_activation(self, query: Query, alt=False):
         """
         Handle the main action
         """
-        handler = self._on_alt_enter if alt else self._on_enter
+        handler = self.on_alt_enter if alt else self.on_enter
         if isinstance(handler, (bool, str, BaseAction)):  # For extensions
             return handler
         return handler(query) if callable(handler) else None

--- a/ulauncher/api/result.py
+++ b/ulauncher/api/result.py
@@ -2,10 +2,11 @@ import os
 
 from ulauncher.api.shared.action.BaseAction import BaseAction
 from ulauncher.api.shared.query import Query
+from ulauncher.utils.basedataclass import BaseDataClass
 from ulauncher.utils.fuzzy_search import get_score
 
 
-class Result(dict):
+class Result(BaseDataClass):
     compact = False
     highlightable = False
     searchable = False
@@ -15,18 +16,7 @@ class Result(dict):
     icon = ""
 
     def __init__(self, **kwargs):
-        super().__init__()
-        # add defaults from parent classes in inheritance order
-        for cls in reversed(self.__class__.__mro__):
-            if cls in dict.__mro__:
-                continue
-            defaults = {
-                k: v for k, v in vars(cls).items() if (not k.startswith("__") and not callable(getattr(cls, k)))
-            }
-            self.update(defaults)
-
-        # set values
-        self.update(**kwargs)
+        super().__init__(**kwargs)
 
         # This part only runs when initialized from an extensions
         ext_path = os.environ.get("EXTENSION_PATH")
@@ -36,44 +26,12 @@ class Result(dict):
             if self.icon and os.path.isfile(f"{ext_path}/{self.icon}"):
                 self.icon = f"{ext_path}/{self.icon}"
 
-    def __delattr__(self, name):
-        del self[name]
-
-    def __dir__(self):  # For IDE autocompletion
-        return dir(type(self)) + list(self.keys())
-
-    def __getattribute__(self, key):
-        try:
-            return self[key]
-        except KeyError:
-            return super().__getattribute__(key)
-
-    def __setattr__(self, key, value):
-        self[key] = value
-
     def __setitem__(self, key, value):
-        if hasattr(self.__class__, key):
-            if key.startswith("__"):
-                msg = f'Invalid property "{key}". Must not override class property.'
-                raise KeyError(msg)
-
-            class_val = getattr(self.__class__, key)
-            if callable(class_val):
-                msg = f'Invalid property "{key}". Must not override class method.'
-                raise KeyError(msg)
-            if not isinstance(value, type(class_val)):
-                msg = f'"{key}" must be of type {type(class_val).__name__}, {type(value).__name__} given.'
-                raise KeyError(msg)
         if key in ["on_enter", "on_alt_enter"] and not isinstance(value, (bool, str, BaseAction)):
             msg = f"Invalid {key} argument. Expected bool, string or BaseAction"
             raise KeyError(msg)
 
         super().__setitem__(key, value)
-
-    # Make sure everything flows through __setitem__
-    def update(self, *args, **kwargs):
-        for k, v in dict(*args, **kwargs).items():
-            self[k] = v
 
     def get_highlightable_input(self, query: Query):
         if self.keyword and self.keyword == query.keyword:

--- a/ulauncher/modes/apps/AppResult.py
+++ b/ulauncher/modes/apps/AppResult.py
@@ -12,22 +12,24 @@ app_starts = JsonData.new_from_file(f"{PATHS.STATE}/app_starts.json")
 
 
 class AppResult(Result):
-    searchable = True
     """
     :param Gio.DesktopAppInfo app_info:
     """
-    # pylint: disable=super-init-not-called
+
+    searchable = True
 
     def __init__(self, app_info):
-        self.name = app_info.get_display_name()
-        self.icon = app_info.get_string("Icon")
-        self.description = app_info.get_description() or app_info.get_generic_name()
-        self.keywords = app_info.get_keywords()
-        self._app_id = app_info.get_id()
-        # TryExec is what we actually want (name of/path to exec), but it's often not specified
-        # get_executable uses Exec, which is always specified, but it will return the actual executable.
-        # Sometimes the actual executable is not the app to start, but a wrappers like "env" or "sh -c"
-        self._executable = basename(app_info.get_string("TryExec") or app_info.get_executable() or "")
+        super().__init__(
+            name=app_info.get_display_name(),
+            icon=app_info.get_string("Icon"),
+            description=app_info.get_description() or app_info.get_generic_name(),
+            keywords=app_info.get_keywords(),
+            _app_id=app_info.get_id(),
+            # TryExec is what we actually want (name of/path to exec), but it's often not specified
+            # get_executable uses Exec, which is always specified, but it will return the actual executable.
+            # Sometimes the actual executable is not the app to start, but a wrappers like "env" or "sh -c"
+            _executable=basename(app_info.get_string("TryExec") or app_info.get_executable() or ""),
+        )
 
     @staticmethod
     def from_id(app_id):

--- a/ulauncher/modes/apps/AppResult.py
+++ b/ulauncher/modes/apps/AppResult.py
@@ -22,7 +22,7 @@ class AppResult(Result):
         super().__init__(
             name=app_info.get_display_name(),
             icon=app_info.get_string("Icon"),
-            description=app_info.get_description() or app_info.get_generic_name(),
+            description=app_info.get_description() or app_info.get_generic_name() or "",
             keywords=app_info.get_keywords(),
             _app_id=app_info.get_id(),
             # TryExec is what we actually want (name of/path to exec), but it's often not specified

--- a/ulauncher/modes/calc/CalcResult.py
+++ b/ulauncher/modes/calc/CalcResult.py
@@ -7,13 +7,12 @@ from ulauncher.config import PATHS
 
 
 class CalcResult(Result):
-    # pylint: disable=super-init-not-called
+    icon = f"{PATHS.ASSETS}/icons/calculator.png"
+
     def __init__(self, result: Optional[Decimal] = None, error: str = "Unknown error"):
-        self.result = result
-        self.error = error
+        super().__init__(result=result, error=error)
         self.name = f"{Decimal(self.result):n}" if self.result is not None else "Error!"
         self.description = "Enter to copy to the clipboard" if self.result is not None else error
-        self.icon = f"{PATHS.ASSETS}/icons/calculator.png"
 
     def on_activation(self, *_):
         if self.result is not None:

--- a/ulauncher/modes/file_browser/CopyPathToClipboardResult.py
+++ b/ulauncher/modes/file_browser/CopyPathToClipboardResult.py
@@ -4,12 +4,8 @@ from ulauncher.api.shared.action.CopyToClipboardAction import CopyToClipboardAct
 
 class CopyPathToClipboardResult(Result):
     compact = True
-
-    # pylint: disable=super-init-not-called
-    def __init__(self, path: str):
-        self.path = path
-        self.name = "Copy Path to Clipboard"
-        self.icon = "edit-copy"
+    name = "Copy Path to Clipboard"
+    icon = "edit-copy"
 
     def on_activation(self, *_):
         return CopyToClipboardAction(self.path)

--- a/ulauncher/modes/file_browser/FileBrowserResult.py
+++ b/ulauncher/modes/file_browser/FileBrowserResult.py
@@ -12,16 +12,18 @@ from ulauncher.utils.fold_user_path import fold_user_path
 class FileBrowserResult(Result):
     compact = True
     highlightable = True
+    path = ""
 
     """
     :param ~str path:
     """
 
-    # pylint: disable=super-init-not-called
     def __init__(self, path):
-        self.path = path
-        self.name = basename(path)
-        self.icon = get_icon_from_path(path)
+        super().__init__(
+            path=path,
+            name=basename(path),
+            icon=get_icon_from_path(path),
+        )
 
     def get_highlightable_input(self, query: Query):
         return basename(query)
@@ -34,8 +36,8 @@ class FileBrowserResult(Result):
             return OpenAction(self.path)
 
         if isdir(self.path):
-            open_folder = OpenFolderResult(self.path, f'Open Folder "{basename(self.path)}"')
+            open_folder = OpenFolderResult(name=f'Open Folder "{basename(self.path)}"', path=self.path)
         else:
-            open_folder = OpenFolderResult(dirname(self.path), "Open Containing Folder")
+            open_folder = OpenFolderResult(name="Open Containing Folder", path=dirname(self.path))
 
-        return [open_folder, CopyPathToClipboardResult(self.path)]
+        return [open_folder, CopyPathToClipboardResult(path=self.path)]

--- a/ulauncher/modes/file_browser/OpenFolderResult.py
+++ b/ulauncher/modes/file_browser/OpenFolderResult.py
@@ -5,11 +5,7 @@ from ulauncher.api.shared.action.OpenAction import OpenAction
 class OpenFolderResult(Result):
     compact = True
     icon = "system-file-manager"
-
-    # pylint: disable=super-init-not-called
-    def __init__(self, path: str, name="Open Folder"):
-        self.path = path
-        self.name = name
+    path = ""
 
     def on_activation(self, *_):
         return OpenAction(self.path)

--- a/ulauncher/modes/shortcuts/ShortcutResult.py
+++ b/ulauncher/modes/shortcuts/ShortcutResult.py
@@ -8,17 +8,9 @@ from ulauncher.modes.shortcuts.run_script import run_script
 
 class ShortcutResult(Result):
     searchable = True
-
-    # pylint: disable=super-init-not-called, too-many-arguments
-    def __init__(
-        self, keyword, name, cmd, icon, is_default_search=False, run_without_argument=False, **kw  # noqa: ARG002
-    ):
-        self.keyword = keyword
-        self.name = name
-        self.cmd = cmd
-        self.icon = icon
-        self.is_default_search = is_default_search
-        self.run_without_argument = run_without_argument
+    run_without_argument = False
+    is_default_search = False
+    cmd = ""
 
     def get_highlightable_input(self, query: Query):
         return str(query) if self.keyword != query.keyword else None

--- a/ulauncher/utils/basedataclass.py
+++ b/ulauncher/utils/basedataclass.py
@@ -1,3 +1,5 @@
+from copy import deepcopy
+
 # This is a more compact alternative to JsonData, which does not require using decorators
 #
 # It works slightly differently by looping through the class props of the class and all inherited classes
@@ -18,7 +20,9 @@ class BaseDataClass(dict):
             if cls in BaseDataClass.__mro__:
                 continue
             defaults = {
-                k: v for k, v in vars(cls).items() if (not k.startswith("__") and not callable(getattr(cls, k)))
+                k: deepcopy(v)  # deep copy to handle https://stackoverflow.com/q/1132941/633921
+                for k, v in vars(cls).items()
+                if (not k.startswith("__") and not callable(getattr(cls, k)))
             }
             self.update(defaults)
 

--- a/ulauncher/utils/basedataclass.py
+++ b/ulauncher/utils/basedataclass.py
@@ -1,0 +1,62 @@
+# This is a more compact alternative to JsonData, which does not require using decorators
+#
+# It works slightly differently by looping through the class props of the class and all inherited classes
+# and setting them for the instance in __init__
+# It also needs to use __getattribute__ instead of __getattr__
+#
+# TODO(friday): try to migrate the methods from JsonData here. # noqa: TD003
+# Should be able to move stringify and save_as here and
+# replace __json_value_blacklist__ and __json_sort_keys__ with params
+# But don't migrate "new_from_file" and "save"
+
+
+class BaseDataClass(dict):
+    def __init__(self, **kwargs):
+        super().__init__()
+        # add defaults from parent classes in inheritance order
+        for cls in reversed(self.__class__.__mro__):
+            if cls in BaseDataClass.__mro__:
+                continue
+            defaults = {
+                k: v for k, v in vars(cls).items() if (not k.startswith("__") and not callable(getattr(cls, k)))
+            }
+            self.update(defaults)
+
+        # set values
+        self.update(**kwargs)
+
+    def __dir__(self):  # For IDE autocompletion
+        return dir(type(self)) + list(self.keys())
+
+    def __delattr__(self, name):
+        del self[name]
+
+    def __getattribute__(self, key):
+        try:
+            return self[key]
+        except KeyError:
+            return super().__getattribute__(key)
+
+    def __setattr__(self, key, value):
+        self[key] = value
+
+    def __setitem__(self, key, value):
+        if hasattr(self.__class__, key):
+            if key.startswith("__"):
+                msg = f'Invalid property "{key}". Must not override class property.'
+                raise KeyError(msg)
+
+            class_val = getattr(self.__class__, key)
+            if callable(class_val):
+                msg = f'Invalid property "{key}". Must not override class method.'
+                raise KeyError(msg)
+            if not isinstance(value, type(class_val)):
+                msg = f'"{key}" must be of type {type(class_val).__name__}, {type(value).__name__} given.'
+                raise KeyError(msg)
+
+        super().__setitem__(key, value)
+
+    # Make sure everything flows through __setitem__
+    def update(self, *args, **kwargs):
+        for k, v in dict(*args, **kwargs).items():
+            self[k] = v


### PR DESCRIPTION
Makes the Result instances JSON serializable.

It's also possible to set any property this way, which is something I plan to utilize in further extension API rework. However the current implementation allows overriding the methods I think. Not sure how to handle that

This is a breaking change since the current `Result` (before the PR) allows passing positional arguments. The extension documentation never mentioned that, and I haven't found a single extension written like that when checking the [github code search](https://github.com/search?q=ExtensionResultItem%28+language%3APython&type=code&l=Python). So I think it's fine as long as it's documented as a breaking change.

This is the first a step towards getting rid of pickle for extension communication. Everything we send as of this PR is JSON serializable except some of the actions: `OpenAction`, `CopyToClipboardAction`, `ActionList` and `ExtensionCustomAction` (the others actions have recently been made serializable already).

After that I plan to do a bigger rewrite of the extension communication, by using sending JSON messages over the existing application dbus connection instead of sockets (sorry @troycurtisjr). I tested it and it's much simpler and allows architectural improvements like #1020 that just I can't implement properly now because of the complex communication flow.

I will test the app for a while with this PR applied, so don't need help with that. Would like some input on the result class though. It's like a simplified dataclass, without the need for a decorator. I haven't noticed any change for the performance. I'm using `__getattribute__` instead of `__getattr__`, which is "dangerous", but I'm handling that by being stricter in the setter. I'm also iterating over the class (default) properties in a bit of a hacky way to make sure they are included in the data.