### PR TITLE
feat: add setting for window width

### DIFF
--- a/preferences-src/src/components/pages/Preferences.vue
+++ b/preferences-src/src/components/pages/Preferences.vue
@@ -116,6 +116,18 @@
 
       <tr>
         <td>
+          <label for="base-width">Window width</label>
+          <small>
+            <p>Window width (in pixels). Min: 540, Max: 2000</p>
+          </small>
+        </td>
+        <td>
+          <b-form-input style="width:380px" id="base-width" v-model.number="base_width" type="number" min="540" max="2000"></b-form-input>
+        </td>
+      </tr>
+
+      <tr>
+        <td>
           <label for="show-recent-apps">Number of frequent apps to show</label>
         </td>
         <td>
@@ -229,6 +241,7 @@ export default {
       'disable_desktop_filters',
       'grab_mouse_pointer',
       'jump_keys',
+      'base_width',
       'enable_application_mode',
       'raise_if_started',
       'render_on_screen',
@@ -242,6 +255,9 @@ export default {
         return this.prefs[name]
       },
       set(value) {
+        if (name === 'base_width' && (value < 540 || value > 2000)) {
+          return
+        }
         return fetchData('prefs:///set', name, value).then(
           () => {
             this.setPrefs({[name]: value})

--- a/ulauncher/ui/windows/UlauncherWindow.py
+++ b/ulauncher/ui/windows/UlauncherWindow.py
@@ -326,7 +326,7 @@ class UlauncherWindow(Gtk.ApplicationWindow, LayerShellOverlay):
         if monitor:
             geo = monitor.get_geometry()
             max_height = geo.height - (geo.height * 0.15) - 100  # 100 is roughly the height of the text input
-            window_width = 750
+            window_width = self.settings.base_width
             pos_x = int(geo.width * 0.5 - window_width * 0.5 + geo.x)
             pos_y = int(geo.y + geo.height * 0.12)
             self.set_property("width-request", window_width)

--- a/ulauncher/utils/Settings.py
+++ b/ulauncher/utils/Settings.py
@@ -12,6 +12,7 @@ class Settings(JsonConf):
     jump_keys = "1234567890abcdefghijklmnopqrstuvwxyz"
     enable_application_mode = True
     max_recent_apps = 0
+    base_width = 750
     raise_if_started = False
     render_on_screen = "mouse-pointer-monitor"
     show_tray_icon = True


### PR DESCRIPTION
Fixes #1277

Feels pretty rudimentary. I would prefer to be able to drag visually to resize, and if not, to check the window size to make sure we never try to render it bigger than the window. But we're limited due to Gtk4 and Wayland.

I managed to kill my Gnome session while trying what would happen if I set it to 9999, so I decided to restrict it to max 2000px. I think anyone with a huge screen would use display scaling of 2x or more. And if not they can let us know.

The better way seems to be to let the window manager handle this and set it up so it will remember, but we're at least a couple of major steps away from being able to do that (need to enable CSD and store settings with GSettings?): https://developer.gnome.org/documentation/tutorials/save-state.html