### PR TITLE
Fix text truncation in result widgets on Wayland

### DIFF
--- a/ulauncher/ui/result_widget.py
+++ b/ulauncher/ui/result_widget.py
@@ -35,6 +35,14 @@ class ResultWidget(Gtk.EventBox):
         inner_margin_x = int(12.0 * text_scaling_factor)
         outer_margin_x = int(18.0 * text_scaling_factor)
         margin_y = (3 if result.compact else 5) * text_scaling_factor
+        
+        # Calculate available width for text container dynamically
+        # Base width from settings minus margins, icon, and shortcut space
+        settings = Settings.load()
+        window_width = settings.base_width
+        shortcut_width = 44  # Fixed width for shortcut label
+        total_margins = (outer_margin_x * 2) + (inner_margin_x * 2)
+        available_width = window_width - icon_size - shortcut_width - total_margins - 20  # 20px buffer
 
         super().__init__()
         self.get_style_context().add_class("item-frame")
@@ -54,7 +62,7 @@ class ResultWidget(Gtk.EventBox):
         item_container.pack_start(icon, False, True, 0)
 
         self.text_container = Gtk.Box(
-            width_request=int(350.0 * text_scaling_factor),
+            width_request=max(int(available_width * text_scaling_factor), int(300.0 * text_scaling_factor)),
             margin_start=inner_margin_x,
             margin_end=inner_margin_x,
             orientation=Gtk.Orientation.VERTICAL,


### PR DESCRIPTION
## Summary
This PR fixes text truncation issues in search result widgets, particularly on Wayland compositors like Niri, where application names get cut off and are difficult to read.

## Problem
The text container width in `ResultWidget` was hardcoded to `350 * text_scaling_factor`, which doesn't adapt to the actual available window width. This caused application names to be truncated when the window was wider than expected, especially on Wayland systems.

## Solution
- Calculate text container width dynamically based on the window's `base_width` setting
- Account for icon size, margins, and shortcut label space when calculating available width
- Set a minimum width of 300px (scaled) to ensure reasonable display on smaller windows
- Use `max()` to ensure the text container is never smaller than the minimum

## Testing
- Tested on Niri (Wayland) compositor with various window widths
- Verified that application names like "ghostty" now display fully instead of being truncated
- Confirmed backward compatibility with existing themes and settings

## Related Issue
Fixes #1514

🤖 Generated with [Claude Code](https://claude.ai/code)