### PR TITLE
fix: refactor remote parser and fix url in preferences UI

### DIFF
--- a/preferences-src/src/components/pages/ExtensionPreferences.vue
+++ b/preferences-src/src/components/pages/ExtensionPreferences.vue
@@ -10,10 +10,16 @@
         <div class="repo" v-if="extension.url">
           <div v-if="extension.commit_hash"><i class="fa fa-code-fork fa-fw"></i><span class="text-monospace">{{ extension.commit_hash.slice(0, 7) }}</span></div>
           <div v-if="extension.commit_hash"><i class="fa fa-calendar fa-fw"></i>{{ extension.updated_at.slice(0, 10) }}</div>
-          <div>
-            <a class="text-muted" href @click.prevent="openUrl(extension.url)" :title="extension.url">
+          <div v-if="extension.browser_url">
+            <a class="text-muted" href @click.prevent="openUrl(extension.browser_url)" :title="extension.browser_url">
               <i class="fa fa-external-link"></i> Open repository
             </a>
+          </div>
+          <div v-if="!extension.browser_url">
+            <i class="fa fa-copy"></i>
+            <a class="text-muted" href @click.prevent
+             v-clipboard:copy="extension.url"
+             :title="'Click to copy: ' + extension.url">Copy url</a>
           </div>
         </div>
         <div class="notes">
@@ -59,7 +65,7 @@
 
     <div class="error-wrapper" v-if="extension.error_type && extension.is_enabled">
       <ext-runtime-error
-        :extUrl="extension.url"
+        :extUrl="extension.browser_url"
         :errorMessage="extension.error_message"
         :errorType="extension.error_type"
       />
@@ -137,7 +143,7 @@
 
       <ext-install-error
         v-if="updateError"
-        :extUrl="extension.url"
+        :extUrl="extension.browser_url"
         :errorMessage="updateError.message"
         :errorType="updateError.type"
       />

--- a/tests/modes/apps/extensions/test_extension_remote.py
+++ b/tests/modes/apps/extensions/test_extension_remote.py
@@ -40,6 +40,9 @@ class TestParseExtensionUrl:
         assert parse_extension_url("https://gitlab.com/u/repo/issues").remote_url == "https://gitlab.com/u/repo.git"
         assert parse_extension_url("https://codeberg.org/u/repo/wiki").remote_url == "https://codeberg.org/u/repo.git"
 
+    def test_browser_url(self) -> None:
+        assert parse_extension_url("git@gitlab.com:user/repo.git").browser_url == "https://gitlab.com/user/repo"
+
     def test_ext_id(self) -> None:
         assert parse_extension_url("https://github.com/user/repo").ext_id == "com.github.user.repo"
         assert parse_extension_url("https://example.co.uk/user/repo").ext_id == "uk.co.example.user.repo"
@@ -73,6 +76,7 @@ class TestParseExtensionUrl:
         result = parse_extension_url("/local/path/to/extension")
         assert result == parse_extension_url("file:///local/path/to/extension")
         assert result.remote_url == "file:///local/path/to/extension"
+        assert result.browser_url == "file:///local/path/to/extension"
 
     def test_empty_path_raises_assertion_error(self) -> None:
         with pytest.raises(AssertionError):

--- a/tests/modes/apps/extensions/test_extension_remote.py
+++ b/tests/modes/apps/extensions/test_extension_remote.py
@@ -5,7 +5,6 @@ import pytest
 from ulauncher.modes.extensions.extension_remote import (
     ExtensionRemote,
     InvalidExtensionRecoverableError,
-    UrlParseResult,
     parse_extension_url,
 )
 
@@ -17,172 +16,80 @@ class TestExtensionRemote:
     def remote(self) -> ExtensionRemote:
         return ExtensionRemote("https://github.com/Ulauncher/ulauncher-timer")
 
