### PR TITLE
chore: migrate from black to ruff format

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -12,8 +12,6 @@ jobs:
     container: ulauncher/build-image:6.2
     steps:
       - uses: actions/checkout@v4
-      - name: black
-        run: make black
       - name: ruff
         run: make ruff
       - name: typo

--- a/lefthook.toml
+++ b/lefthook.toml
@@ -4,20 +4,21 @@
 skip_lfs = true
 
 [pre-commit]
+# make sure to only run one job with stage_fixed, or disable parallel
+# otherwise one job might might overwrite the changes of another job
+# and jobs can fail because a previous job created the git lockfile,
 parallel = true
 
 [pre-commit.commands.typos]
 glob = "*"
 run = "typos --force-exclude {staged_files}"
 
-[pre-commit.commands.black]
-glob = "*.py"
-run = "black {staged_files}"
-stage_fixed = true
-
 [pre-commit.commands.ruff]
 glob = "*.py"
-run = "ruff check --fix {staged_files}"
+run = """
+  ruff check --fix {staged_files}
+  ruff format {staged_files}
+  """
 stage_fixed = true
 
 [pre-commit.commands.mypy]

--- a/makefile
+++ b/makefile
@@ -103,20 +103,18 @@ run-container: # Start a bash session in the Ulauncher Docker build container (U
 
 #=Lint/test Commands
 
-.PHONY: check black mypy ruff typos pytest test format
+.PHONY: check mypy ruff typos pytest test format
 
-check: black mypy ruff typos # Run all linters
+check: typos ruff mypy # Run all linters
 
 test: check pytest # Run all linters and test
-
-black: # Lint with black (formatting checker)
-	black --diff --check .
 
 mypy: # Lint with mypy (type checker)
 	mypy ulauncher
 
 ruff: # Lint with ruff
 	ruff check .
+	ruff format --check .
 
 typos: # Lint with typos (typo checker)
 	typos .
@@ -131,8 +129,8 @@ pytest: # Run unit tests
 	fi
 
 format: # Auto format the code
-	black .
 	ruff check . --fix
+	ruff format .
 
 #=Build Commands
 

