### PR TITLE
chore: update venv deps when installing

### DIFF
--- a/makefile
+++ b/makefile
@@ -47,7 +47,7 @@ python-venv: # Creates a python virtual environment and installs dependencies
 	@echo -e "$(GREEN)[+] Setting up Python virtual environment...$(RESET)"
 	python3 -m venv --system-site-packages .venv
 	@echo -e "$(GREEN)[+] Installing dependencies from requirements.txt...$(RESET)"
-	.venv/bin/python -m pip install --ignore-installed -r requirements.txt
+	.venv/bin/python -m pip install --ignore-installed --upgrade -r requirements.txt
 	@echo -e "$(GREEN)[+] Installing pygobject-stubs with Gtk3 compatibility...$(RESET)"
 
 	# Update to the latest (v2.13.0) after migration to python>=9 in Dockerfile


### PR DESCRIPTION
Since we don't specify versions in our requirements.txt file, I think we need this flag. Otherwise you would get stuck on the latest version as of the initial `make python-venv` run.

Maybe this is not actually needed with the `--ignore-installed` flag, but even if that's true I think it's better to add this explicitly in case we would remove that.