### PR TITLE
feat: add experimental option to use ulauncher daemonless

### DIFF
--- a/preferences-src/src/components/pages/Preferences.vue
+++ b/preferences-src/src/components/pages/Preferences.vue
@@ -167,6 +167,32 @@
 
       <tr>
         <td>
+          <label for="daemonless">Daemonless mode</label>
+          <small>
+            <p>Fully close Ulauncher when the window closes instead of keeping it active in the background.</p>
+          </small>
+        </td>
+        <td>
+          <b-form-checkbox id="daemonless" v-model="daemonless" :disabled="autostart_enabled"></b-form-checkbox>
+          <div v-if="autostart_enabled" class="compat-warning">
+            <b-alert show variant="warning">
+              <small>
+                You need to disable "Launch at login" if you want to enable this option as they are mutually exclusive.
+              </small>
+            </b-alert>
+          </div>
+          <div v-if="daemonless" class="compat-warning">
+            <b-alert show variant="warning">
+              <small>
+                Beware that enabling this feature makes Ulauncher launch slower, and extensions that rely on being able to perform scheduled/background tasks while idle (like `ulauncher-timer`) will not work.
+              </small>
+            </b-alert>
+          </div>
+        </td>
+      </tr>
+
+      <tr>
+        <td>
           <label for="jump-keys">Jump keys</label>
           <small>
             <p>Set the keys to use for quickly jumping to results</p>
@@ -234,6 +260,7 @@ export default {
       'render_on_screen',
       'show_tray_icon',
       'max_recent_apps',
+      'daemonless',
       'terminal_command',
       'theme_name',
     ].map(name => ([name, {

--- a/ulauncher/ui/UlauncherApp.py
+++ b/ulauncher/ui/UlauncherApp.py
@@ -6,6 +6,7 @@ from typing import Any, cast
 
 from gi.repository import Gdk, Gio, Gtk
 
+from ulauncher import config
 from ulauncher.api.shared.query import Query
 from ulauncher.config import APP_ID, FIRST_RUN
 from ulauncher.ui.AppIndicator import AppIndicator
@@ -75,10 +76,12 @@ class UlauncherApp(Gtk.Application):
 
     def setup(self) -> None:
         settings = Settings.load()
-        self.hold()  # Keep the app running even without a window
+        if not settings.daemonless or config.get_options().daemon:
+            # Keep the app running even without a window
+            self.hold()
 
-        if settings.show_tray_icon:
-            self.toggle_tray_icon(True)
+            if settings.show_tray_icon:
+                self.toggle_tray_icon(True)
 
         if FIRST_RUN or settings.hotkey_show_app:
             if HotkeyController.is_supported():

--- a/ulauncher/utils/Settings.py
+++ b/ulauncher/utils/Settings.py
@@ -24,6 +24,7 @@ class Settings(JsonConf):
     terminal_command = ""
     theme_name = "light"
     arrow_key_aliases = "hjkl"
+    daemonless = False
     tray_icon_name = "ulauncher-indicator-symbolic"
 
     # Convert dash to underscore


### PR DESCRIPTION
Fixes #1304 (have verified that it doesn't trigger the focus-stealing prevention)

Changes the Ulauncher behavior so that just running Ulauncher without first starting it as a daemon will run Ulauncher and close the app as soon as the window is closed. This means no resource usage when idle, but instead it will start slower (just short of a second on my system, but deferring extension startup made it launch much faster ~0.6s, and other minor performance improvements might help too, such as conditioning the `v5_to_v6` compat/migration script so it only runs the first launch after upgrading). This might not sound much, but it's huge difference to the near-instant experience when you run we're used to.

Using Ulauncher this way is not currently recommended unless you know the trade-offs, because of the extra time it takes to show the launcher, but also because some extensions assume you have them running in the background always (for example https://github.com/Ulauncher/ulauncher-timer and https://github.com/tchar/ulauncher-albert-calculate-anything)

However, as mentioned in #1063 we could support this with an API, and additionally the user might not use any extensions like this.