### PR TITLE
Update webkitgtk parameter to webkitgtk_4_1 for compatibility with latest nixpkgs

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -5,11 +5,11 @@
         "nixpkgs-lib": "nixpkgs-lib"
       },
       "locked": {
-        "lastModified": 1738453229,
-        "narHash": "sha256-7H9XgNiGLKN1G1CgRh0vUL4AheZSYzPm+zmZ7vxbJdo=",
+        "lastModified": 1749398372,
+        "narHash": "sha256-tYBdgS56eXYaWVW3fsnPQ/nFlgWi/Z2Ymhyu21zVM98=",
         "owner": "hercules-ci",
         "repo": "flake-parts",
-        "rev": "32ea77a06711b758da0ad9bd6a844c5740a87abd",
+        "rev": "9305fe4e5c2a6fcf5ba6a3ff155720fbe4076569",
         "type": "github"
       },
       "original": {
@@ -19,11 +19,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1738680400,
-        "narHash": "sha256-ooLh+XW8jfa+91F1nhf9OF7qhuA/y1ChLx6lXDNeY5U=",
+        "lastModified": 1750134718,
+        "narHash": "sha256-v263g4GbxXv87hMXMCpjkIxd/viIF7p3JpJrwgKdNiI=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "799ba5bffed04ced7067a91798353d360788b30d",
+        "rev": "9e83b64f727c88a7711a2c463a7b16eedb69a84c",
         "type": "github"
       },
       "original": {
@@ -35,14 +35,17 @@
     },
     "nixpkgs-lib": {
       "locked": {
-        "lastModified": 1738452942,
-        "narHash": "sha256-vJzFZGaCpnmo7I6i416HaBLpC+hvcURh/BQwROcGIp8=",
-        "type": "tarball",
-        "url": "https://github.com/NixOS/nixpkgs/archive/072a6db25e947df2f31aab9eccd0ab75d5b2da11.tar.gz"
+        "lastModified": 1748740939,
+        "narHash": "sha256-rQaysilft1aVMwF14xIdGS3sj1yHlI6oKQNBRTF40cc=",
+        "owner": "nix-community",
+        "repo": "nixpkgs.lib",
+        "rev": "656a64127e9d791a334452c6b6606d17539476e2",
+        "type": "github"
       },
       "original": {
-        "type": "tarball",
-        "url": "https://github.com/NixOS/nixpkgs/archive/072a6db25e947df2f31aab9eccd0ab75d5b2da11.tar.gz"
+        "owner": "nix-community",
+        "repo": "nixpkgs.lib",
+        "type": "github"
       }
     },
     "root": {

--- a/nix/default.nix
+++ b/nix/default.nix
@@ -25,7 +25,7 @@
 , stdenv
 , systemd
 , typos
-, webkitgtk_6_0
+, webkitgtk_4_1
 , wrapGAppsHook
 , xdg-utils
 , xvfb-run
@@ -88,7 +88,7 @@ let
       gtk3
       libappindicator
       librsvg
-      webkitgtk_6_0
+      webkitgtk_4_1
     ];
 
     # runtime dependencies / binaries prepended to PATH


### PR DESCRIPTION
This PR updates the `webkitgtk` parameter to `webkitgtk_4_1` to align with the changes made to nixpkgs. The previous attribute name `webkitgtk` has been removed from nixpkgs, and using it would result in a build error: "error: 'webkitgtk' attribute has been removed from nixpkgs, use attribute with ABI version set explicitly".

This change fixes the build issue and ensures that the Ulauncher flake can be successfully built with the current version of nixpkgs.

**Changes**:

- Updated `webkitgtk` parameter to `webkitgtk_4_1` in `nix/default.nix`

**Testing**: The build should now succeed with the latest version of nixpkgs. You can verify this by running nix build or nix flake build after applying this PR.