### PR TITLE
Fix window shifting on double and triple click in some environments

### DIFF
--- a/ulauncher/ui/ResultWidget.py
+++ b/ulauncher/ui/ResultWidget.py
@@ -1,11 +1,11 @@
 from __future__ import annotations
 
 import logging
+from html import unescape
 from types import SimpleNamespace
 from typing import Any
 
 from gi.repository import Gtk, Pango
-from html import unescape
 
 from ulauncher.api.shared.query import Query
 from ulauncher.utils.icon import load_icon_surface

--- a/ulauncher/ui/windows/UlauncherWindow.py
+++ b/ulauncher/ui/windows/UlauncherWindow.py
@@ -260,7 +260,7 @@ class UlauncherWindow(Gtk.ApplicationWindow, LayerShellOverlay):
         """
         Move the window on drag
         """
-        if event.button == 1:
+        if event.button == 1 and event.type == Gdk.EventType.BUTTON_PRESS:
             self.is_dragging = True
             self.begin_move_drag(event.button, event.x_root, event.y_root, event.time)
 

--- a/ulauncher/ui/windows/UlauncherWindow.py
+++ b/ulauncher/ui/windows/UlauncherWindow.py
@@ -260,7 +260,7 @@ class UlauncherWindow(Gtk.ApplicationWindow, LayerShellOverlay):
         """
         Move the window on drag
         """
-        if event.button == 1 and event.type == Gdk.EventType.BUTTON_PRESS:
+        if event.button == 1 and event.type not in (Gdk.EventType._2BUTTON_PRESS, Gdk.EventType._3BUTTON_PRESS):
             self.is_dragging = True
             self.begin_move_drag(event.button, event.x_root, event.y_root, event.time)
 

--- a/ulauncher/ui/windows/UlauncherWindow.py
+++ b/ulauncher/ui/windows/UlauncherWindow.py
@@ -260,7 +260,7 @@ class UlauncherWindow(Gtk.ApplicationWindow, LayerShellOverlay):
         """
         Move the window on drag
         """
-        if event.button == 1 and event.type not in (Gdk.EventType._2BUTTON_PRESS, Gdk.EventType._3BUTTON_PRESS):
+        if event.button == 1 and event.type == Gdk.EventType.BUTTON_PRESS:
             self.is_dragging = True
             self.begin_move_drag(event.button, event.x_root, event.y_root, event.time)
 


### PR DESCRIPTION
Small fix to allow double and triple click to highlight input text in Cinnamon. Fixes https://github.com/Ulauncher/Ulauncher/issues/1297

Behavior before:
[cinnamon-2023-11-02T105036+0100.webm](https://github.com/Ulauncher/Ulauncher/assets/85798751/a9c9c7df-2816-49fd-91a3-e8a9646559f5)

Behavior after:
[cinnamon-2023-11-02T110210+0100.webm](https://github.com/Ulauncher/Ulauncher/assets/85798751/95f1c752-cad9-4ae9-83bc-b99ff3118645)

Can't test this myself but should probably test this in some different environments including using touchpad (maybe touchscreen) to see if they also work with the `Gdk.EventType.BUTTON_PRESS` event type