### PR TITLE
chore: ignore system packages that satisfy the required dev dependencies

### DIFF
--- a/makefile
+++ b/makefile
@@ -47,7 +47,7 @@ python-venv: # Creates a python virtual environment and installs dependencies
 	@echo -e "$(GREEN)[+] Setting up Python virtual environment...$(RESET)"
 	python3 -m venv --system-site-packages .venv
 	@echo -e "$(GREEN)[+] Installing dependencies from requirements.txt...$(RESET)"
-	.venv/bin/python -m pip install -r requirements.txt
+	.venv/bin/python -m pip install --ignore-installed -r requirements.txt
 	@echo -e "$(GREEN)[+] Installing pygobject-stubs with Gtk3 compatibility...$(RESET)"
 
 	# Update to the latest (v2.13.0) after migration to python>=9 in Dockerfile


### PR DESCRIPTION
If you have these packages installed on your system pip tries to use those versions.
This has the potential to break our scripts since a global mypy for example won't
work with the pgobject stubs installed for the .venv

This does make it a few seconds slower to re-run "make python-venv" on my system (6-7 seconds in total instead of 3-4 seconds, so no big deal imo).