### PR TITLE
refactor: follow single responsibility principle in the extension module, use explicit in-memory extension registry

### DIFF
--- a/tests/modes/apps/extensions/test_extension_mode.py
+++ b/tests/modes/apps/extensions/test_extension_mode.py
@@ -8,9 +8,19 @@ from ulauncher.internals.query import Query
 from ulauncher.modes.extensions.extension_mode import ExtensionMode
 from ulauncher.modes.extensions.extension_socket_controller import ExtensionSocketController
 from ulauncher.modes.extensions.extension_socket_server import events as ess_events
+from ulauncher.utils import singleton
 
 
 class TestExtensionMode:
+    @pytest.fixture(autouse=True)
+    def reset_singleton(self) -> None:
+        # Reset singleton before each test
+        singleton._instances.pop(ExtensionMode, None)
+
+    @pytest.fixture(autouse=True)
+    def ext_registry(self, mocker: MockerFixture) -> MagicMock:
+        return mocker.patch("ulauncher.modes.extensions.extension_mode.ExtensionRegistry")
+
     @pytest.fixture(autouse=True)
     def ext_server(self, mocker: MockerFixture) -> Any:
         ess = mocker.patch("ulauncher.modes.extensions.extension_mode.ExtensionSocketServer").return_value
@@ -31,7 +41,7 @@ class TestExtensionMode:
         ext_id = "com.test.ext"
         trigger_id = "trigger_id"
         mode = ExtensionMode()
-        mode._trigger_cache = {keyword: (ext_id, trigger_id)}
+        mode._trigger_cache = {keyword: (trigger_id, ext_id)}
         query = Query(keyword, "ghjk")
         mode.handle_query(query)
-        ext_server.handle_query.assert_called_with(trigger_id, ext_id, query)
+        ext_server.handle_query.assert_called_with(ext_id, trigger_id, query)

--- a/tests/modes/apps/extensions/test_extension_socket_controller.py
+++ b/tests/modes/apps/extensions/test_extension_socket_controller.py
@@ -20,6 +20,15 @@ class TestExtensionSocketController:
     def extension_finder_locate(self, mocker: MockerFixture) -> MagicMock:
         return mocker.patch("ulauncher.modes.extensions.extension_finder.locate")
 
+    @pytest.fixture(autouse=True)
+    def extension_registry(self, mocker: MockerFixture) -> MagicMock:
+        registry = mocker.patch("ulauncher.modes.extensions.extension_socket_controller.ExtensionRegistry")
+        ext_controller = Mock()
+        ext_controller.preferences = {}
+        ext_controller.manifest.input_debounce = 0.05
+        registry.return_value.get_or_raise.return_value = ext_controller
+        return registry
+
     @pytest.fixture
     def controller(self, controllers: dict[str, ExtensionSocketController]) -> ExtensionSocketController:
         controller = ExtensionSocketController(controllers, Mock(), TEST_EXT_ID)

--- a/tests/modes/apps/extensions/test_extension_socket_server.py
+++ b/tests/modes/apps/extensions/test_extension_socket_server.py
@@ -43,7 +43,7 @@ class TestExtensionSocketServer:
 
     @pytest.fixture
     def server(self) -> ExtensionSocketServer:
-        return ExtensionSocketServer()
+        return ExtensionSocketServer(lambda _ext_id, _path: None)
 
     def test_start(self, server: MagicMock) -> None:
         server.start()
@@ -72,7 +72,7 @@ class TestExtensionSocketServer:
         server.start()
         server.handle_incoming(server.service, conn, source)
         extid = "id"
-        event = {"type": "extension:socket_connected", "ext_id": extid}
+        event = {"type": "extension:socket_connected", "ext_id": extid, "path": "/test/path"}
         assert id(jsonframer.return_value) in server.pending
         server.handle_registration(jsonframer.return_value, event)
         assert id(jsonframer.return_value) not in server.pending

