### PR TITLE
feature: #273 automatically install extensions

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -3,7 +3,7 @@ root = true
 [*]
 charset = utf-8
 indent_style = space
-indent_size = 4
+indent_size = 2
 end_of_line = lf
 insert_final_newline = true
 trim_trailing_whitespace = true

--- a/.editorconfig
+++ b/.editorconfig
@@ -3,7 +3,7 @@ root = true
 [*]
 charset = utf-8
 indent_style = space
-indent_size = 2
+indent_size = 4
 end_of_line = lf
 insert_final_newline = true
 trim_trailing_whitespace = true

--- a/docs/extensions/tutorial.rst
+++ b/docs/extensions/tutorial.rst
@@ -218,7 +218,7 @@ ExtensionCustomAction
 
 ActionList
   List of actions
-  
+
 
 Custom Action on Item Enter
 ---------------------------
@@ -265,6 +265,21 @@ Custom Action on Item Enter
   Now this will be rendered when you click on any item
 
 
+Dependencies and requirements.txt file
+--------------------------------------
+
+If your extension requires any python dependencies, you can specify them in a ``requirements.txt`` file.
+Ulauncher will install them automatically when the extension is installed.
+
+Avoid specifying development dependencies such as mypy, pytest, etc. in the ``requirements.txt`` file — users don't need them.
+Instead, you can create a separate ``requirements-dev.txt`` file for your development dependencies.
+
+It's a good idea to specify the version of the dependencies you are using to avoid breaking changes in the future.
+For example, if your extension requires the `requests` library, you can create a `requirements.txt` file with the following content::
+
+  requests==2.32.3
+
+Refer to this `requirements.txt documentation <https://pip.pypa.io/en/stable/reference/requirements-file-format/>`_ for more information.
 
 .. NOTE::
   Please take `a short survey <https://goo.gl/forms/wcIRCTjQXnO0M8Lw2>`_ to help us build greater API and documentation

--- a/makefile
+++ b/makefile
@@ -138,7 +138,7 @@ format: # Auto format the code
 
 .PHONY: prefs docker docs sdist manpage deb nix-run nix-build-dev nix-build
 
-docs: ## Build the API docs
+docs: # Build the API docs
 	@set -euo pipefail
 	cd docs
 	sphinx-build -M html . ./_build

--- a/nix/default.nix
+++ b/nix/default.nix
@@ -119,7 +119,7 @@ let
 
       substituteInPlace \
           ulauncher/modes/extensions/extension_controller.py \
-        --replace-fail '"PYTHONPATH": paths.APPLICATION,' '"PYTHONPATH": ":".join(sys.path),'
+        --replace-fail 'paths.APPLICATION,' '":".join(sys.path),'
 
       substituteInPlace \
           ulauncher.service \

--- a/preferences-src/src/components/widgets/ExtensionInstallError.vue
+++ b/preferences-src/src/components/widgets/ExtensionInstallError.vue
@@ -26,11 +26,18 @@
         >
           A network error occurred: <b>{{ errorMessage }}</b>
           <br><br>Please check that your network is ok, that the repository is not private, and that the extension has all the required files.
-          <br><br>You can also install extensions manually by adding them to 
+          <br><br>You can also install extensions manually by adding them to
           <a
             href
             @click.prevent="openExtensionsDir()"
           >your extension directory</a>.
+        </p>
+        <p v-else-if="errorType === 'ExtensionDependenciesRecoverableError'">
+          Failed to install extension dependencies:
+          <br />
+          <code style="white-space: pre-line;">{{ errorMessage }}</code>
+          <br /><br />If nothing seems clearly wrong on your end, consider
+          <a href @click.prevent="openUrlInBrowser(`${extUrl}/issues`)">contacting</a> the extension author and let them know about this problem.
         </p>
         <p v-else>
           An unexpected error occurred.

