### PR TITLE
feat(ext ui): replace preferences dropdown with dedicated buttons

### DIFF
--- a/preferences-src/src/components/pages/ExtensionConfig.vue
+++ b/preferences-src/src/components/pages/ExtensionConfig.vue
@@ -58,7 +58,7 @@
       />
     </div>
 
-    <div class="ext-form" v-if="!extension.error_type && extension.is_running" ref="ext-form">
+    <div class="ext-form" v-if="!extension.error_type" ref="ext-form">
       <template v-for="(trigger, id) in extension.triggers">
         <b-form-group
           v-if="trigger.keyword"

--- a/ulauncher/ui/preferences_server.py
+++ b/ulauncher/ui/preferences_server.py
@@ -278,11 +278,12 @@ class PreferencesServer:
     def extension_update_prefs(self, extension_id, data):
         logger.info("Update extension preferences %s to %s", extension_id, data)
         controller = ExtensionServer.get_instance().controllers.get(extension_id)
-        manifest = controller.manifest
-        for id, new_value in data.get("preferences", {}).items():
-            pref = manifest.preferences.get(id)
-            if pref and new_value != pref.value:
-                controller.trigger_event({"type": "event:update_preferences", "args": [id, new_value, pref.value]})
+        manifest = ExtensionManifest.load_from_extension_id(extension_id)
+        if controller:  # send update_preferences only if extension is running
+            for id, new_value in data.get("preferences", {}).items():
+                pref = manifest.preferences.get(id)
+                if pref and new_value != pref.value:
+                    controller.trigger_event({"type": "event:update_preferences", "args": [id, new_value, pref.value]})
         manifest.apply_user_preferences(data)
         manifest.save_user_preferences(extension_id)
 


### PR DESCRIPTION
Old look:
![image](https://github.com/Ulauncher/Ulauncher/assets/515120/d48c949a-57ba-41fb-952f-524bd0b3b795)

New look: 
![Peek 2023-11-29 20-40](https://github.com/Ulauncher/Ulauncher/assets/515120/1d0b6df6-e068-422e-94b1-9ab4e961a522)

Bonus feature: You can now see and edit the fields for stopped extensions (previously the limited UI prevented this). Obviously extensions won't get the preferences change event, but they should not rely of that.

"Report issue" button has been removed. It was always unsafe to assume that the repo had an open issue tracker at `{repu_url}/issues`. GitHub defaults to that (but it can be disabled). But we also support more than GitHub. So for the little convenience benefit of saving a click it's not worth it.