### PR TITLE
chore(nix): remove unused dep requests

### DIFF
--- a/nix/default.nix
+++ b/nix/default.nix
@@ -96,7 +96,6 @@ let
       mock
       pycairo
       pygobject3
-      requests
     ] ++ lib.optionals withXorg [
       xlib
     ] ++ [


### PR DESCRIPTION
This was never used by us. Wanted to test the ci without it.