--- a/tests/modes/apps/extensions/test_extension_dependencies.py
+++ b/tests/modes/apps/extensions/test_extension_dependencies.py
@@ -1,0 +1,46 @@
+import sys
+from unittest.mock import MagicMock, mock_open, patch
+
+import pytest
+
+from ulauncher.modes.extensions.extension_dependencies import ExtensionDependencies
+
+
+@pytest.fixture
+def extension_dependencies() -> ExtensionDependencies:
+    return ExtensionDependencies(ext_id="extension-X", path="/fake/path")
+
+
+@patch("ulauncher.modes.extensions.extension_dependencies.isfile", return_value=True)
+@patch("ulauncher.modes.extensions.extension_dependencies.isdir", return_value=True)
+def test_get_dependencies_path(
+    mock_isdir: MagicMock, mock_isfile: MagicMock, extension_dependencies: ExtensionDependencies  # noqa: ARG001
+) -> None:
+    deps_path = extension_dependencies.get_dependencies_path()
+    assert deps_path == "/fake/path/.dependencies"
+
+
+@patch("ulauncher.modes.extensions.extension_dependencies.isfile", return_value=True)
+@patch("builtins.open", new_callable=mock_open, read_data="some-package==1.0\n")
+@patch("subprocess.run")
+def test_install(
+    mock_subprocess: MagicMock,
+    mock_open_fn: MagicMock,  # noqa: ARG001
+    mock_isfile: MagicMock,  # noqa: ARG001
+    extension_dependencies: ExtensionDependencies,
+) -> None:
+    mock_subprocess.return_value = MagicMock(stdout="Installation successful", returncode=0)
+
+    extension_dependencies.install()
+
+    expected_command = [
+        sys.executable,
+        "-m",
+        "pip",
+        "install",
+        "-r",
+        "/fake/path/requirements.txt",
+        "--target",
+        "/fake/path/.dependencies",
+    ]
+    mock_subprocess.assert_called_once_with(expected_command, check=True, capture_output=True, text=True)

--- a/ulauncher/modes/extensions/extension_dependencies.py
+++ b/ulauncher/modes/extensions/extension_dependencies.py
@@ -1,0 +1,74 @@
+from __future__ import annotations
+
+import logging
+import subprocess
+import sys
+from os.path import isdir, isfile
+
+logger = logging.getLogger()
+
+
+class ExtensionDependencies:
+    """
+    Manages python dependencies of the extension.
+    """
+
+    ext_id: str
+    path: str
+
+    deps_out_subdir: str = ".dependencies"
+
+    def __init__(self, ext_id: str, path: str):
+        self.ext_id = ext_id
+        self.path = path
+
+    def get_dependencies_path(self) -> str | None:
+        """
+        Get the path to the dependencies directory.
+        Returns None if there's no dependencies for the extension.
+        """
+        requirements_file = f"{self.path}/requirements.txt"
+        deps_path = f"{self.path}/{self.deps_out_subdir}"
+        if not isfile(requirements_file) or not isdir(deps_path):
+            return None
+
+        return deps_path
+
+    def install(self) -> None:
+        """
+        Install the dependencies for the extension.
+        Runs `pip install -r extension-X/requirements.txt --target extension-X/deps`
+        """
+        requirements = self._read_requirements()
+
+        if not requirements:
+            return
+
+        command = [
+            sys.executable,
+            "-m",
+            "pip",
+            "install",
+            "-r",
+            f"{self.path}/requirements.txt",
+            "--target",
+            f"{self.path}/{self.deps_out_subdir}",
+        ]
+        logger.info("Installing dependencies for %s. Running: %s", self.ext_id, " ".join(command))
+
+        try:
+            result = subprocess.run(command, check=True, capture_output=True, text=True)
+            logger.info("Installation successful. Output: %s", result.stdout)
+        except subprocess.CalledProcessError as e:
+            logger.exception("Error during installation. Output: %s", e.stderr)
+
+    def _read_requirements(self) -> str | None:
+        """
+        Read the requirements file and return its content.
+        """
+        requirements_file = f"{self.path}/requirements.txt"
+        if not isfile(requirements_file):
+            return None
+
+        with open(requirements_file) as f:
+            return f.read().strip()

--- a/ulauncher/modes/extensions/extension_remote.py
+++ b/ulauncher/modes/extensions/extension_remote.py
@@ -66,6 +66,7 @@ class ExtensionRemote:
             self.url = f"{self.protocol}://{self.host}/{self.path}"
 
         except Exception as e:
+            logger.warning("Invalid URL: %s (%s: %s)", url, type(e).__name__, e)
             msg = f"Invalid URL: {url}"
             raise InvalidExtensionRecoverableError(msg) from e
 
@@ -86,6 +87,7 @@ class ExtensionRemote:
 
     def _get_refs(self) -> dict[str, str]:
         refs = {}
+        ref = None
         url = f"{self.url}.git" if self.host in ("github.com", "gitlab.com", "codeberg.org") else self.url
         try:
             if self._use_git:

--- a/ulauncher/ui/preferences_server.py
+++ b/ulauncher/ui/preferences_server.py
@@ -253,7 +253,7 @@ class PreferencesServer:
     async def extension_add(self, url: str) -> dict[str, Any]:
         logger.info("Add extension: %s", url)
         controller = ExtensionController.create_from_url(url)
-        await controller.download()
+        await controller.install()
         await controller.stop()
         await controller.start()
         return get_extension_data(controller)


### PR DESCRIPTION
#273 
Implements automatic dependency installation for extensions.

Uses `pip install ... --target /path` to download dependencies. Then, it passes the deps dir in `PYTHONPATH` when running extensions.