### PR TITLE
fix: restore setsid if not running ulauncher through systemd

### DIFF
--- a/ulauncher/utils/launch_detached.py
+++ b/ulauncher/utils/launch_detached.py
@@ -1,22 +1,11 @@
 import logging
 import os
-from shutil import which
 
 from gi.repository import GLib
 
 from ulauncher.utils.systemd_controller import SystemdController
 
 logger = logging.getLogger()
-use_systemd_run = which("systemd-run") and os.system("systemd-run --user --scope true  2> /dev/null") == 0
-
-if not use_systemd_run:
-    logger.warning(
-        "Your system does not support launching applications in isolated scopes.\n"
-        "This may result in applications launched by Ulauncher to depend on the main\n"
-        "process (Ulauncher) and forced to exit prematurely if Ulauncher exits or crashes.\n"
-        "Most likely this is caused by using an outdated or or misconfigured system.\n\n"
-        "For more details see https://github.com/Ulauncher/Ulauncher/discussions/1352"
-    )
 
 
 def launch_detached(cmd):


### PR DESCRIPTION
The switch to GLib.spawn_async reintroduced #754 because `child_setup=os.setsid` doesn't work. 

Reproduction: Stop the ulauncher systemd service and run `make run` or `ulauncher -v` in a terminal. Launch an app which isn't already running or part of the OS (for example Chrome, Firefox but not for example Nautilus). Switch back to the terminal and press ctrl+c to kill Ulauncher.

With this PR it should not kill any apps when Ulauncher is killed, but before it did.

I have tested and we specifically need both setsid and nohup  if Ulauncher is not running as a systemd service. Running systemd instead of this does not solve the problem because that process will still be killed.

`standard_output=True, standard_error=True` is needed to prevent nohup from creating `nohup.out` files