### PR TITLE
perf: defer loading mode handler until after UI has loaded

### DIFF
--- a/tests/modes/apps/extensions/test_extension_mode.py
+++ b/tests/modes/apps/extensions/test_extension_mode.py
@@ -5,12 +5,15 @@ import pytest
 from ulauncher.internals.query import Query
 from ulauncher.modes.extensions.extension_mode import ExtensionMode
 from ulauncher.modes.extensions.extension_socket_controller import ExtensionSocketController
+from ulauncher.modes.extensions.extension_socket_server import events as ess_events
 
 
 class TestExtensionMode:
     @pytest.fixture(autouse=True)
     def ext_server(self, mocker):
-        return mocker.patch("ulauncher.modes.extensions.extension_mode.ExtensionSocketServer").return_value
+        ess = mocker.patch("ulauncher.modes.extensions.extension_mode.ExtensionSocketServer").return_value
+        ess_events.set_self(ess)
+        return ess
 
     def test_is_enabled__controller_is_running__returns_true(self, ext_server) -> None:
         controller = mock.create_autospec(ExtensionSocketController)

--- a/ulauncher/modes/query_handler.py
+++ b/ulauncher/modes/query_handler.py
@@ -17,11 +17,12 @@ class QueryHandler:
     query: Query = Query(None, "")
     triggers: list[Result] = []
     trigger_mode_map: dict[int, BaseMode] = {}
+    triggers_loaded: bool = False
 
-    def __init__(self) -> None:
-        self.reload_triggers()
+    def load_triggers(self, force: bool = False) -> None:
+        if self.triggers_loaded and not force:
+            return
 
-    def reload_triggers(self) -> None:
         from ulauncher.modes.mode_handler import get_modes
 
         self.triggers.clear()
@@ -30,8 +31,15 @@ class QueryHandler:
             for trigger in mode.get_triggers():
                 self.triggers.append(trigger)
                 self.trigger_mode_map[id(trigger)] = mode
+        self.triggers_loaded = True
 
-    def parse(self, query_str: str) -> None:
+    def update(self, query_str: str) -> None:
+        """Parse the query string and update the mode and query."""
+        if not query_str and not str(self.query):
+            # prevent loading modes until the app has rendered initially when the query is empty
+            # otherwise it will load all the slow stuff before the app is shown
+            return
+
         self.mode = None
         self.query = Query(None, query_str)
 
@@ -43,7 +51,10 @@ class QueryHandler:
                 self.mode = mode
                 self.query = query
 
+        self.handle_change()
+
     def search_triggers(self, min_score: int = 50, limit: int = 50) -> list[Result]:
+        self.load_triggers()
         # Cast apps to AppResult objects. Default apps to Gio.DesktopAppInfo.get_all()
         query_str = self.query.argument
         if not query_str:


### PR DESCRIPTION
Mode handler contains all the stuff that's slow to load. I did previously deferr loading it, but I broke this in recent changes (or maybe in less recent changes too).

Additionally, the event I previously used to load the deferred logic now runs before the window is shows and blocks it from showing. I'm not sure if GTK/Gnome made changes to gazlight me or if this never really worked, but it seems faster in my tests now (loads in ca 80ms on my system, until the window is shown and you can start typing the query).

Also refactored the deferring logic to be more self-contained in the query handler.