### PR TITLE
fix: use relative positioning for layer shell on Wayland

### DIFF
--- a/ulauncher/ui/windows/ulauncher_window.py
+++ b/ulauncher/ui/windows/ulauncher_window.py
@@ -340,7 +340,7 @@ class UlauncherWindow(Gtk.ApplicationWindow):
                 pos_y_for_monitor = int(pos_y + monitor_size.y)
 
                 if self.layer_shell_enabled:
-                    layer_shell.set_vertical_position(self, pos_y_for_monitor)
+                    layer_shell.set_vertical_position(self, pos_y)
                 else:
                     self.move(pos_x_for_monitor, pos_y_for_monitor)
 


### PR DESCRIPTION
Layer shell's set_margin() expects a margin from the monitor edge, not absolute screen coordinates. This fixes window positioning on multi-monitor Wayland setups (Sway, Hyprland, etc.) where the window would appear at incorrect vertical positions.

The fix passes the relative position (pos_y) instead of the absolute coordinate (pos_y_for_monitor) to layer_shell.set_vertical_position().
