### PR TITLE
refactor: static namespace module

### DIFF
--- a/bin/ulauncher
+++ b/bin/ulauncher
@@ -23,6 +23,7 @@ IS_DEV = PROJECT_ROOT.joinpath("ulauncher").exists() and str(PROJECT_ROOT) not i
 if IS_DEV:
     sys.path.insert(0, str(PROJECT_ROOT))
     os.environ["PYTHONPATH"] = ":".join(list(filter(None, [PYTHONPATH, str(PROJECT_ROOT)])))
+    os.environ["ULAUNCHER_DATA_DIR"] = str(Path(PROJECT_ROOT, "data"))
 
 try:
     from ulauncher.main import main

--- a/conftest.py
+++ b/conftest.py
@@ -1,1 +1,5 @@
 # This file has to exist for `pytest` to find the ulauncher module
+
+import os
+
+os.environ["ULAUNCHER_DATA_DIR"] = f"{os.path.dirname(__file__)}/data"

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -158,7 +158,7 @@ texinfo_documents = [
         "Ulauncher Documentation",
         author,
         "Ulauncher",
-        ulauncher.description,
+        "Application launcher for Linux",
         "Miscellaneous",
     ),
 ]

--- a/docs/source/ulauncher.utils.rst
+++ b/docs/source/ulauncher.utils.rst
@@ -51,14 +51,6 @@ ulauncher.utils.fuzzy\_search module
     :undoc-members:
     :show-inheritance:
 
-ulauncher.utils.icon module
-------------------------------------
-
-.. automodule:: ulauncher.utils.icon
-    :members:
-    :undoc-members:
-    :show-inheritance:
-
 ulauncher.utils.text\_highlighter module
 ----------------------------------------
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,5 @@
 [metadata]
 name = ulauncher
-version = 6.0.0-beta4
 url = http://ulauncher.io/
 author = Aleksandr Gornostal
 maintainer = Albin Larsson

--- a/setup.cfg
+++ b/setup.cfg
@@ -39,10 +39,3 @@ install_requires =
 	pycairo
 	PyGObject
 	python-Levenshtein
-
-[gi_versions]
-Gtk = 3.0
-Gdk = 3.0
-GdkX11 = 3.0
-GdkPixbuf = 2.0
-Pango = 1.0

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,5 @@
 #!/usr/bin/env python3
 
-import json
 import subprocess
 import sys
 from pathlib import Path
@@ -76,18 +75,6 @@ class build_wrapper(build_py, Command):
             build_preferences.run(self)
 
         build_py.run(self)
-        print("Overwriting the namespace package with fixed values")  # noqa: T201
-        ns_module = Path(self.build_lib + "/ulauncher/__init__.py")
-        ns_module_footer = ns_module.read_text().split('"""')[-1]
-        ns_module.write_text(
-            "\n".join(
-                [
-                    f'version = "{ulauncher.version}"',
-                    f"gi_versions = {json.dumps(ulauncher.gi_versions)}",
-                    ns_module_footer,
-                ]
-            )
-        )
 
 
 setup(
@@ -114,4 +101,5 @@ setup(
         *data_files_from_path("share/ulauncher", "data"),
     ],
     cmdclass={"build_py": build_wrapper, "build_prefs": build_preferences},
+    version=ulauncher.version,
 )