-    def test_valid_urls_ext_id(self) -> None:
-        assert ExtensionRemote("https://host.tld/user/repo").ext_id == "tld.host.user.repo"
-        assert ExtensionRemote("http://host/user/repo").ext_id == "host.user.repo"
-        assert ExtensionRemote("https://host.org/user/repo.git").ext_id == "org.host.user.repo.git"
-        assert ExtensionRemote("http://host/user/repo.git").ext_id == "host.user.repo.git"
-        assert ExtensionRemote("git@host.com:user/repo").ext_id == "com.host.user.repo"
-        # verify sanitizing github/gitlab/codeberg urls, but leave all others
-        assert ExtensionRemote("https://github.com/user/repo/tree/HEAD").ext_id == "com.github.user.repo"
-        assert ExtensionRemote("https://gitlab.com/user/repo.git").ext_id == "com.gitlab.user.repo"
-        assert ExtensionRemote("https://other.host/a/b/c/d").ext_id == "host.other.a.b.c.d"
-
     def test_invalid_url(self) -> None:
         with pytest.raises(InvalidExtensionRecoverableError):
             ExtensionRemote("INVALID URL")
 
-    def test_get_download_url(self) -> None:
-        assert (
-            ExtensionRemote("https://github.com/user/repo")._get_download_url("master")
-            == "https://github.com/user/repo/archive/master.tar.gz"
-        )
-        assert (
-            ExtensionRemote("https://gitlab.com/user/repo")._get_download_url("master")
-            == "https://gitlab.com/user/repo/-/archive/master/repo-master.tar.gz"
-        )
-
 
 class TestParseExtensionUrl:
-    @patch("ulauncher.modes.extensions.extension_remote.which")
-    def test_https_url(self, mock_which: MagicMock) -> None:
-        mock_which.return_value = "/usr/bin/git"
+    def test_https_url(self) -> None:
         result = parse_extension_url("https://example.com/user/repo")
+        assert result.remote_url == "https://example.com/user/repo"
 
