### PR TITLE
nix: fix `ruff` check on PATHS

### DIFF
--- a/nix/default.nix
+++ b/nix/default.nix
@@ -126,6 +126,7 @@ let
         --replace gapplication ${glib}/bin/gapplication
       substituteInPlace \
           ulauncher/modes/extensions/ExtensionRunner.py \
+        --replace 'from ulauncher.config import PATHS,' 'from ulauncher.config import' \
         --replace '"PYTHONPATH": PATHS.APPLICATION,' '"PYTHONPATH": ":".join(sys.path),'
 
       substituteInPlace \


### PR DESCRIPTION
`ruff check .` is not happy about the missing usage of `PATHS` after the patch
