### PR TITLE
refactor: in-memory extension registry

### DIFF
--- a/tests/modes/apps/extensions/test_extension_mode.py
+++ b/tests/modes/apps/extensions/test_extension_mode.py
@@ -8,9 +8,19 @@ from ulauncher.internals.query import Query
 from ulauncher.modes.extensions.extension_mode import ExtensionMode
 from ulauncher.modes.extensions.extension_socket_controller import ExtensionSocketController
 from ulauncher.modes.extensions.extension_socket_server import events as ess_events
+from ulauncher.utils import singleton
 
 
 class TestExtensionMode:
+    @pytest.fixture(autouse=True)
+    def reset_singleton(self) -> None:
+        # Reset singleton before each test
+        singleton._instances.pop(ExtensionMode, None)
+
+    @pytest.fixture(autouse=True)
+    def ext_registry(self, mocker: MockerFixture) -> MagicMock:
+        return mocker.patch("ulauncher.modes.extensions.extension_mode.ExtensionRegistry")
+
     @pytest.fixture(autouse=True)
     def ext_server(self, mocker: MockerFixture) -> Any:
         ess = mocker.patch("ulauncher.modes.extensions.extension_mode.ExtensionSocketServer").return_value
@@ -31,7 +41,7 @@ class TestExtensionMode:
         ext_id = "com.test.ext"
         trigger_id = "trigger_id"
         mode = ExtensionMode()
-        mode._trigger_cache = {keyword: (ext_id, trigger_id)}
+        mode._trigger_cache = {keyword: (trigger_id, ext_id)}
         query = Query(keyword, "ghjk")
         mode.handle_query(query)
-        ext_server.handle_query.assert_called_with(trigger_id, ext_id, query)
+        ext_server.handle_query.assert_called_with(ext_id, trigger_id, query)

--- a/tests/modes/apps/extensions/test_extension_socket_controller.py
+++ b/tests/modes/apps/extensions/test_extension_socket_controller.py
@@ -20,6 +20,15 @@ class TestExtensionSocketController:
     def extension_finder_locate(self, mocker: MockerFixture) -> MagicMock:
         return mocker.patch("ulauncher.modes.extensions.extension_finder.locate")
 
+    @pytest.fixture(autouse=True)
+    def extension_registry(self, mocker: MockerFixture) -> MagicMock:
+        registry = mocker.patch("ulauncher.modes.extensions.extension_socket_controller.ExtensionRegistry")
+        ext_controller = Mock()
+        ext_controller.preferences = {}
+        ext_controller.manifest.input_debounce = 0.05
+        registry.return_value.get_or_raise.return_value = ext_controller
+        return registry
+
     @pytest.fixture
     def controller(self, controllers: dict[str, ExtensionSocketController]) -> ExtensionSocketController:
         controller = ExtensionSocketController(controllers, Mock(), TEST_EXT_ID)

--- a/tests/modes/apps/extensions/test_extension_socket_server.py
+++ b/tests/modes/apps/extensions/test_extension_socket_server.py
@@ -43,7 +43,7 @@ class TestExtensionSocketServer:
 
     @pytest.fixture
     def server(self) -> ExtensionSocketServer:
-        return ExtensionSocketServer()
+        return ExtensionSocketServer(lambda _ext_id: None)
 
     def test_start(self, server: MagicMock) -> None:
         server.start()

--- a/ulauncher/api/client/Client.py
+++ b/ulauncher/api/client/Client.py
@@ -52,7 +52,13 @@ class Client:
         self.framer.connect("message_parsed", self.on_message)
         self.framer.connect("closed", self.on_close)
         self.framer.set_connection(self.conn)
-        self.send({"type": "extension:socket_connected", "ext_id": self.extension.ext_id})
+        self.send(
+            {
+                "type": "extension:socket_connected",
+                "ext_id": self.extension.ext_id,
+                "path": os.path.dirname(os.path.abspath(sys.argv[0])),
+            }
+        )
 
         mainloop = GLib.MainLoop.new(None, False)
         mainloop.run()

