### PR TITLE
do not clear GDK_BACKEND=wayland

### DIFF
--- a/ulauncher/utils/launch_detached.py
+++ b/ulauncher/utils/launch_detached.py
@@ -24,7 +24,8 @@ def launch_detached(cmd):
     env = dict(os.environ.items())
     # Make sure GDK apps aren't forced to use x11 on wayland due to ulauncher's need to run
     # under X11 for proper centering.
-    env.pop("GDK_BACKEND", None)
+    if env.get("GDK_BACKEND") != "wayland":
+        env.pop("GDK_BACKEND", None)
 
     try:
         envp = [f"{k}={v}" for k, v in env.items()]


### PR DESCRIPTION
I am not sure what exactly `$GDK_BACKEND` does, but I am setting this to `wayland` in my system config and the code comment indicates it should not clear value of `wayland` itself?

picked from #1307 