### PR TITLE
Fix ampersand parsing incosistency

### DIFF
--- a/tests/ui/test_ResultWidget.py
+++ b/tests/ui/test_ResultWidget.py
@@ -88,7 +88,7 @@ class TestResultWidget:
 
     def test_set_name(self, result_wgt, builder):
         result_wgt.set_name("test name")
-        builder.get_object.return_value.set_text.assert_called_with("test name")
+        builder.get_object.return_value.set_markup.assert_called_with("test name")
 
     def test_on_click(self, mocker, result_wgt):
         mock_get_toplevel = mocker.patch.object(result_wgt, "get_toplevel")
@@ -110,7 +110,7 @@ class TestResultWidget:
 
     def test_set_description(self, result_wgt, builder):
         result_wgt.set_description("test description")
-        builder.get_object.return_value.set_text.assert_called_with("test description")
+        builder.get_object.return_value.set_markup.assert_called_with("test description")
 
     def test_no_description(self, result_wgt, builder):
         result_wgt.set_description(None)

--- a/ulauncher/ui/ResultWidget.py
+++ b/ulauncher/ui/ResultWidget.py
@@ -115,10 +115,7 @@ class ResultWidget(Gtk.EventBox):  # type: ignore[name-defined]
 
     def set_name(self, name: str) -> None:
         item = self.builder.get_object("item-name")
-        if "<span" in name:  # dealing with markup
-            item.set_markup(name)
-        else:
-            item.set_text(name)
+        item.set_markup(name)
         self.name = name
 
     def get_name(self):
@@ -139,7 +136,7 @@ class ResultWidget(Gtk.EventBox):  # type: ignore[name-defined]
         description_obj = self.builder.get_object("item-descr")
 
         if description and not self.compact:
-            description_obj.set_text(description)
+            description_obj.set_markup(description)
         else:
             description_obj.destroy()  # remove description label
 


### PR DESCRIPTION
<!--
Thank you for submitting a PR to Ulauncher!

Please read our contribution instructions if you haven't:
https://github.com/Ulauncher/Ulauncher#code-contribution

* Explain the changes in this PR and link to related issue(s) if applicable
* When applicable, please update the documentation according to your changes.
* Ensure that the PR doesn't break existing tests, and please add your own if applicable.

A git action will verify your PR, but you can also test locally with `./ul test`

-->

Changed `set_name()` and `set_description()` functions to always use `set_markup()` instead of `set_text()`.

Previously, set_markup was used conditionally in set_name based on if there's highlighted text in the name. This could create an inconsistent side effect when an application name has the html `&amp;` entity, which would get parsed as & by set_markup, but not by set_text (so you would get `&amp;`)

For consistency's sake, I also changed this behavior in set_description, so now `&amp;` gets parsed there correctly as well.

A possible downside is that other HTML tags like links get parsed as well, but this would already happen in the title if set_markup was called conditionally. All this does is make the behavior more consistent

### Weird thing I found
According to gMarkup (used by Pango) [documentation](https://docs.gtk.org/Pango/pango_markup.html), entities  `&lt;`, `&gt;`, `&quot;`, `&apos;` should work as well but they don't. I've tested this a bunch but I don't think this is something we could change

fixes #1288 