### PR TITLE
fix(cli): simplify the parsing, ext controller interaction and improve error handling

### DIFF
--- a/ulauncher/modes/extensions/extension_cli_handlers.py
+++ b/ulauncher/modes/extensions/extension_cli_handlers.py
@@ -152,10 +152,8 @@ def upgrade_extensions(_: ArgumentParser, args: Namespace) -> bool:
         except Exception:
             logger.exception("Failed to update %s", ext_name)
 
-    if len(updated_extensions) == 0:
-        logger.info("All extensions are up to date")
-    else:
+    if updated_extensions:
         dbus_trigger_event("extensions:reload", updated_extensions)
-        logger.info("Successfully updated %s extensions", len(updated_extensions))
 
+    logger.info("\n%s extensions updated", len(updated_extensions))
     return True

--- a/ulauncher/modes/extensions/extension_remote.py
+++ b/ulauncher/modes/extensions/extension_remote.py
@@ -59,7 +59,7 @@ class ExtensionRemote(UrlParseResult):
         try:
             if which("git"):
                 if isdir(self._git_dir):
-                    subprocess.run(
+                    subprocess.check_call(
                         [
                             "git",
                             f"--git-dir={self._git_dir}",
@@ -69,11 +69,14 @@ class ExtensionRemote(UrlParseResult):
                             "--prune",
                             "--prune-tags",
                         ],
-                        check=True,
+                        stderr=subprocess.DEVNULL,
                     )
                 else:
                     os.makedirs(self._git_dir)
-                    subprocess.run(["git", "clone", "--bare", self.remote_url, self._git_dir], check=True)
+                    subprocess.check_call(
+                        ["git", "clone", "--bare", self.remote_url, self._git_dir],
+                        stderr=subprocess.DEVNULL,
+                    )
 
                 response = subprocess.check_output(["git", "ls-remote", self._git_dir]).decode().strip().split("\n")
             else:
@@ -94,7 +97,6 @@ class ExtensionRemote(UrlParseResult):
                 msg = f'Could not access repository resource "{self.url}"'
                 raise ExtensionNetworkError(msg) from e
 
-            logger.warning("Unexpected error fetching extension versions '%s' (%s: %s)", self.url, type(e).__name__, e)
             msg = f'Could not fetch reference "{ref}" for {self.url}.' if ref else f"Could not fetch remote {self.url}."
             raise ExtensionRemoteError(msg) from e
 


### PR DESCRIPTION
This PR was mostly motivated by needing to change the CLI parser logic before #1543, but it goes further than that.

Leverages `parse_extension_url` to make a simpler method to get the controller, instead of get_argument_type(). Also change the meaning of the controller getter method to only return for installed extensions.
This simplifies our error handling, and aligns with how we've #1543 implements ExtController.

The old error handling was using a lot of try/except with bare excepts, overly verbose errors logged by the modules we're calling from the CLI.

I also did a bunch of testing with network disabled etc, but only for the CLI. I found that the preferences UI extension view also had issues and broken error handling (not introduced in this PR), which needs to be reworked separately.