### PR TITLE
Update build-rpm.sh to include ulauncher.service

### DIFF
--- a/scripts/build-rpm.sh
+++ b/scripts/build-rpm.sh
@@ -49,6 +49,7 @@ build-rpm () {
         setup.py \
         ulauncher \
         ulauncher.desktop.in \
+        ulauncher.service \
         $tmpdir \
         --exclude-from=.gitignore
 


### PR DESCRIPTION
# Bugfix for rpm-build.sh

## Issue

In Ulauncher v5 the rpm build process currently returns an error.
`error: can't copy 'ulauncher.service': doesn't exist or not a regular file`
This was already mentioned in issue #1156 for Fedora 36.
Since I encountered the same issue when running `./ul build-rpm 5.15.7 alma9.4`, I investigated.

## Cause

This is due to the build script at `scripts/build-rpm.sh` missing the line for ulauncher.service in its rsync command.

## Testing
I only tested this for Almalinux 9.4 but it should make no difference when it comes to Fedora.


