### PR TITLE
perf: avoid refreshing triggers for every keystroke

### DIFF
--- a/ulauncher/modes/ModeHandler.py
+++ b/ulauncher/modes/ModeHandler.py
@@ -23,6 +23,7 @@ from ulauncher.utils.Settings import Settings
 _logger = logging.getLogger()
 _events = EventBus("mode")
 _modes: list[BaseMode] = []
+_triggers: list[Result] = []
 
 
 def get_modes() -> list[BaseMode]:
@@ -65,13 +66,14 @@ def get_mode_from_query(query: Query) -> BaseMode | None:
     return None
 
 
-def search(query: Query, min_score: int = 50, limit: int = 50) -> list[Result]:
-    searchables: list[Result] = []
+def refresh_triggers() -> None:
     for mode in get_modes():
-        searchables.extend([*mode.get_triggers()])
+        _triggers.extend([*mode.get_triggers()])
 
+
+def search(query: Query, min_score: int = 50, limit: int = 50) -> list[Result]:
     # Cast apps to AppResult objects. Default apps to Gio.DesktopAppInfo.get_all()
-    sorted_ = sorted(searchables, key=lambda i: i.search_score(query), reverse=True)[:limit]
+    sorted_ = sorted(_triggers, key=lambda i: i.search_score(query), reverse=True)[:limit]
     return list(filter(lambda searchable: searchable.search_score(query) > min_score, sorted_))
 
 

--- a/ulauncher/ui/windows/UlauncherWindow.py
+++ b/ulauncher/ui/windows/UlauncherWindow.py
@@ -281,6 +281,7 @@ class UlauncherWindow(Gtk.ApplicationWindow):
                 self.move(pos_x, pos_y)
 
     def show(self) -> None:
+        ModeHandler.refresh_triggers()
         self.present()
         # note: present_with_time is needed on some DEs to defeat focus stealing protection
         # (Gnome 3 forks like Cinnamon or Budgie, but not Gnome 3 itself any longer)


### PR DESCRIPTION
Previously the triggers were updated for every keystroke. Now instead we refresh them when we open the window and then not again until the next time we open the window