### PR TITLE
feat: close window instead of hiding

### DIFF
--- a/ulauncher/modes/ModeHandler.py
+++ b/ulauncher/modes/ModeHandler.py
@@ -83,7 +83,7 @@ def clipboard_store(data: str) -> None:
     clipboard = Gtk.Clipboard.get(Gdk.SELECTION_CLIPBOARD)
     clipboard.set_text(data, -1)
     clipboard.store()
-    _events.emit("window:hide")
+    _events.emit("window:close")
     copy_hook = Settings.load().copy_hook
     if copy_hook:
         _logger.info("Running copy hook: %s", copy_hook)
@@ -98,7 +98,7 @@ def handle_action(event: bool | list[Any] | str | dict[str, Any] | None) -> None
     elif isinstance(event, str):
         _events.emit("app:set_query", event)
     elif event in (None, False) or (isinstance(event, dict) and not _handle_action(event)):
-        _events.emit("window:hide")
+        _events.emit("window:close")
 
 
 def _handle_action(event: dict[str, Any]) -> bool:

--- a/ulauncher/modes/extensions/ExtensionSocketServer.py
+++ b/ulauncher/modes/extensions/ExtensionSocketServer.py
@@ -124,7 +124,7 @@ class ExtensionSocketServer(metaclass=Singleton):
         if self.active_controller:
             self.active_controller.trigger_event(event)
             if not event.get("keep_app_open"):
-                events.emit("window:hide")
+                events.emit("window:close")
 
     @events.on
     def handle_response(self, response: dict[str, Any], controller: ExtensionSocketController) -> None:

--- a/ulauncher/ui/UlauncherApp.py
+++ b/ulauncher/ui/UlauncherApp.py
@@ -25,7 +25,6 @@ class UlauncherApp(Gtk.Application):
     # new instances sends the signals to the registered one
     # So all methods except __init__ runs on the main app
     _query = ""
-    window: UlauncherWindow | None = None
     _preferences: weakref.ReferenceType[PreferencesWindow] | None = None
     _appindicator: AppIndicator | None = None
 
@@ -45,9 +44,8 @@ class UlauncherApp(Gtk.Application):
     @events.on
     def set_query(self, value: str, update_input: bool = True) -> None:
         self._query = value.lstrip()
-        if update_input and self.window:
-            self.window.input.set_text(self._query)
-            self.window.input.set_position(-1)
+        if update_input:
+            events.emit("window:set_input", self._query)
 
     def do_startup(self) -> None:
         Gtk.Application.do_startup(self)
@@ -109,13 +107,11 @@ class UlauncherApp(Gtk.Application):
 
     @events.on
     def show_launcher(self) -> None:
-        if not self.window:
-            self.window = UlauncherWindow(application=self)
-        self.window.show()
+        UlauncherWindow(application=self)
 
     @events.on
     def show_preferences(self, page: str | None = None) -> None:
-        events.emit("window:hide", clear_input=False)
+        events.emit("window:close", save_query=True)
 
         preferences = self._preferences and self._preferences()
 


### PR DESCRIPTION
Closes #1151 

After refactoring elsewhere, making the Window class much more isolated (#1378) we can now easily do this.

Two advantages:
* Instead of reusing the previous window we re-draw the window when you open it now, each time. This way for example if you search for an app, close ulauncher, and uninstall it, it will not show up next time you re-open the launcher (this was always a bug imo, but no one complained about it).
* #1304 will now be possible and easy (although systemd integration might still cause problems for it)
* Should use less memory, but this seems insignificant when compared to #1063.