### PR TITLE
fix: timer method only works in GLib.MainContext

### DIFF
--- a/tests/utils/test_timer.py
+++ b/tests/utils/test_timer.py
@@ -1,35 +1,65 @@
-from typing import Any
-from unittest.mock import MagicMock, Mock
-
-import pytest
-from pytest_mock import MockerFixture
+import time
+from unittest.mock import Mock
 
 from ulauncher.utils.timer import timer
 
+TIMER_BUFFER = 0.02  # seconds
+
+
+def padded_wait(seconds: float) -> None:
+    """Wait the given number of seconds plus a small buffer to ensure timer execution."""
+    time.sleep(seconds + TIMER_BUFFER)
+
 
 class TestTimer:
-    @pytest.fixture(autouse=True)
-    def glib(self, mocker: MockerFixture) -> MagicMock:
-        return mocker.patch("ulauncher.utils.timer.GLib")
-
-    def test_timer_subsecond(self, glib: MagicMock) -> None:
+    def test_timer_executes_function(self) -> None:
+        """Test that timer executes the function after the delay."""
         func = Mock()
-        subsecond_time = 0.5
-        ctx = timer(subsecond_time, func)
-        glib.timeout_source_new.assert_called_with(subsecond_time * 1000)
-        src: Any = ctx.source
-        ctx.trigger(None)
+        delay = 0.1
+
+        ctx = timer(delay, func)
+
+        # Function should not be called immediately
+        func.assert_not_called()
+
+        padded_wait(delay)
+
         func.assert_called_once()
         ctx.cancel()
-        src.destroy.assert_called_once()
 
-    def test_timer_second(self, glib: MagicMock) -> None:
+    def test_timer_cancel(self) -> None:
+        """Test that cancelling a timer prevents execution."""
         func = Mock()
-        seconds_time = 2
-        ctx = timer(seconds_time, func)
-        glib.timeout_source_new_seconds.assert_called_with(seconds_time)
-        src: Any = ctx.source
-        ctx.trigger(None)
-        func.assert_called_once()
+        delay = 0.1
+
+        ctx = timer(delay, func)
+
+        # Cancel immediately
         ctx.cancel()
-        src.destroy.assert_called_once()
+
+        padded_wait(delay)
+
+        # Function should not be called
+        func.assert_not_called()
+
+    def test_timer_multiple_instances(self) -> None:
+        """Test that multiple timer instances work independently."""
+        func1 = Mock()
+        func2 = Mock()
+
+        ctx1 = timer(0.05, func1)
+        ctx2 = timer(0.1, func2)
+
+        # Wait for first timer
+        padded_wait(0.05)
+        func1.assert_called_once()
+        func2.assert_not_called()
+
+        # Wait for second timer
+        padded_wait(0.05)
+        func1.assert_called_once()
+        func2.assert_called_once()
+
+        # Clean up
+        ctx1.cancel()
+        ctx2.cancel()

--- a/ulauncher/utils/timer.py
+++ b/ulauncher/utils/timer.py
@@ -10,12 +10,10 @@ class TimerContext:
     """A utility class to hold the context for the timer() function."""
 
     source: GLib.Source | None
-    repeat: bool
     func: Callable[[], None]
 
-    def __init__(self, source: GLib.Source, func: Callable[[], None], repeat: bool = False) -> None:
+    def __init__(self, source: GLib.Source, func: Callable[[], None]) -> None:
         self.source = source
-        self.repeat = repeat
         self.func = func
         self.source.set_callback(self.trigger)
         self.source.attach(None)
@@ -25,15 +23,14 @@ class TimerContext:
             self.source.destroy()
             self.source = None
 
-    def trigger(self, *_args: Any) -> bool:
+    def trigger(self, *_args: Any) -> None:
         self.func()
-        return self.repeat
 
 
-def timer(delay_sec: float, func: Callable[[], None], repeat: bool = False) -> TimerContext:
+def timer(delay_sec: float, func: Callable[[], None]) -> TimerContext:
     """
-    Executes the given function after a delay given in seconds. Repeats every delay_sec if
-    repeat==True. The function is executed in the context of the GLib MainContext thread.
+    Executes the given function after a delay given in seconds.
+    The function is executed in the context of the GLib MainContext thread.
 
     func is not called with any arguments, so to call with custom arguments use functools.partial,
     such as `timer(0.5, partial(myfunc, myarg1, myarg2))`.
@@ -48,4 +45,4 @@ def timer(delay_sec: float, func: Callable[[], None], repeat: bool = False) -> T
         else GLib.timeout_source_new(int(delay_sec * 1000.0))
     )
 
-    return TimerContext(source, func, repeat)
+    return TimerContext(source, func)


### PR DESCRIPTION
Maybe this isn't strictly speaking a fix. The `timer` method was always documented to work inside GLib.MainContext, and both the app and extension runtime run inside GLib.MainContext now.

But when I made a draft PR (#1534) where the extension runtime no longer runs inside GLib.MainContext, then this method would silently stop working. Even though this PR won't be merged in this state I found this to be a bit of a footgun, and would rather see it to work regardless of the context.

Furthermore, the unit tests were misleading imo. They didn't run inside of GLib.MainContext, and they also don't wait for the timer, so they were not really testing that the timer worked. `func.assert_called_once()` was effectively testing something else I think.

So I rewrote the timer method to use `threading.Timer` instead. It works similar to the GLib implementation but requires less code. I removed the repeat argument because we don't use it, and I think this would have required some more complexity to support with `threading.Timer` (not a lot, but I see no reason to add it if we don't need it).

And I (mostly copilot tbh) added more thorough tests.

I'm suspecting @troycurtisjr will say this is going to use more resources (or he wouldn't have implemented it like it was originally)?