### PR TITLE
refactor: rewrite device pointer grabbing to avoid using deprecated apis

### DIFF
--- a/ulauncher/ui/windows/ulauncher_window.py
+++ b/ulauncher/ui/windows/ulauncher_window.py
@@ -313,17 +313,16 @@ class UlauncherWindow(Gtk.ApplicationWindow):
 
     def toggle_grab_pointer_device(self, grab: bool) -> None:
         window = self.get_window()
-        device_manager = window and window.get_display().get_device_manager()
-        pointer_device = device_manager and device_manager.get_client_pointer()
-        if not (window and device_manager and pointer_device):
+        seat = window and window.get_display().get_default_seat()
+        if not window or not seat:
             logger.warning("Could not get the pointer device.")
             return
 
         if not grab:
-            pointer_device.ungrab(0)
+            seat.ungrab()
             return
 
-        grab_status = pointer_device.grab(window, Gdk.GrabOwnership.NONE, True, Gdk.EventMask.ALL_EVENTS_MASK, None, 0)
+        grab_status = seat.grab(window, Gdk.SeatCapabilities.ALL_POINTING, True)
         logger.debug("Focus in event, grabbing pointer: %s", grab_status)
 
     @events.on


### PR DESCRIPTION
Most of the old APIs we use here are deprecated since Gtk 3.20, and if I enable deprecation warnings (which I think is a good idea for dev mode) I get  a lot of these:

![image](https://github.com/user-attachments/assets/46661eae-0713-422d-8e3a-c8c0b1868168)


The GTK docs recommend using [`Seat.grab()`](https://docs.gtk.org/gdk3/method.Seat.grab.html) instead, which skips one step. However `Seat.grab()` takes different params compared to [`Device.grab()`](https://docs.gtk.org/gdk3/method.Device.grab.html). The first and third params (window and True) are exactly the same, but not the rest.

So I would appreciate help to confirm this works since I don't use or know how to use "Sloppy focus mode".