### PR TITLE
refactor(ext-socket-server): remove logic to start self if __main__

### DIFF
--- a/ulauncher/modes/extensions/extension_socket_server.py
+++ b/ulauncher/modes/extensions/extension_socket_server.py
@@ -138,10 +138,3 @@ class ExtensionSocketServer(metaclass=Singleton):
         )
         self.active_event = event
         self.active_controller = controller
-
-
-if __name__ == "__main__":
-    logging.basicConfig(level=logging.DEBUG)
-
-    server = ExtensionSocketServer()
-    server.start()


### PR DESCRIPTION
I never touched this, but I can't imagine it's anything other than a leftover from some testing.

This module should never be `__main__`