### PR TITLE
fix: check for yarn when running prefs in makefile

### DIFF
--- a/makefile
+++ b/makefile
@@ -148,9 +148,16 @@ docker: # Build the docker image (only needed if you make changes to it)
 
 prefs: # Build the preferences web app
 	@set -euo pipefail
-	if [ ! -d "preferences-src" ]; then
-		echo -e "${BOLD}${RED}preferences-src does not exist.${RESET}"
-		exit 1
+	if [ -z "${YARN_BIN}" ] || [ ! -x "${YARN_BIN}" ]; then \
+	  echo -e "${BOLD}${RED}yarn is not installed or not executable.${RESET}"; \
+	  echo -e "${BOLD}${RED}yarn is needed to set up the local build environment.${RESET}"; \
+	  echo -e "${BOLD}${RED}Please visit https://classic.yarnpkg.com/en/docs/install to install yarn.${RESET}"; \
+	  exit 1; \
+  fi
+
+	if [ ! -d "preferences-src" ]; then \
+		echo -e "${BOLD}${RED}preferences-src does not exist.${RESET}"; \
+		exit 1; \
 	fi
 
 	if [ -z "$(FORCE)" ] && [ -d data/preferences ] && [ -z $(shell eval "find preferences-src -newer data/preferences -print -quit") ] ; then


### PR DESCRIPTION
<!--
Thank you for submitting a PR to Ulauncher!

Please read our contribution instructions if you haven't:
https://github.com/Ulauncher/Ulauncher#code-contribution

* Explain the changes in this PR and link to related issue(s) if applicable
* When applicable, please update the documentation according to your changes.
* Ensure that the PR doesn't break existing tests, and please add your own if applicable.

A git action will verify your PR, but you can also test locally with `make test`

-->

fix: #1527 

Before:

```
find: ‘data/preferences’: No such file or directory
bash: line 12: build: command not found
make: *** [makefile:150: prefs] Error 127
```

After:

```
find: ‘data/preferences’: No such file or directory
yarn is not installed or not executable.
yarn is needed to set up the local build environment.
Please visit https://classic.yarnpkg.com/en/docs/install to install yarn.
make: *** [makefile:150: prefs] Error 1
```