### PR TITLE
docs: update link to systemd

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ For more info or download links see [ulauncher.io](https://ulauncher.io)
 
 ### Run Ulauncher on startup
 
-If your distribution uses [Systemd](https://www.freedesktop.org/wiki/Software/systemd/) and the packages includes [ulauncher.service](ulauncher.service), then you can run `ulauncher` on startup by running:
+If your distribution uses [Systemd](https://systemd.io/) and the packages includes [ulauncher.service](ulauncher.service), then you can run `ulauncher` on startup by running:
 
 ```
 systemctl --user enable --now ulauncher


### PR DESCRIPTION
The old website says: 
"This page has been obsoleted and replaced. All the new contents are on the new website: https://systemd.io/."

I have updated the link to the new website.