### PR TITLE
build: update nix build configuration to specify setuptools

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -5,11 +5,11 @@
         "nixpkgs-lib": "nixpkgs-lib"
       },
       "locked": {
-        "lastModified": 1749398372,
-        "narHash": "sha256-tYBdgS56eXYaWVW3fsnPQ/nFlgWi/Z2Ymhyu21zVM98=",
+        "lastModified": 1751413152,
+        "narHash": "sha256-Tyw1RjYEsp5scoigs1384gIg6e0GoBVjms4aXFfRssQ=",
         "owner": "hercules-ci",
         "repo": "flake-parts",
-        "rev": "9305fe4e5c2a6fcf5ba6a3ff155720fbe4076569",
+        "rev": "77826244401ea9de6e3bac47c2db46005e1f30b5",
         "type": "github"
       },
       "original": {
@@ -19,11 +19,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1750134718,
-        "narHash": "sha256-v263g4GbxXv87hMXMCpjkIxd/viIF7p3JpJrwgKdNiI=",
+        "lastModified": 1751637120,
+        "narHash": "sha256-xVNy/XopSfIG9c46nRmPaKfH1Gn/56vQ8++xWA8itO4=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "9e83b64f727c88a7711a2c463a7b16eedb69a84c",
+        "rev": "5c724ed1388e53cc231ed98330a60eb2f7be4be3",
         "type": "github"
       },
       "original": {
@@ -35,11 +35,11 @@
     },
     "nixpkgs-lib": {
       "locked": {
-        "lastModified": 1748740939,
-        "narHash": "sha256-rQaysilft1aVMwF14xIdGS3sj1yHlI6oKQNBRTF40cc=",
+        "lastModified": 1751159883,
+        "narHash": "sha256-urW/Ylk9FIfvXfliA1ywh75yszAbiTEVgpPeinFyVZo=",
         "owner": "nix-community",
         "repo": "nixpkgs.lib",
-        "rev": "656a64127e9d791a334452c6b6606d17539476e2",
+        "rev": "14a40a1d7fb9afa4739275ac642ed7301a9ba1ab",
         "type": "github"
       },
       "original": {

--- a/nix/default.nix
+++ b/nix/default.nix
@@ -21,6 +21,8 @@
 , nix-update-script
 , procps
 , python3Packages
+, setuptools ? python3Packages.setuptools
+, setuptools-scm ? python3Packages.setuptools-scm
 , ruff
 , stdenv
 , systemd
@@ -53,7 +55,6 @@ let
     distPhase = "true";
   };
 
-  format = "other";
 
   packages.preferences.dev = [ yarn ];
   packages.tests.python = pp: (with pp; [
@@ -75,7 +76,11 @@ let
     inherit version pname;
     src = src.python;
 
+    pyproject = true;
+    build-system = [ setuptools ];
+
     nativeBuildInputs = [
+      setuptools-scm
       gdk-pixbuf
       gobject-introspection
       intltool

--- a/result
+++ b/result
@@ -1,0 +1,1 @@
+/nix/store/vcysl6bpqx7p2v43lk27v7vm4v67afjc-python3.13-ulauncher-v6


### PR DESCRIPTION
This PR updates the Nix build configuration to explicitly specify `setuptools` and `setuptools-scm` as inputs. This change addresses the error encountered during the build process: "error: python3.13-ulauncher-v6 does not configure a `format`. To build with setuptools as before, set `pyproject = true` and `build-system = [ setuptools ]`."

By making these adjustments, we ensure compatibility with the latest version of nixpkgs and resolve the build issues.

**Changes**:

- Added `setuptools` and `setuptools-scm` to inputs in `nix/default.nix`.
- Configured the build system to use `setuptools` by setting `pyproject = true` and `build-system = [ setuptools ]`.
- Updated `nativeBuildInputs` to include `setuptools-scm`.
- Updated `flake.lock` to reflect the changes made in accordance with nixpkgs.

**Testing**: The build should now succeed with the latest version of nixpkgs. You can verify this by running `nix build` or `nix flake build` after applying this PR

**Note**: Further review may be required as I am not fully familiar with the build process used. Any feedback or suggestions would be appreciated.