--- a/ulauncher/modes/extensions/extension_registry.py
+++ b/ulauncher/modes/extensions/extension_registry.py
@@ -1,0 +1,190 @@
+from __future__ import annotations
+
+import asyncio
+import logging
+import tempfile
+from datetime import datetime
+from pathlib import Path
+from shutil import copytree, rmtree
+from typing import Iterator
+
+from ulauncher import paths
+from ulauncher.modes.extensions import extension_finder
+from ulauncher.modes.extensions.extension_controller import ExtensionController, ExtensionNotFoundError
+from ulauncher.modes.extensions.extension_dependencies import (
+    ExtensionDependencies,
+    ExtensionDependenciesRecoverableError,
+)
+from ulauncher.modes.extensions.extension_remote import ExtensionRemote
+from ulauncher.utils.singleton import Singleton
+
+logger = logging.getLogger()
+
+
+class ExtensionRegistry(metaclass=Singleton):
+    """
+    Singleton registry for managing all extension controllers.
+    Provides centralized access to extension controllers throughout the application.
+    """
+
+    _registry: dict[str, ExtensionController]
+
+    def __init__(self) -> None:
+        self._registry = {}
+
+    def get(self, ext_id: str) -> ExtensionController | None:
+        """Get an extension controller by ID."""
+        return self._registry.get(ext_id)
+
+    def get_or_raise(self, ext_id: str) -> ExtensionController:
+        """Get an extension controller by ID."""
+        controller = self._registry.get(ext_id)
+        if not controller:
+            msg = f"Extension with ID '{ext_id}' not found in registry"
+            raise ExtensionNotFoundError(msg)
+
+        return controller
+
+    def iterate(self) -> Iterator[ExtensionController]:
+        """Iterate over all registered extension controllers."""
+        yield from self._registry.values()
+
+    def load(self, ext_id: str, path: str | None = None) -> ExtensionController:
+        """Load an extension controller into in-memory registry. It doesn't run it."""
+        if not path:
+            path = extension_finder.locate(ext_id)
+            if not path:
+                # If it's already in the registry but not found on disk, it means it's been removed
+                self._registry.pop(ext_id, None)
+
+                msg = f"Extension with ID '{ext_id}' not found"
+                raise ExtensionNotFoundError(msg)
+        new_controller = ExtensionController(ext_id, path)
+        self._registry[ext_id] = new_controller
+        return new_controller
+
+    def load_all(self) -> Iterator[ExtensionController]:
+        """Load all extensions found by the extension finder into in-memory registry. It doesn't run them."""
+        for ext_id, ext_path in extension_finder.iterate():
+            self.load(ext_id, ext_path)
+
+        yield from self._registry.values()
+
+    async def install(
+        self, url: str, commit_hash: str | None = None, warn_if_overwrite: bool = True
+    ) -> ExtensionController:
+        logger.info("Installing extension: %s", url)
+        remote = ExtensionRemote(url)
+        commit_hash, commit_timestamp = remote.download(commit_hash, warn_if_overwrite)
+
+        try:
+            # install python dependencies from requirements.txt
+            deps = ExtensionDependencies(remote.ext_id, remote.target_dir)
+            deps.install()
+        except ExtensionDependenciesRecoverableError:
+            # clean up broken install
+            rmtree(remote.target_dir)
+            raise
+        else:
+            controller = self.load(remote.ext_id, remote.target_dir)
+            controller.state.save(
+                url=url,
+                browser_url=remote.browser_url or "",
+                commit_hash=commit_hash,
+                commit_time=datetime.fromtimestamp(commit_timestamp).isoformat(),
+                updated_at=datetime.now().isoformat(),
+                error_type="",
+                error_message="",
+            )
+            logger.info("Extension %s installed successfully", controller.id)
+            return controller
+
+    async def install_preview(self, ext_id: str, path: str) -> ExtensionController:
+        logger.info("Installing extension in preview: %s", path)
+
+        # install python dependencies from requirements.txt
+        deps = ExtensionDependencies(ext_id, path)
+        deps.install()
+
+        controller = self.load(ext_id, path)
+        controller.state.save(
+            url=path,
+            browser_url=path,
+            commit_hash="(preview)",
+            commit_time="N/A",
+            updated_at="N/A",
+            error_type="",
+            error_message="",
+        )
+        logger.info("Extension %s installed successfully", controller.id)
+        return controller
+
+    async def stop_all(self) -> None:
+        """Stop all running extensions."""
+
+        jobs = [c.stop() for c in self._registry.values() if c.is_running]
+        await asyncio.gather(*jobs)
+
+    async def remove(self, controller: ExtensionController) -> None:
+        """Remove an installed extension."""
+
+        if not controller.is_manageable:
+            logger.warning(
+                "Extension %s is not manageable. Cannot remove it automatically. "
+                "Please remove it manually from the extensions directory: %s",
+                controller.id,
+                controller.path,
+            )
+            return
+
+        await controller.stop()
+        rmtree(controller.path)
+        self._registry.pop(controller.id, None)
+        logger.info("Extension %s uninstalled successfully", controller.id)
+
+        # non-manageable extension still exists (installed elsewhere)
+        if fallback_path := extension_finder.locate(controller.id):
+            controller = ExtensionController(controller.id, fallback_path)
+            controller.state.save(is_enabled=False)
+            logger.info("Non-manageable extension with the same id exists in '%s'", fallback_path)
+            return
+
+        state_path = Path(f"{paths.EXTENSIONS_STATE}/{controller.id}.json")
+        if state_path.is_file():
+            state_path.unlink()
+
+    async def update(self, controller: ExtensionController) -> bool:
+        """Update an extension to the latest available version."""
+
+        logger.debug("Checking for updates to %s", controller.id)
+        has_update, commit_hash = await controller.check_update()
+        was_running = controller.is_running
+        if not has_update:
+            logger.info('Extension "%s" is already on the latest version', controller.id)
+            return False
+
+        logger.info(
+            'Updating extension "%s" from commit %s to %s',
+            controller.id,
+            controller.state.commit_hash[:8],
+            commit_hash[:8],
+        )
+
+        # Backup extension files. If update fails, restore from backup
+        with tempfile.TemporaryDirectory(prefix="ulauncher_ext_") as backup_dir:
+            ext_path = controller.path
+            copytree(ext_path, backup_dir, dirs_exist_ok=True)
+
+            try:
+                await controller.stop()
+                await self.install(controller.state.url, commit_hash, warn_if_overwrite=False)
+            except Exception:
+                logger.exception("Could not update extension '%s'.", controller.id)
+                copytree(backup_dir, ext_path, dirs_exist_ok=True)
+                await controller.toggle_enabled(was_running)
+                raise
+
+        await controller.toggle_enabled(was_running)
+        logger.info("Successfully updated extension: %s", controller.id)
+
+        return True