--- a/nix/default.nix
+++ b/nix/default.nix
@@ -55,7 +55,6 @@ let
 
   packages.preferences.dev = [ yarn ];
   packages.tests.python = pp: (with pp; [
-    black
     mock
     (pygobject-stubs.overridePythonAttrs (old: { PYGOBJECT_STUB_CONFIG = "Gtk3,Gdk3,Soup2"; }))
     pytest

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,9 +24,6 @@ dynamic = ["version"]
 [tool.setuptools.dynamic]
 version = {attr = "ulauncher.version"}
 
-[tool.black]
-line-length = 120
-
 [tool.mypy]
 python_version = "3.8"
 strict = true
@@ -76,7 +73,7 @@ select = [
   "B",        # flake8-bugbear
   "BLE",      # flake8-blind-except
   "C4",       # flake8-comprehensions
-  # "COM",    # flake8-commas (we use black for formatting, so this would conflict)
+  # "COM",    # flake8-commas (we use ruff format instead)
   # "CPY",    # flake8-copyright (enforces copyright headers in python files)
   # "DTZ",    # flake8-datetimez (too focused on enforcing time zone argument, which we don't need)
   # "D",      # pydocstyle (validates, formats and enforces docstrings)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,3 @@
-black
 build
 lefthook
 mypy

--- a/tests/modes/apps/extensions/test_extension_dependencies.py
+++ b/tests/modes/apps/extensions/test_extension_dependencies.py
@@ -14,7 +14,9 @@ def extension_dependencies() -> ExtensionDependencies:
 @patch("ulauncher.modes.extensions.extension_dependencies.isfile", return_value=True)
 @patch("ulauncher.modes.extensions.extension_dependencies.isdir", return_value=True)
 def test_get_dependencies_path(
-    mock_isdir: MagicMock, mock_isfile: MagicMock, extension_dependencies: ExtensionDependencies  # noqa: ARG001
+    mock_isdir: MagicMock,  # noqa: ARG001
+    mock_isfile: MagicMock,  # noqa: ARG001
+    extension_dependencies: ExtensionDependencies,
 ) -> None:
     deps_path = extension_dependencies.get_dependencies_path()
     assert deps_path == "/fake/path/.dependencies"

--- a/ulauncher/modes/extensions/extension_manifest.py
+++ b/ulauncher/modes/extensions/extension_manifest.py
@@ -118,9 +118,9 @@ class ExtensionManifest(JsonConf):
                 default = p.default_value
                 assert p.name, f'"{id}" missing non-optional field "name"'
                 assert p.type, f'"{id}" missing non-optional field "type"'
-                assert (
-                    p.type in valid_types
-                ), f'"{id}" invalid type "{p.type}" (should be either "{", ".join(valid_types)}")'
+                assert p.type in valid_types, (
+                    f'"{id}" invalid type "{p.type}" (should be either "{", ".join(valid_types)}")'
+                )
                 assert p.min is None or p.type == "number", f'"min" specified for "{id}", which is not a number type'
                 assert p.max is None or p.type == "number", f'"max" specified for "{id}", which is not a number type'
                 if p.type == "checkbox" and default:
@@ -128,21 +128,21 @@ class ExtensionManifest(JsonConf):
                 if p.type == "number":
                     assert isinstance(default, int), f'"{id}" default_value must be a non-decimal number'
                     assert not isinstance(default, bool), f'"{id}" default_value must be a non-decimal number'
-                    assert not p.min or isinstance(
-                        p.min, int
-                    ), f'"{id}" "min" value must be non-decimal number if specified'
-                    assert not p.max or isinstance(
-                        p.min, int
-                    ), f'"{id}" "max" value must be non-decimal number if specified'
-                    assert (
-                        not p.min or not p.max or p.min < p.max
-                    ), f'"{id}" "min" value must be lower than "max" if specified'
-                    assert (
-                        not default or not p.max or default <= p.max
-                    ), f'"{id}" "default_value" must not be higher than "max"'
-                    assert (
-                        not default or not p.min or default >= p.min
-                    ), f'"{id}" "min" value must not be higher than "default_value"'
+                    assert not p.min or isinstance(p.min, int), (
+                        f'"{id}" "min" value must be non-decimal number if specified'
+                    )
+                    assert not p.max or isinstance(p.min, int), (
+                        f'"{id}" "max" value must be non-decimal number if specified'
+                    )
+                    assert not p.min or not p.max or p.min < p.max, (
+                        f'"{id}" "min" value must be lower than "max" if specified'
+                    )
+                    assert not default or not p.max or default <= p.max, (
+                        f'"{id}" "default_value" must not be higher than "max"'
+                    )
+                    assert not default or not p.min or default >= p.min, (
+                        f'"{id}" "min" value must not be higher than "default_value"'
+                    )
                 if p.type == "select":
                     assert isinstance(p.options, list), f'"{id}" options field must be a list'
                     assert p.options, f'"{id}" option cannot be empty for select type'

--- a/ulauncher/utils/singleton.py
+++ b/ulauncher/utils/singleton.py
@@ -11,6 +11,5 @@ def get_instance(supercls: Any, cls: Any, *args: Any, **kwargs: Any) -> Any:
 
 # Use with metaclass=Singleton (not possible when inheriting from Gtk classes for example)
 class Singleton(type):
-
     def __call__(cls, *args: Any, **kwargs: Any) -> Any:
         return get_instance(super(), cls, *args, **kwargs)


### PR DESCRIPTION
https://docs.astral.sh/ruff/formatter/

* Ruff improves upon the already well defined black formatting style, but in most cases they work exactly the same (only three files were changed - see the diff).
* Ruff is much faster (10-20x). But black was already extremely fast, so this is more to get rid of the extra dev dependency.