--- a/setup.py
+++ b/setup.py
@@ -82,7 +82,6 @@ class build_wrapper(build_py, Command):
         ns_module.write_text(
             "\n".join(
                 [
-                    f'data_dir = "{sys.prefix}/share/ulauncher"',
                     f'version = "{ulauncher.version}"',
                     f"gi_versions = {json.dumps(ulauncher.gi_versions)}",
                     ns_module_footer,

--- a/setup.py
+++ b/setup.py
@@ -84,7 +84,6 @@ class build_wrapper(build_py, Command):
                 [
                     f'data_dir = "{sys.prefix}/share/ulauncher"',
                     f'version = "{ulauncher.version}"',
-                    f'description = "{ulauncher.description}"',
                     f"gi_versions = {json.dumps(ulauncher.gi_versions)}",
                     ns_module_footer,
                 ]

--- a/ulauncher/__init__.py
+++ b/ulauncher/__init__.py
@@ -14,7 +14,13 @@ _config.read(f"{_project_root}/setup.cfg")
 data_dir = f"{_project_root}/data"  # substituted for `{sys.prefix}/share/ulauncher` at build time
 version = _config["metadata"]["version"]
 description = _config["metadata"]["description"]
-gi_versions = dict(_config["gi_versions"])
+gi_versions = {
+    "Gtk": "3.0",
+    "Gdk": "3.0",
+    "GdkX11": "3.0",
+    "GdkPixbuf": "2.0",
+    "Pango": "1.0",
+}
 
 """
 This file is written for when running Ulauncher from the source directory

--- a/ulauncher/__init__.py
+++ b/ulauncher/__init__.py
@@ -13,7 +13,6 @@ _config.read(f"{_project_root}/setup.cfg")
 
 data_dir = f"{_project_root}/data"  # substituted for `{sys.prefix}/share/ulauncher` at build time
 version = _config["metadata"]["version"]
-description = _config["metadata"]["description"]
 gi_versions = {
     "Gtk": "3.0",
     "Gdk": "3.0",

--- a/ulauncher/__init__.py
+++ b/ulauncher/__init__.py
@@ -11,7 +11,6 @@ _project_root = dirname(dirname(__file__))
 _config = CaseSensitiveConfigParser()
 _config.read(f"{_project_root}/setup.cfg")
 
-data_dir = f"{_project_root}/data"  # substituted for `{sys.prefix}/share/ulauncher` at build time
 version = _config["metadata"]["version"]
 gi_versions = {
     "Gtk": "3.0",

--- a/ulauncher/__init__.py
+++ b/ulauncher/__init__.py
@@ -1,17 +1,4 @@
-from configparser import ConfigParser
-from os.path import dirname
-
-
-class CaseSensitiveConfigParser(ConfigParser):
-    def optionxform(self, optionstr):
-        return optionstr
-
-
-_project_root = dirname(dirname(__file__))
-_config = CaseSensitiveConfigParser()
-_config.read(f"{_project_root}/setup.cfg")
-
-version = _config["metadata"]["version"]
+version = "6.0.0-beta4"
 gi_versions = {
     "Gtk": "3.0",
     "Gdk": "3.0",
@@ -19,12 +6,6 @@ gi_versions = {
     "GdkPixbuf": "2.0",
     "Pango": "1.0",
 }
-
-"""
-This file is written for when running Ulauncher from the source directory
-When packaging Ulauncher we overwrite everything above this comment with static variables
-So IF YOU EDIT THIS FILE make sure your changes are reflected in setup.py:build_wrapper
-"""
 
 # this namespace module is the only way we can pin gi versions globally,
 # but we also use it when we build, then we don't want to require gi

--- a/ulauncher/config.py
+++ b/ulauncher/config.py
@@ -1,5 +1,6 @@
 import argparse
 import os
+import sys
 from functools import lru_cache
 from gettext import gettext
 
@@ -9,24 +10,26 @@ APP_ID = "io.ulauncher.Ulauncher"
 API_VERSION = "3.0"
 # spec: https://specifications.freedesktop.org/menu-spec/latest/ar01s02.html
 APPLICATION = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+# ULAUNCHER_DATA_DIR is added by the ulauncher binary if it's detecting that it's running from source
+DATA_DIR = os.environ.get("ULAUNCHER_DATA_DIR", f"{sys.prefix}/share/ulauncher")
 HOME = os.path.expanduser("~")
 CONFIG = os.path.join(os.environ.get("XDG_CONFIG_HOME", f"{HOME}/.config"), "ulauncher")
-DATA = os.path.join(os.environ.get("XDG_DATA_HOME", f"{HOME}/.local/share"), "ulauncher")
+USER_DATA = os.path.join(os.environ.get("XDG_DATA_HOME", f"{HOME}/.local/share"), "ulauncher")
 STATE = os.path.join(os.environ.get("XDG_STATE_HOME", f"{HOME}/.local/state"), "ulauncher")
-EXTENSIONS = os.path.join(DATA, "extensions")
+EXTENSIONS = os.path.join(USER_DATA, "extensions")
 EXTENSIONS_CONFIG = os.path.join(CONFIG, "ext_preferences")
 USER_THEMES = os.path.join(CONFIG, "user-themes")
-SYSTEM_THEMES = os.path.join(ulauncher.data_dir, "themes")
+SYSTEM_THEMES = os.path.join(DATA_DIR, "themes")
 VERSION = ulauncher.version
 
 
 # Would use SimpleNamespace if that worked with typing and auto-completion.
 class _PATHS_CLASS:
     APPLICATION = APPLICATION
-    ASSETS = ulauncher.data_dir
+    ASSETS = DATA_DIR
     HOME = HOME
     CONFIG = CONFIG
-    DATA = DATA
+    DATA = USER_DATA
     STATE = STATE
     EXTENSIONS = EXTENSIONS
     EXTENSIONS_CONFIG = EXTENSIONS_CONFIG

--- a/ulauncher/ui/ResultWidget.py
+++ b/ulauncher/ui/ResultWidget.py
@@ -8,7 +8,7 @@ from typing import Any
 from gi.repository import Gtk, Pango
 
 from ulauncher.api.shared.query import Query
-from ulauncher.utils.icon import load_icon_surface
+from ulauncher.utils.load_icon_surface import load_icon_surface
 from ulauncher.utils.Settings import Settings
 from ulauncher.utils.text_highlighter import highlight_text
 from ulauncher.utils.wm import get_text_scaling_factor

--- a/ulauncher/ui/preferences_server.py
+++ b/ulauncher/ui/preferences_server.py
@@ -20,8 +20,8 @@ from ulauncher.modes.shortcuts.ShortcutsDb import ShortcutsDb
 from ulauncher.utils.decorator.glib_idle_add import glib_idle_add
 from ulauncher.utils.decorator.run_async import run_async
 from ulauncher.utils.environment import IS_X11
+from ulauncher.utils.get_icon_path import get_icon_path
 from ulauncher.utils.hotkey_controller import HotkeyController
-from ulauncher.utils.icon import get_icon_path
 from ulauncher.utils.launch_detached import open_detached
 from ulauncher.utils.Settings import Settings
 from ulauncher.utils.systemd_controller import SystemdController

--- a/ulauncher/ui/windows/UlauncherWindow.py
+++ b/ulauncher/ui/windows/UlauncherWindow.py
@@ -17,8 +17,8 @@ from ulauncher.ui.LayerShell import LayerShellOverlay
 
 # these imports are needed for Gtk to find widget classes
 from ulauncher.ui.ResultWidget import ResultWidget  # noqa: F401
-from ulauncher.utils.icon import load_icon_surface
 from ulauncher.utils.launch_detached import open_detached
+from ulauncher.utils.load_icon_surface import load_icon_surface
 from ulauncher.utils.Settings import Settings
 from ulauncher.utils.Theme import Theme
 from ulauncher.utils.wm import get_monitor

--- a/ulauncher/utils/get_icon_path.py
+++ b/ulauncher/utils/get_icon_path.py
@@ -1,0 +1,34 @@
+from __future__ import annotations
+
+import logging
+import mimetypes
+from os.path import expanduser, join
+
+from gi.repository import Gtk
+
+icon_theme = Gtk.IconTheme.get_default()  # type: ignore[attr-defined]
+logger = logging.getLogger()
+
+
+def get_icon_path(icon, size=32, base_path=""):
+    """
+    :param str icon:
+    :rtype: str
+    """
+    try:
+        if icon and isinstance(icon, str):
+            icon = expanduser(icon)
+            if icon.startswith("/"):
+                return icon
+
+            if "/" in icon or mimetypes.guess_type(icon)[0]:
+                return join(base_path, icon)
+
+            themed_icon = icon_theme.lookup_icon(icon, size, Gtk.IconLookupFlags.FORCE_SIZE)
+            if themed_icon:
+                return themed_icon.get_filename()
+
+    except Exception as e:
+        logger.info("Could not load icon path %s. E: %s", icon, e)
+
+    return None

--- a/ulauncher/utils/load_icon_surface.py
+++ b/ulauncher/utils/load_icon_surface.py
@@ -1,40 +1,16 @@
-import logging
-import mimetypes
-from functools import lru_cache
-from os.path import expanduser, join
+from __future__ import annotations
 
-from gi.repository import Gdk, GdkPixbuf, Gtk
+import logging
+from functools import lru_cache
+
+from gi.repository import Gdk, GdkPixbuf
 
 import ulauncher
+from ulauncher.utils.get_icon_path import get_icon_path
 
-icon_theme = Gtk.IconTheme.get_default()  # type: ignore[attr-defined]
 logger = logging.getLogger()
 
 DEFAULT_EXE_ICON = f"{ulauncher.data_dir}/icons/executable.png"
-
-
-def get_icon_path(icon, size=32, base_path=""):
-    """
-    :param str icon:
-    :rtype: str
-    """
-    try:
-        if icon and isinstance(icon, str):
-            icon = expanduser(icon)
-            if icon.startswith("/"):
-                return icon
-
-            if "/" in icon or mimetypes.guess_type(icon)[0]:
-                return join(base_path, icon)
-
-            themed_icon = icon_theme.lookup_icon(icon, size, Gtk.IconLookupFlags.FORCE_SIZE)
-            if themed_icon:
-                return themed_icon.get_filename()
-
-    except Exception as e:
-        logger.info("Could not load icon path %s. E: %s", icon, e)
-
-    return None
 
 
 @lru_cache(maxsize=50)

--- a/ulauncher/utils/load_icon_surface.py
+++ b/ulauncher/utils/load_icon_surface.py
@@ -5,12 +5,12 @@ from functools import lru_cache
 
 from gi.repository import Gdk, GdkPixbuf
 
-import ulauncher
+from ulauncher.config import PATHS
 from ulauncher.utils.get_icon_path import get_icon_path
 
 logger = logging.getLogger()
 
-DEFAULT_EXE_ICON = f"{ulauncher.data_dir}/icons/executable.png"
+DEFAULT_EXE_ICON = f"{PATHS.ASSETS}/icons/executable.png"
 
 
 @lru_cache(maxsize=50)


### PR DESCRIPTION
Refactored the namespace package (`__init__.py`) so it doesn't need to be overwritten in the build.
This was one of the quirky things needing special code in setup.py.