### PR TITLE
Revert "feat: add copy hook"

### DIFF
--- a/preferences-src/src/components/pages/Preferences.vue
+++ b/preferences-src/src/components/pages/Preferences.vue
@@ -191,19 +191,6 @@
           <b-form-input style="width:500px" id="terminal-exec" v-model="terminal_command"></b-form-input>
         </td>
       </tr>
-      <tr>
-        <td>
-          <label for="copy-hook">Copy-hook</label>
-          <small>
-            <p>
-              A command to run after copying. Can be for example <code>xdotool key ctrl+v</code> on X11, which will trigger pasting, assuming your keyboard combination to paste is ctrl+v.
-            </p>
-          </small>
-        </td>
-        <td>
-          <b-form-input style="width:500px" id="copy-hook" v-model="copy_hook"></b-form-input>
-        </td>
-      </tr>
     </table>
   </div>
 </template>
@@ -247,7 +234,6 @@ export default {
       'render_on_screen',
       'show_tray_icon',
       'max_recent_apps',
-      'copy_hook',
       'terminal_command',
       'theme_name',
     ].map(name => ([name, {

--- a/ulauncher/modes/ModeHandler.py
+++ b/ulauncher/modes/ModeHandler.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import logging
-import subprocess
 from typing import Any
 
 from gi.repository import Gdk, Gtk
@@ -17,7 +16,6 @@ from ulauncher.modes.shortcuts.run_script import run_script
 from ulauncher.modes.shortcuts.ShortcutMode import ShortcutMode
 from ulauncher.utils.eventbus import EventBus
 from ulauncher.utils.launch_detached import open_detached
-from ulauncher.utils.Settings import Settings
 
 _logger = logging.getLogger()
 _events = EventBus("mode")
@@ -82,10 +80,6 @@ def clipboard_store(data: str) -> None:
     clipboard.set_text(data, -1)
     clipboard.store()
     _events.emit("window:close")
-    copy_hook = Settings.load().copy_hook
-    if copy_hook:
-        _logger.info("Running copy hook: %s", copy_hook)
-        subprocess.Popen(["sh", "-c", copy_hook])
 
 
 @_events.on

--- a/ulauncher/utils/Settings.py
+++ b/ulauncher/utils/Settings.py
@@ -24,7 +24,6 @@ class Settings(JsonConf):
     terminal_command = ""
     theme_name = "light"
     arrow_key_aliases = "hjkl"
-    copy_hook = ""
     tray_icon_name = "ulauncher-indicator-symbolic"
 
     # Convert dash to underscore


### PR DESCRIPTION
This reverts commit 9aca04c5f044ab1365c712086c20c338726faee6 (#1371)

I would like to bring this back and support this feature, but having tested it myself a bit with the example command it just doesn't work very well. I realized part of this is that xdotool is slow, but another part is that Gtk needs to sync/store the data that was copied in the background before it can be pasted, and there is no way to force this or any event to listen to.

It's the same problem that causes setting the clipboard and exiting the Gtk mainloop too soon after to lost the clipboard content: https://discourse.gnome.org/t/setting-clipboard-contents-from-a-script/15072, except we can get around that by waiting to exit the app after copying. 0.02s seems "enough", but I prefer to wait much longer to be on the safe side, while I can't really do that for this feature because it's expected to be instant)