--- a/ulauncher/modes/extensions/extension_socket_controller.py
+++ b/ulauncher/modes/extensions/extension_socket_controller.py
@@ -6,6 +6,7 @@ from typing import Any
 
 from ulauncher.internals.query import Query
 from ulauncher.modes.extensions.extension_controller import ExtensionController
+from ulauncher.modes.extensions.extension_registry import ExtensionRegistry
 from ulauncher.utils.decorator.debounce import debounce
 from ulauncher.utils.eventbus import EventBus
 from ulauncher.utils.framer import JSONFramer
@@ -32,7 +33,8 @@ class ExtensionSocketController:
         self.socket_controllers = socket_controllers
         self.framer: JSONFramer = framer
         self.ext_id = ext_id
-        self.ext_controller = ExtensionController.create(ext_id)
+        registry = ExtensionRegistry()
+        self.ext_controller = registry.get_or_raise(ext_id)
 
         self.socket_controllers[ext_id] = self
         self._debounced_send_event = debounce(self.ext_controller.manifest.input_debounce)(self.send_message)

--- a/ulauncher/utils/migrate.py
+++ b/ulauncher/utils/migrate.py
@@ -56,13 +56,14 @@ def _migrate_app_state(old_format: dict[str, int]) -> dict[str, int]:
 
 
 def _migrate_user_prefs(ext_id: str, user_prefs: dict[str, dict[str, Any]]) -> dict[str, dict[str, Any]]:
-    from ulauncher.modes.extensions.extension_controller import ExtensionController
+    from ulauncher.modes.extensions.extension_registry import ExtensionRegistry
 
     # Check if already migrated
     if sorted(user_prefs.keys()) == ["preferences", "triggers"]:
         return user_prefs
     new_prefs: dict[str, dict[str, Any]] = {"preferences": {}, "triggers": {}}
-    controller = ExtensionController.create(ext_id)
+    registry = ExtensionRegistry()
+    controller = registry.load(ext_id)
     for p_id, pref in user_prefs.items():
         try:
             if controller.manifest.triggers.get(p_id):


### PR DESCRIPTION
- follow single responsibility principle in extension module,
- replace extension cache with an explicit in-memory extension registry

The in-memory registry is necessary for the feature of preview extensions.
