### PR TITLE
use `sys.path` instead of `os.getenv("PYTHONPATH")`

### DIFF
--- a/ulauncher/modes/extensions/ExtensionRunner.py
+++ b/ulauncher/modes/extensions/ExtensionRunner.py
@@ -77,7 +77,7 @@ class ExtensionRunner:
             cmd = [sys.executable, f"{extension_path}/main.py"]
             env = {
                 "VERBOSE": str(int(self.verbose)),
-                "PYTHONPATH": ":".join(filter(bool, [PATHS.APPLICATION, os.getenv("PYTHONPATH")])),
+                "PYTHONPATH": ":".join([PATHS.APPLICATION] + sys.path),
                 "EXTENSION_ICON": manifest.icon,
                 "EXTENSION_PATH": extension_path,
                 "EXTENSION_PREFERENCES": json.dumps(backwards_compatible_preferences, separators=(",", ":")),


### PR DESCRIPTION
<!--
Thank you for submitting a PR to Ulauncher!

Please read our contribution instructions if you haven't:
https://github.com/Ulauncher/Ulauncher#code-contribution

* Explain the changes in this PR and link to related issue(s) if applicable
* When applicable, please update the documentation according to your changes.
* Ensure that the PR doesn't break existing tests, and please add your own if applicable.

A git action will verify your PR, but you can also test locally with `./ul test`

-->
When trying to package `v6` for NixOS I stumbled upon [this patch](https://github.com/NixOS/nixpkgs/blob/e44462d6021bfe23dfb24b775cc7c390844f773d/pkgs/applications/misc/ulauncher/fix-extensions.patch) and thought it could be merged upstream.

I don't know the whole story behind using `$PYTHONPATH`, but `sys.path` seems like a cleaner replacement.
