### PR TITLE
feat(#204): added ctrl-j/k navigation hotkeys

### DIFF
--- a/ulauncher/ui/windows/UlauncherWindow.py
+++ b/ulauncher/ui/windows/UlauncherWindow.py
@@ -195,7 +195,7 @@ class UlauncherWindow(Gtk.ApplicationWindow, LayerShellOverlay):
             # input_changed can trigger when hiding window
             self.handle_event(ModeHandler.get_instance().on_query_change(self.app.query))
 
-    def on_input_key_press(self, widget, event) -> bool:  # noqa: PLR0911
+    def on_input_key_press(self, widget, event) -> bool:  # noqa: PLR0911, PLR0912
         """
         Triggered by user key press
         Return True to stop other handlers from being invoked for the event

--- a/ulauncher/ui/windows/UlauncherWindow.py
+++ b/ulauncher/ui/windows/UlauncherWindow.py
@@ -242,21 +242,23 @@ class UlauncherWindow(Gtk.ApplicationWindow, LayerShellOverlay):
                 return True
 
         if self.results_nav:
-            if keyname in ("Up", "ISO_Left_Tab") or (ctrl and keyname == "p") or (ctrl and keyname == "k"):
+            if keyname in ("Up", "ISO_Left_Tab") or (ctrl and keyname == "p"):
                 self.results_nav.go_up()
                 return True
 
+            if keyname in ("Down", "Tab") or (ctrl and keyname == "n"):
+                self.results_nav.go_down()
+                return True
+
             if not self.emacs_bindings_active():
-                if (ctrl and keyname == "k"):
+                if keyname in (ctrl and keyname == "k"):
                     self.results_nav.go_up()
                     return True
-                if (ctrl and keyname == "j"):
+
+                if keyname in (ctrl and keyname == "j"):
                     self.results_nav.go_down()
                     return True
 
-            if keyname in ("Down", "Tab") or (ctrl and keyname == "n") or (ctrl and keyname == "j"):
-                self.results_nav.go_down()
-                return True
             if keyname in ("Return", "KP_Enter"):
                 result = self.results_nav.activate(self.app.query, alt=alt)
                 self.handle_event(result)

--- a/ulauncher/ui/windows/UlauncherWindow.py
+++ b/ulauncher/ui/windows/UlauncherWindow.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import logging
 from typing import Any
 
-from gi.repository import Gdk, Gtk, Gio, Keybinder  # type: ignore[attr-defined]
+from gi.repository import Gdk, Gio, Gtk, Keybinder  # type: ignore[attr-defined]
 
 from ulauncher.api.result import Result
 from ulauncher.config import PATHS
@@ -195,9 +195,21 @@ class UlauncherWindow(Gtk.ApplicationWindow, LayerShellOverlay):
             # input_changed can trigger when hiding window
             self.handle_event(ModeHandler.get_instance().on_query_change(self.app.query))
 
-    def emacs_bindings_active(self) -> bool:
-        gsettings = Gio.Settings.new("org.gnome.desktop.interface")
-        return gsettings.get_string("gtk-key-theme") == "Emacs"
+    def is_emacs_bindings_active(self) -> bool:
+        """
+        Checks whether the Emacs bindings are active in the GNOME.
+
+        Returns:
+            bool: True if the Emacs bindings are active, False otherwise.
+        """
+        try:
+            gsettings = Gio.Settings.new("org.gnome.desktop.interface")
+            key_theme = gsettings.get_string("gtk-key-theme")
+        except Exception as e:
+            logger.info("Failed to get the gtk-key-theme: %s", e)
+            return False
+
+        return key_theme.lower() == "emacs"
 
     def on_input_key_press(self, widget, event) -> bool:  # noqa: PLR0911
         """

--- a/ulauncher/ui/windows/UlauncherWindow.py
+++ b/ulauncher/ui/windows/UlauncherWindow.py
@@ -241,15 +241,6 @@ class UlauncherWindow(Gtk.ApplicationWindow, LayerShellOverlay):
                 self.results_nav.go_down()
                 return True
 
-            if not self.settings.emacs_bindings:
-                if keyname in (ctrl and keyname == "k"):
-                    self.results_nav.go_up()
-                    return True
-
-                if keyname in (ctrl and keyname == "j"):
-                    self.results_nav.go_down()
-                    return True
-
             if keyname in ("Return", "KP_Enter"):
                 result = self.results_nav.activate(self.app.query, alt=alt)
                 self.handle_event(result)

--- a/ulauncher/ui/windows/UlauncherWindow.py
+++ b/ulauncher/ui/windows/UlauncherWindow.py
@@ -250,7 +250,7 @@ class UlauncherWindow(Gtk.ApplicationWindow, LayerShellOverlay):
                 self.results_nav.go_down()
                 return True
 
-            if not self.emacs_bindings_active():
+            if not self.is_emacs_bindings_active():
                 if keyname in (ctrl and keyname == "k"):
                     self.results_nav.go_up()
                     return True

--- a/ulauncher/ui/windows/UlauncherWindow.py
+++ b/ulauncher/ui/windows/UlauncherWindow.py
@@ -226,10 +226,10 @@ class UlauncherWindow(Gtk.ApplicationWindow, LayerShellOverlay):
                 return True
 
         if self.results_nav:
-            if keyname in ("Up", "ISO_Left_Tab") or (ctrl and keyname == "p"):
+            if keyname in ("Up", "ISO_Left_Tab") or (ctrl and keyname == "p") or (ctrl and keyname == "k"):
                 self.results_nav.go_up()
                 return True
-            if keyname in ("Down", "Tab") or (ctrl and keyname == "n"):
+            if keyname in ("Down", "Tab") or (ctrl and keyname == "n") or (ctrl and keyname == "j"):
                 self.results_nav.go_down()
                 return True
             if keyname in ("Return", "KP_Enter"):

--- a/ulauncher/ui/windows/UlauncherWindow.py
+++ b/ulauncher/ui/windows/UlauncherWindow.py
@@ -206,12 +206,13 @@ class UlauncherWindow(Gtk.ApplicationWindow, LayerShellOverlay):
         ctrl = bool(event.state & Gdk.ModifierType.CONTROL_MASK)
         jump_keys = self.settings.get_jump_keys()
 
-        if not self.settings.emacs_bindings:
-            up_aliases = ["k"]
-            down_aliases = ["j"]
+        if len(self.settings.arrow_key_aliases) == 4:  # noqa: PLR2004
+            _left_alias, down_alias, up_alias, _right_alias = [*self.settings.arrow_key_aliases]  # type: ignore[misc]
         else:
-            up_aliases = ["p"]
-            down_aliases = ["n"]
+            _left_alias, down_alias, up_alias, _right_alias = [None] * 4
+            logger.warning(
+                "Invalid value for arrow_key_aliases: %s, expected four letters", self.settings.arrow_key_aliases
+            )
 
         if keyname == "Escape":
             self.hide()
@@ -233,11 +234,11 @@ class UlauncherWindow(Gtk.ApplicationWindow, LayerShellOverlay):
                 return True
 
         if self.results_nav:
-            if keyname in ("Up", "ISO_Left_Tab") or (ctrl and keyname in up_aliases):
+            if keyname in ("Up", "ISO_Left_Tab") or (ctrl and keyname == up_alias):
                 self.results_nav.go_up()
                 return True
 
-            if keyname in ("Down", "Tab") or (ctrl and keyname in down_aliases):
+            if keyname in ("Down", "Tab") or (ctrl and keyname == down_alias):
                 self.results_nav.go_down()
                 return True
 

--- a/ulauncher/ui/windows/UlauncherWindow.py
+++ b/ulauncher/ui/windows/UlauncherWindow.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import logging
 from typing import Any
 
-from gi.repository import Gdk, Gtk, Keybinder  # type: ignore[attr-defined]
+from gi.repository import Gdk, Gtk, Gio, Keybinder  # type: ignore[attr-defined]
 
 from ulauncher.api.result import Result
 from ulauncher.config import PATHS
@@ -195,6 +195,10 @@ class UlauncherWindow(Gtk.ApplicationWindow, LayerShellOverlay):
             # input_changed can trigger when hiding window
             self.handle_event(ModeHandler.get_instance().on_query_change(self.app.query))
 
+    def emacs_bindings_active(self) -> bool:
+        gsettings = Gio.Settings.new("org.gnome.desktop.interface")
+        return gsettings.get_string("gtk-key-theme") == "Emacs"
+
     def on_input_key_press(self, widget, event) -> bool:  # noqa: PLR0911
         """
         Triggered by user key press
@@ -229,6 +233,15 @@ class UlauncherWindow(Gtk.ApplicationWindow, LayerShellOverlay):
             if keyname in ("Up", "ISO_Left_Tab") or (ctrl and keyname == "p") or (ctrl and keyname == "k"):
                 self.results_nav.go_up()
                 return True
+
+            if not self.emacs_bindings_active():
+                if (ctrl and keyname == "k"):
+                    self.results_nav.go_up()
+                    return True
+                if (ctrl and keyname == "j"):
+                    self.results_nav.go_down()
+                    return True
+
             if keyname in ("Down", "Tab") or (ctrl and keyname == "n") or (ctrl and keyname == "j"):
                 self.results_nav.go_down()
                 return True

--- a/ulauncher/ui/windows/UlauncherWindow.py
+++ b/ulauncher/ui/windows/UlauncherWindow.py
@@ -207,9 +207,9 @@ class UlauncherWindow(Gtk.ApplicationWindow, LayerShellOverlay):
         jump_keys = self.settings.get_jump_keys()
 
         if len(self.settings.arrow_key_aliases) == 4:  # noqa: PLR2004
-            _left_alias, down_alias, up_alias, _right_alias = [*self.settings.arrow_key_aliases]  # type: ignore[misc]
+            left_alias, down_alias, up_alias, right_alias = [*self.settings.arrow_key_aliases]  # type: ignore[misc]
         else:
-            _left_alias, down_alias, up_alias, _right_alias = [None] * 4
+            left_alias, down_alias, up_alias, right_alias = [None] * 4
             logger.warning(
                 "Invalid value for arrow_key_aliases: %s, expected four letters", self.settings.arrow_key_aliases
             )
@@ -240,6 +240,14 @@ class UlauncherWindow(Gtk.ApplicationWindow, LayerShellOverlay):
 
             if keyname in ("Down", "Tab") or (ctrl and keyname == down_alias):
                 self.results_nav.go_down()
+                return True
+
+            if ctrl and keyname == left_alias:
+                widget.set_position(max(0, widget.get_position() - 1))
+                return True
+
+            if ctrl and keyname == right_alias:
+                widget.set_position(widget.get_position() + 1)
                 return True
 
             if keyname in ("Return", "KP_Enter"):

--- a/ulauncher/ui/windows/UlauncherWindow.py
+++ b/ulauncher/ui/windows/UlauncherWindow.py
@@ -207,8 +207,8 @@ class UlauncherWindow(Gtk.ApplicationWindow, LayerShellOverlay):
         jump_keys = self.settings.get_jump_keys()
 
         if not self.settings.emacs_bindings:
-            up_aliases = ["k", "p"]
-            down_aliases = ["j", "n"]
+            up_aliases = ["k"]
+            down_aliases = ["j"]
         else:
             up_aliases = ["p"]
             down_aliases = ["n"]

--- a/ulauncher/utils/Settings.py
+++ b/ulauncher/utils/Settings.py
@@ -17,7 +17,7 @@ class Settings(JsonConf):
     show_indicator_icon = True
     terminal_command = ""
     theme_name = "light"
-    emacs_bindings = False
+    arrow_key_aliases = "hjkl"
 
     # Convert dash to underscore
     def __setitem__(self, key, value):

--- a/ulauncher/utils/Settings.py
+++ b/ulauncher/utils/Settings.py
@@ -17,6 +17,7 @@ class Settings(JsonConf):
     show_indicator_icon = True
     terminal_command = ""
     theme_name = "light"
+    emacs_bindings = False
 
     # Convert dash to underscore
     def __setitem__(self, key, value):


### PR DESCRIPTION
## Link to the related issue: #204 

## Summary
The purpose of this change is to assist the Vim community by enabling the use of ctrl-j/k for navigating through Ulauncher results. This combination is widely recognized as a navigation hotkey and is currently supported by most Linux, Mac, and Windows launchers.

## Local testing
The change has been tested successfully on Ubuntu 23.04.