### PR TITLE
#1324: override installed extension when installing local clone

### DIFF
--- a/ulauncher/ui/preferences_server.py
+++ b/ulauncher/ui/preferences_server.py
@@ -252,7 +252,7 @@ class PreferencesServer:
     @route("/extension/add")
     async def extension_add(self, url: str) -> dict[str, Any]:
         logger.info("Add extension: %s", url)
-        controller = ExtensionController.create_from_url(url)
+        controller = await ExtensionController.create_from_url(url)
         await controller.install()
         await controller.stop()
         await controller.start()


### PR DESCRIPTION
I implemented the option with `git remote get-url origin` as you suggested in #1324.

As for the ID in the manifest file, I think at some point we should add it. Maybe in API v3?
We can also consider using a reverse DNS instead of URLs, similarly to how Android and iOS do it.