### PR TITLE
refactor: switch extension message format from pickle to json

### DIFF
--- a/tests/api/client/test_Client.py
+++ b/tests/api/client/test_Client.py
@@ -17,7 +17,7 @@ class TestClient:
 
     @pytest.fixture(autouse=True)
     def framer(self, mocker):
-        return mocker.patch("ulauncher.api.client.Client.PickleFramer")
+        return mocker.patch("ulauncher.api.client.Client.JSONFramer")
 
     @pytest.fixture(autouse=True)
     def timer(self, mocker):

--- a/tests/modes/apps/extensions/test_ExtensionServer.py
+++ b/tests/modes/apps/extensions/test_ExtensionServer.py
@@ -33,8 +33,8 @@ class TestExtensionServer:
         return mocker.patch("ulauncher.modes.extensions.ExtensionServer.os.unlink")
 
     @pytest.fixture(autouse=True)
-    def PickleFramer(self, mocker):
-        return mocker.patch("ulauncher.modes.extensions.ExtensionServer.PickleFramer")
+    def JSONFramer(self, mocker):
+        return mocker.patch("ulauncher.modes.extensions.ExtensionServer.JSONFramer")
 
     @pytest.fixture
     def server(self):
@@ -55,24 +55,24 @@ class TestExtensionServer:
         with pytest.raises(ServerIsRunningError):
             server.start()
 
-    def test_handle_incoming(self, server, PickleFramer):
+    def test_handle_incoming(self, server, JSONFramer):
         conn = mock.Mock()
         source = mock.Mock()
         server.start()
         server.handle_incoming(server.service, conn, source)
-        assert id(PickleFramer.return_value) in server.pending
-        PickleFramer.return_value.set_connection.assert_called_with(conn)
+        assert id(JSONFramer.return_value) in server.pending
+        JSONFramer.return_value.set_connection.assert_called_with(conn)
 
-    def test_handle_registration(self, server, PickleFramer, GObject, ExtensionController):
+    def test_handle_registration(self, server, JSONFramer, GObject, ExtensionController):
         conn = mock.Mock()
         source = mock.Mock()
         server.start()
         server.handle_incoming(server.service, conn, source)
         extid = "id"
         event = {"type": "extension:socket_connected", "ext_id": extid}
-        assert id(PickleFramer.return_value) in server.pending
-        server.handle_registration(PickleFramer.return_value, event)
-        assert id(PickleFramer.return_value) not in server.pending
+        assert id(JSONFramer.return_value) in server.pending
+        server.handle_registration(JSONFramer.return_value, event)
+        assert id(JSONFramer.return_value) not in server.pending
         assert GObject.signal_handler_disconnect.call_count == 2
         ExtensionController.assert_called_once()
 

--- a/ulauncher/api/client/Client.py
+++ b/ulauncher/api/client/Client.py
@@ -7,7 +7,7 @@ from functools import partial
 from gi.repository import Gio, GLib
 
 from ulauncher.api.shared.socket_path import get_socket_path
-from ulauncher.utils.framer import PickleFramer
+from ulauncher.utils.framer import JSONFramer
 from ulauncher.utils.timer import timer
 
 logger = logging.getLogger()
@@ -35,7 +35,7 @@ class Client:
         if not self.conn:
             msg = f"Failed to connect to socket_path {self.socket_path}"
             raise RuntimeError(msg)
-        self.framer = PickleFramer()
+        self.framer = JSONFramer()
         self.framer.connect("message_parsed", self.on_message)
         self.framer.connect("closed", self.on_close)
         self.framer.set_connection(self.conn)
@@ -49,7 +49,7 @@ class Client:
         """
         Parses message from Ulauncher and triggers extension event
 
-        :param ulauncher.utils.framer.PickleFramer framer:
+        :param ulauncher.utils.framer.JSONFramer framer:
         :param ulauncher.api.shared.events.Event event:
         """
         logger.debug("Incoming event %s", type(event).__name__)
@@ -65,7 +65,7 @@ class Client:
 
         Triggers :class:`~ulauncher.api.shared.event.UnloadEvent` for graceful shutdown
 
