### PR TITLE
perf: lazy load slow modules that we don't need for showing the window

### DIFF
--- a/ulauncher/internals/result.py
+++ b/ulauncher/internals/result.py
@@ -4,7 +4,6 @@ from typing import Any
 
 from ulauncher.internals.query import Query
 from ulauncher.utils.basedataclass import BaseDataClass
-from ulauncher.utils.fuzzy_search import get_score
 
 DEFAULT_ACTION = True  #  keep window open and do nothing
 
@@ -58,4 +57,6 @@ class Result(BaseDataClass):
     def search_score(self, query: str) -> float:
         if not self.searchable:
             return 0
+        from ulauncher.utils.fuzzy_search import get_score
+
         return max(get_score(query, field) * weight for field, weight in self.get_searchable_fields() if field)

--- a/ulauncher/modes/file_browser/file_browser_mode.py
+++ b/ulauncher/modes/file_browser/file_browser_mode.py
@@ -5,7 +5,6 @@ from pathlib import Path
 
 from ulauncher.modes.base_mode import BaseMode
 from ulauncher.modes.file_browser.file_browser_result import FileBrowserResult
-from ulauncher.utils.fuzzy_search import get_score
 
 
 class FileBrowserMode(BaseMode):
@@ -56,6 +55,8 @@ class FileBrowserMode(BaseMode):
 
                 if not query.startswith("."):
                     file_names = self.filter_dot_files(file_names)
+
+                from ulauncher.utils.fuzzy_search import get_score
 
                 sorted_files = sorted(file_names, key=lambda fn: get_score(query, fn), reverse=True)
                 filtered = list(filter(lambda fn: get_score(query, fn) > self.THRESHOLD, sorted_files))[: self.LIMIT]

--- a/ulauncher/ui/ulauncher_app.py
+++ b/ulauncher/ui/ulauncher_app.py
@@ -6,14 +6,12 @@ from typing import Any, cast
 
 from gi.repository import Gio, Gtk
 
+import ulauncher
 from ulauncher import config
 from ulauncher.config import APP_ID, FIRST_RUN
 from ulauncher.internals.query import Query
-from ulauncher.ui.tray_icon import TrayIcon
-from ulauncher.ui.windows.preferences_window import PreferencesWindow
 from ulauncher.ui.windows.ulauncher_window import UlauncherWindow
 from ulauncher.utils.eventbus import EventBus
-from ulauncher.utils.hotkey_controller import HotkeyController
 from ulauncher.utils.settings import Settings
 from ulauncher.utils.singleton import get_instance
 
@@ -27,8 +25,8 @@ class UlauncherApp(Gtk.Application):
     # So all methods except __init__ runs on the main app
     _query = ""
     _window: weakref.ReferenceType[UlauncherWindow] | None = None
-    _preferences: weakref.ReferenceType[PreferencesWindow] | None = None
-    _tray_icon: TrayIcon | None = None
+    _preferences: weakref.ReferenceType[ulauncher.ui.windows.preferences_window.PreferencesWindow] | None = None
+    _tray_icon: ulauncher.ui.tray_icon.TrayIcon | None = None
 
     def __call__(self, *args: Any, **kwargs: Any) -> UlauncherApp:
         return cast(UlauncherApp, get_instance(super(), self, *args, **kwargs))
@@ -83,6 +81,8 @@ class UlauncherApp(Gtk.Application):
                 self.toggle_tray_icon(True)
 
         if FIRST_RUN or settings.hotkey_show_app:
+            from ulauncher.utils.hotkey_controller import HotkeyController
+
             if HotkeyController.is_supported():
                 hotkey = "<Primary>space"
                 if settings.hotkey_show_app and not HotkeyController.is_plasma():
@@ -128,6 +128,8 @@ class UlauncherApp(Gtk.Application):
         if preferences:
             preferences.present(page)
         else:
