### PR TITLE
Update ulauncher-toggle script to comply with POSIX sh

### DIFF
--- a/bin/ulauncher-toggle
+++ b/bin/ulauncher-toggle
@@ -3,11 +3,12 @@
 # NOTE: ulauncher-toggle is no longer needed.
 # It's better to use these two gapplication commands directly.
 
-for ((i=1; i<=$#; i++))
+while [ "$#" -gt 0 ]
 do
-  if [ "${!i}" = "--query" ] || [ "${!i}" = "-q" ]; then
-    let val=i+1
-    gapplication action io.ulauncher.Ulauncher set-query "'${!val}'"
+  arg="$1"
+  shift
+  if [ "$arg" = "--query" ] || [ "$arg" = "-q" ]; then
+    gapplication action io.ulauncher.Ulauncher set-query "'$1'"
     exit 0
   fi
 done


### PR DESCRIPTION
This pull request updates the ulauncher-toggle script to comply with POSIX sh.

Without this, ulauncher-toggle may not work, since `/bin/sh` only guarantees POSIX sh compatibility and may not support Bash-specific extensions.
For instance on Debian, where `/bin/sh` is linked to **d**ash, I get an error:
```
$ ulauncher-toggle 
/usr/bin/ulauncher-toggle: 6: Syntax error: Bad for loop variable
```

I used [shellcheck](https://www.shellcheck.net/) to validate that the script is now compliant.