### PR TITLE
chore: always use pytest no:cacheprovider

### DIFF
--- a/.github/workflows/draft-release.yml
+++ b/.github/workflows/draft-release.yml
@@ -12,9 +12,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: Quick test
-        run: |
-          mypy ulauncher
-          DISPLAY=:1 xvfb-run pytest tests
+        run: ./ul test
       - name: Build release
         run: |
           VERSION=$(./ul version)

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -17,7 +17,7 @@ jobs:
       - name: mypy
         run: mypy ulauncher
       - name: pytest
-        run: DISPLAY=:1 xvfb-run pytest tests
+        run: ./ul test-pytest
       - name: build preferences
         run: ./setup.py build_prefs --force
       - uses: cachix/install-nix-action@v22

--- a/nix/default.nix
+++ b/nix/default.nix
@@ -146,10 +146,6 @@ let
       export HOME=$TMPDIR
 
       substituteInPlace \
-          scripts/tests.sh \
-        --replace ' pytest ' ' pytest -p no:cacheprovider '
-
-      substituteInPlace \
           tests/modes/shortcuts/test_RunScript.py \
         --replace '#!/bin/bash' '#!${stdenv.shell}'
 

--- a/scripts/tests.sh
+++ b/scripts/tests.sh
@@ -29,10 +29,9 @@ test-pytest () {
     echo '[ test: pytest ]'
     if ! command -v xvfb-run >/dev/null
     then
-        pytest tests
+        pytest -p no:cacheprovider tests
     else
         # Use xvfb-run (virtual X server environment)
-        xvfb-run --auto-servernum pytest tests
+        xvfb-run --auto-servernum pytest -p no:cacheprovider tests
     fi
 }
-


### PR DESCRIPTION
I don't know why this patch was needed in the first place, but the cache provider isn't making these tests faster anyway, so might as well always disable it and not need the patch.