+            from ulauncher.ui.windows.preferences_window import PreferencesWindow
+
             preferences = PreferencesWindow(application=self)
             self._preferences = weakref.ref(preferences)
             preferences.show(page)
@@ -139,6 +141,8 @@ class UlauncherApp(Gtk.Application):
     @events.on
     def toggle_tray_icon(self, enable: bool) -> None:
         if not self._tray_icon:
+            from ulauncher.ui.tray_icon import TrayIcon
+
             self._tray_icon = TrayIcon()
         self._tray_icon.switch(enable)
 

--- a/ulauncher/utils/wm.py
+++ b/ulauncher/utils/wm.py
@@ -7,15 +7,6 @@ from gi.repository import Gdk, GdkX11, Gio  # type: ignore[attr-defined]
 from ulauncher.utils.environment import IS_X11
 
 logger = logging.getLogger()
-if IS_X11:
-    try:
-        # Import will fail if Xlib is not installed
-        from Xlib.display import Display as XlibDisplay
-
-        from ulauncher.utils.ewmh import EWMH
-
-    except ModuleNotFoundError:
-        XlibDisplay = None
 
 
 def get_monitor(use_mouse_position: bool = False) -> Gdk.Monitor | None:
@@ -46,18 +37,25 @@ def try_raise_app(app_id: str) -> bool:
     Try to raise an app by id (str) and return whether successful
     Currently only supports X11 via EWMH/Xlib
     """
-    if IS_X11 and XlibDisplay:
-        ewmh = EWMH()
-        for win in reversed(ewmh.getClientListStacking()):
-            class_id, class_name = win.get_wm_class()
-            win_app_id = (class_id or "").lower()
-            if win_app_id == "thunar" and win.get_wm_name().startswith("Bulk Rename"):
-                # "Bulk Rename" identify as "Thunar": https://gitlab.xfce.org/xfce/thunar/-/issues/731
-                # Also, note that get_wm_name is unreliable, but it works for Thunar https://github.com/parkouss/pyewmh/issues/15
-                win_app_id = "thunar --bulk-rename"
-            if app_id == win_app_id or app_id == class_name.lower():
-                logger.info("Raising application %s", app_id)
-                ewmh.setActiveWindow(win)
-                ewmh.display.flush()
-                return True
+    if IS_X11:
+        try:
+            from ulauncher.utils.ewmh import EWMH
+
+            ewmh = EWMH()
+            for win in reversed(ewmh.getClientListStacking()):
+                class_id, class_name = win.get_wm_class()
+                win_app_id = (class_id or "").lower()
+                if win_app_id == "thunar" and win.get_wm_name().startswith("Bulk Rename"):
+                    # "Bulk Rename" identify as "Thunar": https://gitlab.xfce.org/xfce/thunar/-/issues/731
+                    # Also, note that get_wm_name is unreliable, but it works for Thunar https://github.com/parkouss/pyewmh/issues/15
+                    win_app_id = "thunar --bulk-rename"
+                if app_id == win_app_id or app_id == class_name.lower():
+                    logger.info("Raising application %s", app_id)
+                    ewmh.setActiveWindow(win)
+                    ewmh.display.flush()
+                    return True
+
+        except ModuleNotFoundError:
+            pass
+
     return False


### PR DESCRIPTION
Defers loading the slow modules for EWMH, fuzzy_search, ItemNavigation, ResultWidget, AppResult and PreferencesWindow until we need them.  Additionally deferred hotkey_controller and tray_icon although they were not that slow.

Remaining culprits:
* load_icon_surface is oddly slow ~35-40ms
* JsonConf takes a few ms (around ~7ms). Maybe most of that is due to BaseDataClass
* I didn't test, but I know that loading the Gtk app with dbus etc is time we could shave off by just showing the window.
* Python itself (maybe using cython could help, but then [there is a risk to introduce memory bugs](https://pythonspeed.com/articles/cython-limitations/)?)