### PR TITLE
refactor: skip propagating PYTHONPATH from the app to extensions

### DIFF
--- a/ulauncher/modes/extensions/ExtensionRunner.py
+++ b/ulauncher/modes/extensions/ExtensionRunner.py
@@ -1,6 +1,5 @@
 import json
 import logging
-import os
 import signal
 import sys
 from collections import deque
@@ -77,7 +76,7 @@ class ExtensionRunner:
             cmd = [sys.executable, f"{extension_path}/main.py"]
             env = {
                 "VERBOSE": str(int(self.verbose)),
-                "PYTHONPATH": ":".join(filter(bool, [PATHS.APPLICATION, os.getenv("PYTHONPATH")])),
+                "PYTHONPATH": PATHS.APPLICATION,
                 "EXTENSION_ICON": manifest.icon,
                 "EXTENSION_PATH": extension_path,
                 "EXTENSION_PREFERENCES": json.dumps(backwards_compatible_preferences, separators=(",", ":")),


### PR DESCRIPTION
This code has been in the extension implementation since the original design https://github.com/Ulauncher/Ulauncher/pull/116/files#diff-96890e4141fb84b7c4642a31a1f51c1ead12e61994fbc4a62e2a7d549913a233R59

I don't think we really need it. All the extension should need is the ulauncher application added to its path so it can import the ulauncher module even if it's not installed (running from source)

`PYTHONPATH` is still used as a way to send that path to the extensions though.