### PR TITLE
Feature/nix runs on ubuntu container

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -24,10 +24,13 @@ jobs:
         run: make pytest
       - name: build preferences
         run: make prefs FORCE=1
+      - name: build docs
+        run: make docs
+  nix-build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
       - uses: cachix/install-nix-action@v30
       - name: make nix-build
         run: make nix-build
         timeout-minutes: 5
-      - name: build docs
-        run: make docs
-

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     container: ulauncher/build-image:6.0
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: black
         run: make black
       - name: ruff
@@ -29,7 +29,7 @@ jobs:
   nix-build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: cachix/install-nix-action@v30
       - name: make nix-build
         run: make nix-build


### PR DESCRIPTION
Changes:
- Making the nix build run in its own empty ubuntu container since running in the `ulauncher/build-image:6.0` one returns errors
- Bump actions checkout to v4

The build was failing with the following error in the nix build:
`error: opening Git repository '"/__w/Ulauncher/Ulauncher"': repository path '/__w/Ulauncher/Ulauncher' is not owned by current user`
after investigating this issue I discover that looks like newer versions of the nix runner have conflict with the users in the ulauncher docker image. Since by design nix doesnt need a pre-conf docker image to run a build, i think the best practice here will be to split those two steps and make the nix build run in an agnostic container with no configurations/libs pre-installed and keep the ulauncher image for the rest of steps