### PR TITLE
chore: use project.licen spdx expression

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ name = "ulauncher"
 description = "Application launcher for Linux"
 readme = "README.md"
 requires-python = ">=3.8"
-license = {text = "GPL-3"}
+license = {text = "GPL-3.0-only"}
 authors = [
   {name = "Aleksandr Gornostal"},
   {name = "Albin Larsson"},


### PR DESCRIPTION
We now get two deprecation warnings when building. The first one is this:

![Screenshot From 2025-06-29 10-31-20](https://github.com/user-attachments/assets/578d7f8a-fb3a-48f2-8fc7-caf152a08221)

https://packaging.python.org/en/latest/guides/writing-pyproject-toml/#license

GPL-3 corresponds to c or  "GPL-3.0-only". I think the latter is what our licence file in fact says, and I'm not sure what the legal aspect of switching to GPL-3.0-or-later would be.