### PR TITLE
chore: simplify sdist

### DIFF
--- a/.github/workflows/draft-release.yml
+++ b/.github/workflows/draft-release.yml
@@ -21,7 +21,7 @@ jobs:
           DEB_VERSION=$(echo "$VERSION" | tr "-" "~")
           echo "Building Ulauncher version: $VERSION"
           ln -s /var/node_modules preferences-src # use node modules from cache
-          python3 -m build --sdist
+          ./ul sdist
           mv dist/ulauncher*.tar.gz ulauncher_$VERSION.tar.gz
           ./ul build-deb --signed
           cp /tmp/ulauncher*.deb ulauncher_${VERSION}_all.deb

--- a/scripts/build-targz.sh
+++ b/scripts/build-targz.sh
@@ -4,14 +4,12 @@
 # Builds tar.gz file with (un)install script and Ulauncher src
 ##############################################################
 build-targz () {
-    version=$(./ul version)
-
-    echo "#########################################"
-    echo "# Building ulauncher v$version sdist #"
-    echo "#########################################"
-
-    ./setup.py build_prefs --force
-    rm -rf ulauncher.egg-info # https://stackoverflow.com/a/59686298/633921
-    python3 -m build --sdist
-    echo "Build sdist to ./dist"
+    VERSION=$(./ul version)
+    ./setup.py build_prefs
+    # copy gitignore to .tarignore, remove data/preferences and add others to ignore instead
+    cat .gitignore | grep -v data/preferences | cat <(echo -en "preferences-src\nscripts\ntests\ndebian\ndocs\n.github\nconftest.py\nDockerfile\nCO*.md\n.*ignore\nmakefile\nnix\n.editorconfig\nrequirements.txt\n*.nix\nflake.lock\n") -  > .tarignore
+    # create archive with .tarignore
+    tar --transform "s|^\.|ulauncher-${VERSION}|" --exclude-vcs --exclude-ignore-recursive=.tarignore -hzcf "dist/ulauncher-${VERSION}.tar.gz" .
+	rm .tarignore
+	echo -e "Built source dist tarball to ./dist/ulauncher-${VERSION}.tar.gz"
 }

--- a/scripts/help.sh
+++ b/scripts/help.sh
@@ -32,11 +32,11 @@ help () {
 
 The commands below are useful for maintainers:
 
+  ${bold}./ul sdist
+    ${dim}Builds a tar.gz archive with the source code${normal}
+
   ${bold}./ul build-deb
     ${dim}Builds a deb package or uploads new Ulauncher version to PPA in Launchpad${normal}
-
-  ${bold}./ul build-targz
-    ${dim}Builds a targz archive with the source code${normal}
 
   ${bold}./ul build-doc
     ${dim}Builds API docs for extensions using sphinx${normal}

--- a/ul
+++ b/ul
@@ -28,9 +28,9 @@ main () {
     edit-ui) edit-ui $2 ;;
     build-deb) build-deb ;;
     release-deb) release-deb "${@:2}" ;;
+    sdist) build-targz ;;
     build-nix) exec nix build --out-link nix/result --show-trace --print-build-logs "${@:2}" '.#default' ;;
     build-nix-dev) exec nix build --out-link nix/dev --show-trace --print-build-logs "${@:2}" '.#development' ;;
-    build-targz) build-targz $2 ;;
     build-doc) build-doc ;;
     watch-doc) watch-doc ;;
 


### PR DESCRIPTION
This is the second time I rewrite this. The first rewrite (c9066f5dcfe78e05bdca7d7723edd00725c09107) was because I though the original version was convoluted and added an unnecessary build dependency `rsync`, which feels hard to motivate just for this, and I wanted to reuse the standard python setuptools sdist `python3 -m build --sdist`.

This however came with a lot of caveats
* It renames the Ulauncher version to follow the [python version standard](https://packaging.python.org/en/latest/specifications/version-specifiers/#public-version-identifiers), for example renaming `1.2.3-beta1` to `1.2.3-b1`.
* It uses ulauncher.egg-info to select files if it exists, instead of setup.py, so you need to `rm -rf ulauncher.egg-info`  first if you make changes to setup.py https://stackoverflow.com/a/59686298/633921
* It creates egg-info/pkg-info entries we don't want.
* It's much slower (although still sub-second).

This PR reverts to a behavior more similar to the old one, but without `rsync`. Optimally this can be improved later (it would be better as whitelist-based, like the old rsync version, but also reusing the same logic as in setup.py/[manifest.in](https://packaging.python.org/en/latest/guides/using-manifest-in/))

