### PR TITLE
ci: add test to validate nix package can be built

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -20,6 +20,9 @@ jobs:
         run: DISPLAY=:1 xvfb-run pytest tests
       - name: build preferences
         run: ./setup.py build_prefs --force
+      - uses: cachix/install-nix-action@v22
+      - name: nix build
+        run: nix build --out-link nix/result --show-trace --print-build-logs .#default
       - name: build docs
         run: |
           cd docs

--- a/nix/default.nix
+++ b/nix/default.nix
@@ -126,7 +126,7 @@ let
           io.ulauncher.Ulauncher.desktop \
         --replace gapplication ${glib}/bin/gapplication
       substituteInPlace \
-          ulauncher/modes/extensions/ExtensionController.py \
+          ulauncher/modes/extensions/ExtensionRunner.py \
         --replace '"PYTHONPATH": PATHS.APPLICATION,' '"PYTHONPATH": ":".join(sys.path),'
 
       substituteInPlace \

--- a/nix/default.nix
+++ b/nix/default.nix
@@ -126,7 +126,7 @@ let
           io.ulauncher.Ulauncher.desktop \
         --replace gapplication ${glib}/bin/gapplication
       substituteInPlace \
-          ulauncher/modes/extensions/ExtensionRunner.py \
+          ulauncher/modes/extensions/ExtensionController.py \
         --replace '"PYTHONPATH": PATHS.APPLICATION,' '"PYTHONPATH": ":".join(sys.path),'
 
       substituteInPlace \


### PR DESCRIPTION
Cherry-picked from https://github.com/Ulauncher/Ulauncher/pull/1330#pullrequestreview-1801933060 (credit to nazarewk). It wasn't working in that PR, but that was due to issues with the docker image which have been fixed since.

I'm keeping this as a separate PR for now since this runner is a bit slow (understandably) compared to the others and I'm not sure I want this to run for every push (because we have limited free ci minutes).