### PR TITLE
feat: add copy hook

### DIFF
--- a/preferences-src/src/components/pages/Preferences.vue
+++ b/preferences-src/src/components/pages/Preferences.vue
@@ -179,6 +179,19 @@
           <b-form-input style="width:500px" id="terminal-exec" v-model="terminal_command"></b-form-input>
         </td>
       </tr>
+      <tr>
+        <td>
+          <label for="copy-hook">Copy-hook</label>
+          <small>
+            <p>
+              A command to run after copying. Can be for example <code>xdotool key ctrl+v</code> on X11, which will trigger pasting, assuming your keyboard combination to paste is ctrl+v.
+            </p>
+          </small>
+        </td>
+        <td>
+          <b-form-input style="width:500px" id="copy-hook" v-model="copy_hook"></b-form-input>
+        </td>
+      </tr>
     </table>
   </div>
 </template>
@@ -221,6 +234,7 @@ export default {
       'render_on_screen',
       'show_tray_icon',
       'max_recent_apps',
+      'copy_hook',
       'terminal_command',
       'theme_name',
     ].map(name => ([name, {

--- a/ulauncher/ui/windows/UlauncherWindow.py
+++ b/ulauncher/ui/windows/UlauncherWindow.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import logging
+import subprocess
 from typing import Any
 
 from gi.repository import Gdk, Gtk
@@ -45,6 +46,11 @@ def handle_event(window: UlauncherWindow, event: bool | list | str | dict[str, A
         clipboard.set_text(data, -1)
         clipboard.store()
         window.hide_and_clear_input()
+        copy_hook = Settings.load().copy_hook
+        if copy_hook:
+            logger.info("Running copy hook: %s", copy_hook)
+            subprocess.Popen(["sh", "-c", copy_hook])
+
     elif event_type == "action:legacy_run_script" and isinstance(data, list):
         run_script(*data)
     elif event_type == "action:legacy_run_many" and isinstance(data, list):

--- a/ulauncher/utils/Settings.py
+++ b/ulauncher/utils/Settings.py
@@ -18,6 +18,7 @@ class Settings(JsonConf):
     terminal_command = ""
     theme_name = "light"
     arrow_key_aliases = "hjkl"
+    copy_hook = ""
     tray_icon_name = "ulauncher-indicator-symbolic"
 
     # Convert dash to underscore


### PR DESCRIPTION
Fixes #804

![image](https://github.com/Ulauncher/Ulauncher/assets/515120/89144fb2-1d72-4650-a4c2-1194d4646b1b)

Pasting cannot be supported cross desktop. There is no API for it. The best we can do it to trigger the desktop to think the user pressed the keyboard combination to paste. So the solution both depends on the users keyboard combination and being able to trigger it (xdotool only works for X11).