-        :param ulauncher.utils.framer.PickleFramer framer:
+        :param ulauncher.utils.framer.JSONFramer framer:
         """
         logger.warning("Connection closed. Exiting")
         self.extension.trigger_event({"type": "event:unload"})

--- a/ulauncher/modes/extensions/ExtensionServer.py
+++ b/ulauncher/modes/extensions/ExtensionServer.py
@@ -7,7 +7,7 @@ from gi.repository import Gio, GObject
 
 from ulauncher.api.shared.socket_path import get_socket_path
 from ulauncher.modes.extensions.ExtensionController import ExtensionController
-from ulauncher.utils.framer import PickleFramer
+from ulauncher.utils.framer import JSONFramer
 
 logger = logging.getLogger()
 
@@ -46,7 +46,7 @@ class ExtensionServer:
 
     # pylint: disable=unused-argument
     def handle_incoming(self, _service, conn, _source):
-        framer = PickleFramer()
+        framer = JSONFramer()
         msg_handler_id = framer.connect("message_parsed", self.handle_registration)
         closed_handler_id = framer.connect("closed", self.handle_pending_close)
         self.pending[id(framer)] = (framer, msg_handler_id, closed_handler_id)

--- a/ulauncher/ui/windows/UlauncherWindow.py
+++ b/ulauncher/ui/windows/UlauncherWindow.py
@@ -3,6 +3,7 @@ from typing import Any, Dict, Union
 
 from gi.repository import Gdk, Gtk, Keybinder  # type: ignore[attr-defined]
 
+from ulauncher.api.result import Result
 from ulauncher.config import PATHS
 from ulauncher.modes.apps.AppResult import AppResult
 from ulauncher.modes.extensions.DeferredResultRenderer import DeferredResultRenderer
@@ -28,7 +29,7 @@ def handle_event(window, event: Union[bool, list, str, Dict[str, Any]]) -> bool:
     if isinstance(event, bool):
         return event
     if isinstance(event, list):
-        window.show_results(event)
+        window.show_results(res if isinstance(res, Result) else Result(**res) for res in event)
         return True
     if isinstance(event, str):
         window.app.query = event

--- a/ulauncher/utils/framer.py
+++ b/ulauncher/utils/framer.py
@@ -1,5 +1,5 @@
+import json
 import logging
-import pickle
 from collections import deque
 from struct import pack, unpack_from
 
@@ -67,7 +67,7 @@ class PickleFramer(GObject.GObject):
             self._conn.close_async(GLib.PRIORITY_DEFAULT, None, self._close_ready, None)
 
     def send(self, obj: object):
-        objp = pickle.dumps(obj)
+        objp = json.dumps(obj).encode()
         msg = pack("I", len(objp)) + objp
         self._outbound.append(msg)
         self._write_next()
@@ -113,7 +113,7 @@ class PickleFramer(GObject.GObject):
                 break
             ptr += INTSZ
             objp = self._inbound[ptr : ptr + msgsize]
-            obj = pickle.loads(objp)
+            obj = json.loads(objp)
             log.debug('Received message with keys "%s"', set(obj))
             self.emit("message_parsed", obj)
             ptr += msgsize

--- a/ulauncher/utils/framer.py
+++ b/ulauncher/utils/framer.py
@@ -16,14 +16,14 @@ class InvalidStateError(RuntimeError):
     """
 
 
-class PickleFramer(GObject.GObject):
+class JSONFramer(GObject.GObject):
     """
-    The PickleFramer frames objects serialized using Pickle into and out of a Gio based
+    The JSONFramer frames objects serialized using JSON into and out of a Gio based
     SocketConnection instances.
 
-    The binary data resulting from Pickle serialization has no inherent boundaries, so this class
+    The binary data resulting from JSON serialization has no inherent boundaries, so this class
     uses a typical "bytes to follow" word to indicate the size of each frame worth of data. This
-    way the receiver, which is expected to be another instance of PickleFramer, can correctly
+    way the receiver, which is expected to be another instance of JSONFramer, can correctly
     extract the right number of bytes to deserialize back into the original object. This class
     handles all of the async API of the Gio stream interface as well as some of the edge cases such
     as short reads and error states.


### PR DESCRIPTION
I've been pushing underlying PRs and commits to enable this change recently: #1221, #1230, 6706467, ee73262 #1237 d8f65e2 a23ff49

It's working well for me, although pickle is apparently more compact, so the result is the messages are actually much longer now (sometimes more than twice as big).

I tested with ulauncher-clipboard and sending 200 items (not that my window is big enough to render them all). The result size is 54196 bytes instead of 22773 before this PR.

But that still wasn't noticably slow. JSON is much faster to serialize and parse (more than 10x) and it is generally better and a step towards supporting extensions in other languages #283

I'm not sure how much the PickleFramer class (now renamed) still makes sense though. It looks to me like it's more about the socket communication and switching from pickle to json doesn't really change anything there?