--- a/ulauncher/api/client/Client.py
+++ b/ulauncher/api/client/Client.py
@@ -52,7 +52,13 @@ class Client:
         self.framer.connect("message_parsed", self.on_message)
         self.framer.connect("closed", self.on_close)
         self.framer.set_connection(self.conn)
-        self.send({"type": "extension:socket_connected", "ext_id": self.extension.ext_id})
+        self.send(
+            {
+                "type": "extension:socket_connected",
+                "ext_id": self.extension.ext_id,
+                "path": os.path.dirname(os.path.abspath(sys.argv[0])),
+            }
+        )
 
         mainloop = GLib.MainLoop.new(None, False)
         mainloop.run()

--- a/ulauncher/modes/extensions/extension_controller.py
+++ b/ulauncher/modes/extensions/extension_controller.py
@@ -8,8 +8,7 @@ import tempfile
 from datetime import datetime
 from pathlib import Path
 from shutil import copytree, rmtree
-from typing import Any, Iterator
-from weakref import WeakValueDictionary
+from typing import Any
 
 from ulauncher import paths
 from ulauncher.cli import get_cli_args
@@ -27,6 +26,7 @@ from ulauncher.modes.extensions.extension_manifest import (
 )
 from ulauncher.modes.extensions.extension_remote import ExtensionRemote
 from ulauncher.modes.extensions.extension_runtime import ExtensionRuntime
+from ulauncher.utils.eventbus import EventBus
 from ulauncher.utils.get_icon_path import get_icon_path
 from ulauncher.utils.json_conf import JsonConf
 from ulauncher.utils.json_utils import json_load
@@ -60,8 +60,8 @@ class ExtensionState(JsonConf):
 
 
 logger = logging.getLogger()
-controller_cache: WeakValueDictionary[str, ExtensionController] = WeakValueDictionary()
 extension_runtimes: dict[str, ExtensionRuntime] = {}
+lifecycle_events = EventBus("extensions")
 
 
 def _load_preferences(ext_id: str) -> JsonConf:
@@ -69,6 +69,8 @@ def _load_preferences(ext_id: str) -> JsonConf:
 
 
 class ExtensionController:
+    """Manages the lifecycle of an extension."""
+
     id: str
     path: str
     state: ExtensionState
@@ -91,24 +93,12 @@ class ExtensionController:
             self.state.update(defaults)
 
     @classmethod
-    def create(cls, ext_id: str, path: str | None = None) -> ExtensionController:
-        if not path:
-            path = extension_finder.locate(ext_id)
-            if not path:
-                msg = f"Extension with ID '{ext_id}' not found"
-                raise ExtensionNotFoundError(msg)
-        if controller := controller_cache.get(ext_id):
-            return controller
-        new_controller = cls(ext_id, path)
-        controller_cache[ext_id] = new_controller
-        return new_controller
-
-    @classmethod
     async def install(
         cls, url: str, commit_hash: str | None = None, warn_if_overwrite: bool = True
     ) -> ExtensionController:
         logger.info("Installing extension: %s", url)
         remote = ExtensionRemote(url)
+        is_new_install = not Path(remote.target_dir).exists()
         commit_hash, commit_timestamp = remote.download(commit_hash, warn_if_overwrite)
 
         try:
@@ -120,7 +110,7 @@ class ExtensionController:
             rmtree(remote.target_dir)
             raise
         else:
-            controller = cls.create(remote.ext_id, remote.target_dir)
+            controller = cls(remote.ext_id, remote.target_dir)
             controller.state.save(
                 url=url,
                 browser_url=remote.browser_url or "",
@@ -131,12 +121,9 @@ class ExtensionController:
                 error_message="",
             )
             logger.info("Extension %s installed successfully", controller.id)
+            if is_new_install:
+                lifecycle_events.emit("extensions:installed", controller)
             return controller
-
-    @classmethod
-    def iterate(cls) -> Iterator[ExtensionController]:
-        for ext_id, ext_path in extension_finder.iterate():
-            yield ExtensionController.create(ext_id, ext_path)
 
     @property
     def is_enabled(self) -> bool:
@@ -192,12 +179,13 @@ class ExtensionController:
 
         # non-manageable extension still exists (installed elsewhere)
         if fallback_path := extension_finder.locate(self.id):
-            controller_cache.pop(self.id, None)
-            fallback_ext = ExtensionController.create(self.id, fallback_path)
+            fallback_ext = ExtensionController(self.id, fallback_path)
             fallback_ext.state.save(is_enabled=False)
             logger.info("Non-manageable extension with the same id exists in '%s'", fallback_path)
         elif self._state_path.is_file():
             self._state_path.unlink()
+
+        lifecycle_events.emit("extensions:removed", self.id)
 
     async def update(self) -> bool:
         """
@@ -206,6 +194,7 @@ class ExtensionController:
         logger.debug("Checking for updates to %s", self.id)
         has_update, commit_hash = await self.check_update()
         was_running = self.is_running
+
         if not has_update:
             logger.info('Extension "%s" is already on the latest version', self.id)
             return False
@@ -233,6 +222,7 @@ class ExtensionController:
                 raise
 
         await self.toggle_enabled(was_running)
+        lifecycle_events.emit("extensions:updated", self)
         logger.info("Successfully updated extension: %s", self.id)
 
         return True
@@ -301,11 +291,6 @@ class ExtensionController:
         if runtime := extension_runtimes.pop(self.id, None):
             await runtime.stop()
             self.is_running = False
-
-    @classmethod
-    async def stop_all(cls) -> None:
-        jobs = [c.stop() for c in controller_cache.values() if c.is_running]
-        await asyncio.gather(*jobs)
 
 
 class ExtensionNotFoundError(Exception):

--- a/ulauncher/modes/extensions/extension_mode.py
+++ b/ulauncher/modes/extensions/extension_mode.py
@@ -1,17 +1,21 @@
 from __future__ import annotations
 
 import asyncio
+import contextlib
 import html
 import logging
+from pathlib import Path
 from threading import Thread
 from typing import Any, Iterator, Literal
 
 from ulauncher.internals.query import Query
 from ulauncher.internals.result import ActionMetadata, Result
 from ulauncher.modes.base_mode import BaseMode
-from ulauncher.modes.extensions.extension_controller import ExtensionController
+from ulauncher.modes.extensions.extension_controller import ExtensionController, ExtensionNotFoundError
+from ulauncher.modes.extensions.extension_registry import ExtensionRegistry
 from ulauncher.modes.extensions.extension_socket_server import ExtensionSocketServer
 from ulauncher.utils.eventbus import EventBus
+from ulauncher.utils.singleton import Singleton
 
 DEFAULT_ACTION = True  #  keep window open and do nothing
 logger = logging.getLogger()
@@ -22,15 +26,26 @@ class ExtensionTrigger(Result):
     searchable = True
 
 
-class ExtensionMode(BaseMode):
+class ExtensionMode(BaseMode, metaclass=Singleton):
+    """
+    Mode that handles extension triggers and communication with extensions.
+    Is singleton because it owns the ExtensionSocketServer instance.
+    """
+
     ext_socket_server: ExtensionSocketServer
+    registry: ExtensionRegistry
     active_ext: ExtensionController | None = None
     _trigger_cache: dict[str, tuple[str, str]] = {}  # keyword: (trigger_id, ext_id)
 
     def __init__(self) -> None:
-        self.ext_socket_server = ExtensionSocketServer()
+        self.registry = ExtensionRegistry()
+        self.ext_socket_server = ExtensionSocketServer(self._on_extension_registered)
         self.ext_socket_server.start()
         events.set_self(self)
+
+    def _on_extension_registered(self, ext_id: str, _: Path) -> None:
+        """Callback when an extension successfully registers with the socket server."""
+        self.registry.get_or_raise(ext_id).is_running = True
 
     def handle_query(self, query: Query) -> None:
         if not query.keyword:
@@ -56,7 +71,7 @@ class ExtensionMode(BaseMode):
 
     def get_triggers(self) -> Iterator[Result]:
         self._trigger_cache.clear()
-        for ext in ExtensionController.iterate():
+        for ext in self.registry.iterate():
             if not ext.is_enabled or ext.has_error:
                 continue
 
@@ -92,7 +107,11 @@ class ExtensionMode(BaseMode):
     def run_ext_batch_job(
         self, extension_ids: list[str], jobs: list[Literal["start", "stop"]], done_msg: str | None = None
     ) -> None:
-        ext_controllers = [ExtensionController.create(ext_id) for ext_id in extension_ids]
+        ext_controllers: list[ExtensionController] = []
+        for ext_id in extension_ids:
+            with contextlib.suppress(ExtensionNotFoundError):
+                # suppress so if an extension is removed, it doesn't try to load it
+                ext_controllers.append(self.registry.load(ext_id))
 
         # run the reload in a separate thread to avoid blocking the main thread
         async def run_batch_async() -> None:

--- a/ulauncher/modes/extensions/extension_registry.py
+++ b/ulauncher/modes/extensions/extension_registry.py
@@ -1,0 +1,80 @@
+from __future__ import annotations
+
+import logging
+from typing import Iterator
+
+from ulauncher.modes.extensions import extension_finder
+from ulauncher.modes.extensions.extension_controller import (
+    ExtensionController,
+    ExtensionNotFoundError,
+    lifecycle_events,
+)
+from ulauncher.utils.singleton import Singleton
+
+logger = logging.getLogger()
+
+
+class ExtensionRegistry(metaclass=Singleton):
+    """Central in-memory registry for extension controllers."""
+
+    _registry: dict[str, ExtensionController]
+
+    def __init__(self) -> None:
+        self._registry = {}
+        lifecycle_events.set_self(self)
+
+    def get(self, ext_id: str) -> ExtensionController | None:
+        """Get an extension from the registry."""
+        return self._registry.get(ext_id)
+
+    def get_or_raise(self, ext_id: str) -> ExtensionController:
+        """Get an extension from the registry or raise if not found."""
+        controller = self._registry.get(ext_id)
+        if not controller:
+            msg = f"Extension with ID '{ext_id}' not found in registry"
+            raise ExtensionNotFoundError(msg)
+
+        return controller
+
+    def iterate(self) -> Iterator[ExtensionController]:
+        """Iterate over registered extension controllers."""
+        yield from self._registry.values()
+
+    def load(self, ext_id: str, path: str | None = None) -> ExtensionController:
+        """Load an extension controller into the registry without starting it."""
+        if not path:
+            path = extension_finder.locate(ext_id)
+            if not path:
+                self._registry.pop(ext_id, None)
+                msg = f"Extension with ID '{ext_id}' not found"
+                raise ExtensionNotFoundError(msg)
+
+        controller = ExtensionController(ext_id, path)
+        self._registry[ext_id] = controller
+        return controller
+
+    def load_all(self) -> Iterator[ExtensionController]:
+        """Load all extensions found by the extension finder into the registry."""
+        for ext_id, ext_path in extension_finder.iterate():
+            self.load(ext_id, ext_path)
+
+        yield from self._registry.values()
+
+    @lifecycle_events.on
+    def installed(self, controller: ExtensionController) -> None:
+        """Handle install events dispatched by controllers."""
+        self._registry[controller.id] = controller
+
+    @lifecycle_events.on
+    def updated(self, controller: ExtensionController) -> None:
+        """Handle update events dispatched by controllers."""
+        self._registry[controller.id] = controller
+
+    @lifecycle_events.on
+    def removed(self, ext_id: str) -> None:
+        """Handle removal events dispatched by controllers."""
+        self._registry.pop(ext_id, None)
+
+
+# Instantiate singleton early so event handlers are bound when first emitted
+ExtensionRegistry()

--- a/ulauncher/modes/extensions/extension_socket_controller.py
+++ b/ulauncher/modes/extensions/extension_socket_controller.py
@@ -6,6 +6,7 @@ from typing import Any
 
 from ulauncher.internals.query import Query
 from ulauncher.modes.extensions.extension_controller import ExtensionController
+from ulauncher.modes.extensions.extension_registry import ExtensionRegistry
 from ulauncher.utils.decorator.debounce import debounce
 from ulauncher.utils.eventbus import EventBus
 from ulauncher.utils.framer import JSONFramer
@@ -32,7 +33,8 @@ class ExtensionSocketController:
         self.socket_controllers = socket_controllers
         self.framer: JSONFramer = framer
         self.ext_id = ext_id
-        self.ext_controller = ExtensionController.create(ext_id)
+        registry = ExtensionRegistry()
+        self.ext_controller = registry.get_or_raise(ext_id)
 
         self.socket_controllers[ext_id] = self
         self._debounced_send_event = debounce(self.ext_controller.manifest.input_debounce)(self.send_message)

--- a/ulauncher/modes/extensions/extension_socket_server.py
+++ b/ulauncher/modes/extensions/extension_socket_server.py
@@ -2,16 +2,17 @@ from __future__ import annotations
 
 import logging
 import os
-from typing import Any
+from pathlib import Path
+from typing import Any, Callable
 
 from gi.repository import Gio, GLib, GObject
 
 from ulauncher.internals.query import Query
 from ulauncher.modes.extensions.extension_controller import ExtensionController
+from ulauncher.modes.extensions.extension_registry import ExtensionRegistry
 from ulauncher.modes.extensions.extension_socket_controller import ExtensionSocketController
 from ulauncher.utils.eventbus import EventBus
 from ulauncher.utils.framer import JSONFramer
-from ulauncher.utils.singleton import Singleton
 from ulauncher.utils.socket_path import get_socket_path
 
 logger = logging.getLogger()
@@ -21,18 +22,20 @@ logger = logging.getLogger()
 events = EventBus()
 
 
-class ExtensionSocketServer(metaclass=Singleton):
+class ExtensionSocketServer:
     socket_path: str
     service: Gio.SocketService | None
     socket_controllers: dict[str, ExtensionSocketController]
     pending: dict[int, tuple[JSONFramer, int, int]]
     active_socket_controller: ExtensionSocketController | None = None
+    on_extension_registered: Callable[[str, Path], None]
 
-    def __init__(self) -> None:
+    def __init__(self, on_extension_registered: Callable[[str, Path], None]) -> None:
         self.service = None
         self.socket_path = get_socket_path()
         self.socket_controllers = {}
         self.pending = {}
+        self.on_extension_registered = on_extension_registered
         events.set_self(self)
 
     def start(self) -> None:
@@ -50,7 +53,8 @@ class ExtensionSocketServer(metaclass=Singleton):
         self.socket_controllers = {}
 
         def start_extensions() -> None:
-            for ext_controller in ExtensionController.iterate():
+            registry = ExtensionRegistry()
+            for ext_controller in registry.load_all():
                 if ext_controller.is_enabled and not ext_controller.has_error:
                     ext_controller.start_detached()
 
@@ -83,10 +87,11 @@ class ExtensionSocketServer(metaclass=Singleton):
                 for msg_id in pended[1:]:
                     GObject.signal_handler_disconnect(framer, msg_id)
             ext_id: str | None = event.get("ext_id")
+            path: str | None = event.get("path")
             assert ext_id
+            assert path
             ExtensionSocketController(self.socket_controllers, framer, ext_id)
-            # TODO: This is ugly, but we have no other way to detect the extension started successfully
-            ExtensionController.create(ext_id).is_running = True
+            self.on_extension_registered(ext_id, Path(path))
         else:
             logger.debug("Unhandled message received: %s", event)
 

--- a/ulauncher/ui/preferences_server.py
+++ b/ulauncher/ui/preferences_server.py
@@ -14,6 +14,7 @@ from gi.repository import Gio, GLib, Gtk
 from ulauncher import api_version, paths, version
 from ulauncher.modes.extensions import extension_finder
 from ulauncher.modes.extensions.extension_controller import ExtensionController
+from ulauncher.modes.extensions.extension_registry import ExtensionRegistry
 from ulauncher.modes.shortcuts.shortcuts_db import ShortcutsDb
 from ulauncher.utils.decorator.run_async import run_async
 from ulauncher.utils.environment import IS_X11
@@ -243,10 +244,11 @@ class PreferencesServer:
     @route("/extension/get-all")
     async def extension_get_all(self, reload: bool) -> dict[str, dict[str, Any]]:
         logger.info("Handling /extension/get-all")
+        registry = ExtensionRegistry()
         if reload:
-            tasks = [controller.start() for controller in ExtensionController.iterate() if controller.is_enabled]
+            tasks = [controller.start() for controller in registry.iterate() if controller.is_enabled]
             await asyncio.gather(*tasks)
-        return {ex.id: get_extension_data(ex) for ex in ExtensionController.iterate()}
+        return {ex.id: get_extension_data(ex) for ex in registry.iterate()}
 
     @route("/extension/add")
     async def extension_add(self, url: str) -> dict[str, Any]:
@@ -262,29 +264,34 @@ class PreferencesServer:
         events.emit("extensions:update_preferences", ext_id, data)
         # Note: Must save after emitting because the event above need access to
         # both the new and old data
-        ExtensionController.create(ext_id).save_user_preferences(data)
+        registry = ExtensionRegistry()
+        registry.get_or_raise(ext_id).save_user_preferences(data)
 
     @route("/extension/check-update")
     async def extension_check_update(self, ext_id: str) -> tuple[bool, str]:
         logger.info("Checking if extension has an update")
-        controller = ExtensionController.create(ext_id)
+        registry = ExtensionRegistry()
+        controller = registry.get_or_raise(ext_id)
         return await controller.check_update()
 
     @route("/extension/update-ext")
     async def extension_update_ext(self, ext_id: str) -> dict[str, Any]:
         logger.info("Update extension: %s", ext_id)
-        controller = ExtensionController.create(ext_id)
+        registry = ExtensionRegistry()
+        controller = registry.get_or_raise(ext_id)
         await controller.update()
         return get_extension_data(controller)
 
     @route("/extension/remove")
     async def extension_remove(self, ext_id: str) -> None:
         logger.info("Remove extension: %s", ext_id)
-        controller = ExtensionController.create(ext_id)
+        registry = ExtensionRegistry()
+        controller = registry.get_or_raise(ext_id)
         await controller.remove()
 
     @route("/extension/toggle-enabled")
     async def extension_toggle_enabled(self, ext_id: str, is_enabled: bool) -> None:
         logger.info("Toggle extension: %s on: %s", ext_id, is_enabled)
-        controller = ExtensionController.create(ext_id)
+        registry = ExtensionRegistry()
+        controller = registry.get_or_raise(ext_id)
         await controller.toggle_enabled(is_enabled)

--- a/ulauncher/utils/migrate.py
+++ b/ulauncher/utils/migrate.py
@@ -56,13 +56,14 @@ def _migrate_app_state(old_format: dict[str, int]) -> dict[str, int]:
 
 
 def _migrate_user_prefs(ext_id: str, user_prefs: dict[str, dict[str, Any]]) -> dict[str, dict[str, Any]]:
-    from ulauncher.modes.extensions.extension_controller import ExtensionController
+    from ulauncher.modes.extensions.extension_registry import ExtensionRegistry
 
     # Check if already migrated
     if sorted(user_prefs.keys()) == ["preferences", "triggers"]:
         return user_prefs
     new_prefs: dict[str, dict[str, Any]] = {"preferences": {}, "triggers": {}}
-    controller = ExtensionController.create(ext_id)
+    registry = ExtensionRegistry()
+    controller = registry.load(ext_id)
     for p_id, pref in user_prefs.items():
         try:
             if controller.manifest.triggers.get(p_id):


### PR DESCRIPTION
The main reason I need this is to have an in-memory extension registry. It will allow registering temporary (preview) extensions.
Other changes are to make the related classes cleaner.