-        assert result == UrlParseResult(
-            use_git=True, url="https://example.com/user/repo", path="user/repo", protocol="https", host="example.com"
+    def test_http_url_converts_http_to_https(self) -> None:
+        assert parse_extension_url("http://example.com/user/repo").remote_url.startswith("https://")
+
+    def test_url_sanitization(self) -> None:
+        assert parse_extension_url("  https://example.com/path  ").remote_url == "https://example.com/path"
+        assert parse_extension_url("https://github.com/user/repo").remote_url == "https://github.com/user/repo.git"
+        assert parse_extension_url("git@gitlab.com:user/repo.git").remote_url == "https://gitlab.com/user/repo.git"
+        assert (
+            parse_extension_url("https://github.com/user/repo/blob/master").remote_url
+            == "https://github.com/user/repo.git"
+        )
+        assert parse_extension_url("https://gitlab.com/u/repo/issues").remote_url == "https://gitlab.com/u/repo.git"
+        assert parse_extension_url("https://codeberg.org/u/repo/wiki").remote_url == "https://codeberg.org/u/repo.git"
+
+    def test_ext_id(self) -> None:
+        assert parse_extension_url("https://github.com/user/repo").ext_id == "com.github.user.repo"
+        assert parse_extension_url("https://example.co.uk/user/repo").ext_id == "uk.co.example.user.repo"
+        assert parse_extension_url("https://gitlab.com/user/repo/issues").ext_id == "com.gitlab.user.repo"
+        assert parse_extension_url("https://local/path/to/extension").ext_id == "local.path.to.extension"
+        assert parse_extension_url("https://localhost/extension").ext_id == "localhost.extension"
+
+    def test_download_url_template(self) -> None:
+        assert (
+            parse_extension_url("https://github.com/user/repo").download_url_template
+            == "https://github.com/user/repo/archive/[commit].tar.gz"
+        )
+        assert (
+            parse_extension_url("https://codeberg.org/user/repo").download_url_template
+            == "https://codeberg.org/user/repo/archive/[commit].tar.gz"
+        )
+        assert (
+            parse_extension_url("https://gitlab.com/user/repo").download_url_template
+            == "https://gitlab.com/user/repo/-/archive/[commit]/repo-[commit].tar.gz"
         )
 
-    @patch("ulauncher.modes.extensions.extension_remote.which")
-    def test_http_url_converts_to_https(self, mock_which: MagicMock) -> None:
-        mock_which.return_value = "/usr/bin/git"
-        result = parse_extension_url("http://example.com/user/repo")
-
-        assert result == UrlParseResult(
-            use_git=True, url="https://example.com/user/repo", path="user/repo", protocol="https", host="example.com"
-        )
-
-    @patch("ulauncher.modes.extensions.extension_remote.which")
-    def test_ssh_url_reformatting(self, mock_which: MagicMock) -> None:
-        mock_which.return_value = "/usr/bin/git"
-        result = parse_extension_url("git@github.com:user/repo")
-
-        assert result == UrlParseResult(
-            use_git=False,  # don't use git for github, gitlab, codeberg URLs
-            url="https://github.com/user/repo",
-            path="user/repo",
-            protocol="https",
-            host="github.com",
-        )
-
-    @patch("ulauncher.modes.extensions.extension_remote.which")
     @patch("ulauncher.modes.extensions.extension_remote.isdir")
-    def test_local_file_path(self, mock_isdir: MagicMock, mock_which: MagicMock) -> None:
-        mock_which.return_value = "/usr/bin/git"
-        mock_isdir.return_value = True
-        result = parse_extension_url("/local/path/to/extension")
-
-        assert result == UrlParseResult(
-            use_git=True,
-            url="file:///local/path/to/extension",
-            path="local/path/to/extension",
-            protocol="file",
-            host="",
-        )
-
-    @patch("ulauncher.modes.extensions.extension_remote.which")
-    def test_github_url_sanitization(self, mock_which: MagicMock) -> None:
-        mock_which.return_value = "/usr/bin/git"
-        result = parse_extension_url("https://github.com/user/repo/blob/master")
-
-        assert result == UrlParseResult(
-            use_git=False, url="https://github.com/user/repo", path="user/repo", protocol="https", host="github.com"
-        )
-
-    @patch("ulauncher.modes.extensions.extension_remote.which")
-    def test_gitlab_url_sanitization(self, mock_which: MagicMock) -> None:
-        mock_which.return_value = "/usr/bin/git"
-        result = parse_extension_url("https://gitlab.com/user/repo/issues")
-
-        assert result == UrlParseResult(
-            use_git=False, url="https://gitlab.com/user/repo", path="user/repo", protocol="https", host="gitlab.com"
-        )
-
-    @patch("ulauncher.modes.extensions.extension_remote.which")
-    def test_codeberg_url_sanitization(self, mock_which: MagicMock) -> None:
-        mock_which.return_value = "/usr/bin/git"
-        result = parse_extension_url("https://codeberg.org/user/repo/wiki")
-
-        assert result == UrlParseResult(
-            use_git=False,
-            url="https://codeberg.org/user/repo",
-            path="user/repo",
-            protocol="https",
-            host="codeberg.org",
-        )
-
-    @patch("ulauncher.modes.extensions.extension_remote.which")
-    def test_git_extension_removal(self, mock_which: MagicMock) -> None:
-        mock_which.return_value = "/usr/bin/git"
-        result = parse_extension_url("https://github.com/user/repo.git")
-
-        assert result == UrlParseResult(
-            use_git=False, url="https://github.com/user/repo", path="user/repo", protocol="https", host="github.com"
-        )
-
-    @patch("ulauncher.modes.extensions.extension_remote.which")
-    def test_no_git_available(self, mock_which: MagicMock) -> None:
-        mock_which.return_value = None
-        result = parse_extension_url("https://example.com/user/repo")
-
-        assert result == UrlParseResult(
-            use_git=False, url="https://example.com/user/repo", path="user/repo", protocol="https", host="example.com"
-        )
-
-    @patch("ulauncher.modes.extensions.extension_remote.which")
-    def test_url_with_whitespace(self, mock_which: MagicMock) -> None:
-        mock_which.return_value = "/usr/bin/git"
-        result = parse_extension_url("  https://example.com/user/repo  ")
-
-        assert result == UrlParseResult(
-            use_git=True, url="https://example.com/user/repo", path="user/repo", protocol="https", host="example.com"
-        )
-
-    @patch("ulauncher.modes.extensions.extension_remote.which")
-    @patch("ulauncher.modes.extensions.extension_remote.isdir")
-    def test_file_protocol_url(self, mock_isdir: MagicMock, mock_which: MagicMock) -> None:
-        mock_which.return_value = "/usr/bin/git"
-        mock_isdir.return_value = True
-        result = parse_extension_url("file:///local/path/to/extension")
-
-        assert result == UrlParseResult(
-            use_git=True,
-            url="file:///local/path/to/extension",
-            path="local/path/to/extension",
-            protocol="file",
-            host="",
-        )
-
-    @patch("ulauncher.modes.extensions.extension_remote.which")
-    @patch("ulauncher.modes.extensions.extension_remote.isdir")
-    def test_invalid_local_path_raises_assertion_error(self, mock_isdir: MagicMock, mock_which: MagicMock) -> None:
-        mock_which.return_value = "/usr/bin/git"
+    def test_invalid_local_path_raises_assertion_error(self, mock_isdir: MagicMock) -> None:
         mock_isdir.return_value = False
-
         with pytest.raises(AssertionError):
             parse_extension_url("/nonexistent/path")
 
-    @patch("ulauncher.modes.extensions.extension_remote.which")
-    def test_empty_path_raises_assertion_error(self, mock_which: MagicMock) -> None:
-        mock_which.return_value = "/usr/bin/git"
+    @patch("ulauncher.modes.extensions.extension_remote.isdir")
+    def test_local_file_path(self, mock_isdir: MagicMock) -> None:
+        mock_isdir.return_value = True
+        result = parse_extension_url("/local/path/to/extension")
+        assert result == parse_extension_url("file:///local/path/to/extension")
+        assert result.remote_url == "file:///local/path/to/extension"
 
+    def test_empty_path_raises_assertion_error(self) -> None:
         with pytest.raises(AssertionError):
             parse_extension_url("https://example.com/")
 
-    @patch("ulauncher.modes.extensions.extension_remote.which")
-    def test_no_host_no_file_protocol_raises_assertion_error(self, mock_which: MagicMock) -> None:
-        mock_which.return_value = "/usr/bin/git"
-
+    def test_no_host_no_file_protocol_raises_assertion_error(self) -> None:
         with pytest.raises(AssertionError):
             # This creates a URL with no host but protocol is https
             parse_extension_url("https:///user/repo")
+
+    def test_valid_urls_ext_id(self) -> None:
+        assert parse_extension_url("https://host.tld/user/repo").ext_id == "tld.host.user.repo"
+        assert parse_extension_url("http://host/user/repo").ext_id == "host.user.repo"
+        assert parse_extension_url("https://host.org/user/repo.git").ext_id == "org.host.user.repo.git"
+        assert parse_extension_url("http://host/user/repo.git").ext_id == "host.user.repo.git"
+        assert parse_extension_url("git@host.com:user/repo").ext_id == "com.host.user.repo"
+        # verify sanitizing github/gitlab/codeberg urls, but leave all others
+        assert parse_extension_url("https://github.com/user/repo/tree/HEAD").ext_id == "com.github.user.repo"
+        assert parse_extension_url("https://gitlab.com/user/repo.git").ext_id == "com.gitlab.user.repo"
+        assert parse_extension_url("https://other.host/a/b/c/d").ext_id == "host.other.a.b.c.d"

--- a/ulauncher/modes/extensions/extension_controller.py
+++ b/ulauncher/modes/extensions/extension_controller.py
@@ -34,6 +34,7 @@ from ulauncher.utils.json_utils import json_load
 class ExtensionState(JsonConf):
     id = ""
     url = ""
+    browser_url = ""
     updated_at = ""
     commit_hash = ""
     commit_time = ""
@@ -75,6 +76,7 @@ class ExtensionController:
 
         if self.state.url:
             self.remote = ExtensionRemote(self.state.url)
+            self.state.browser_url = self.remote.browser_url or ""
 
     @classmethod
     def create(cls, ext_id: str, path: str | None = None) -> ExtensionController:
@@ -94,6 +96,7 @@ class ExtensionController:
             controller_cache[remote.ext_id] = instance
         instance.remote = remote
         instance.state.url = url
+        instance.state.browser_url = remote.browser_url or ""
         return instance
 
     @classmethod

--- a/ulauncher/modes/extensions/extension_remote.py
+++ b/ulauncher/modes/extensions/extension_remote.py
@@ -34,6 +34,7 @@ class ExtensionNetworkError(Exception):
 class UrlParseResult(BaseDataClass):
     ext_id: str
     remote_url: str
+    browser_url: str | None = None
     download_url_template: str | None = None
 
 
@@ -171,6 +172,7 @@ def parse_extension_url(input_url: str) -> UrlParseResult:
     Parses the extension URL and returns a dictionary.
     Raises AssertionError if the URL is invalid.
     """
+    browser_url: str | None = None
     download_url_template: str | None = None
     input_url_is_ssl = False
     input_url = input_url.strip()
@@ -190,7 +192,7 @@ def parse_extension_url(input_url: str) -> UrlParseResult:
 
     if url_parts.scheme in ("", "file"):
         assert isdir(url_parts.path)
-        remote_url = f"file://{host}/{path}"
+        browser_url = remote_url = f"file:///{path}"
 
     elif host in ("github.com", "gitlab.com", "codeberg.org"):
         # Sanitize URLs with known hosts and invalid trailing paths like /blob/master or /issues, /wiki etc
@@ -198,7 +200,7 @@ def parse_extension_url(input_url: str) -> UrlParseResult:
         if repo.endswith(".git"):
             repo = repo[:-4]
         path = f"{user}/{repo}"
-        base_url = f"https://{host}/{path}"
+        browser_url = base_url = f"https://{host}/{path}"
         remote_url = f"{base_url}.git"
         download_url_template = (
             f"{base_url}/-/archive/[commit]/{repo}-[commit].tar.gz"
@@ -217,5 +219,6 @@ def parse_extension_url(input_url: str) -> UrlParseResult:
     return UrlParseResult(
         ext_id=ext_id,
         remote_url=remote_url,
+        browser_url=browser_url,
         download_url_template=download_url_template,
     )


### PR DESCRIPTION
The major part of this PR is refactoring. After reviewing #1488 I was confused about my own code, and unsure if it was doing the right thing, and I also wanted to simplify the tests so that they would only check the props that are really affected by the tests (otherwise all tests will break if you change any prop). But that lead to a bigger refactoring to make the parse method and result more self contained, ie: handle all parsing and the host, path and id in one place, so the parse result doesn't have to expose internals.

Adds a new "download_url_template" prop so we don't need to conditionally check the host outside of the parser.

Removes the "use_git" prop, which didn't belong in the url parser anyway (I think I put it there, so not blaming anyone else), and now we can check if we have git and not the "download_url_template" prop instead.

Also replaced TypeDict with BaseDataClass as the baseclass for UrlParseResult. Then used UrlParseResult as the baseclass for ExtensionRemote (avoids some repetitious code).

Rewrote the tests to account for the new changes, to simplify, and as mentioned above to be more isolated (only check the props that has to do with the test). Added some new tests too.

**As for the actual fix**, if you install the url `git@gitlab.com:friday/ulauncher-locate.git`, then the preferences would also use that as the link (which wouldn't work). Now it will use the converted web link if available and allow to copy the link otherwise. 

This PR will introduce a lot of conflicts with #1488. Sorry about that.