### PR TITLE
chore: replace type linter mypy with pyrefly

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -14,10 +14,12 @@ jobs:
       - uses: actions/checkout@v5
       - name: ruff
         run: make ruff
+      - name: pyrefly
+        run: make pyrefly
       - name: typo
         run: make typos
       - name: mypy
-        run: make mypy
+        run: mypy ulauncher
       - name: pytest
         run: make pytest
       - name: build docs

--- a/lefthook.toml
+++ b/lefthook.toml
@@ -24,7 +24,7 @@ run = """
   """
 stage_fixed = true
 
-[pre-commit.commands.mypy]
+[pre-commit.commands.pyrefly]
 root = "ulauncher"
 glob = "*.py"
-run = "mypy {staged_files}"
+run = "pyrefly check {staged_files}"

--- a/makefile
+++ b/makefile
@@ -103,7 +103,7 @@ run-container: # Start a bash session in the Ulauncher Docker build container (U
 
 #=Lint/test Commands
 
-.PHONY: check mypy ruff typos pytest test format check-dev-deps
+.PHONY: check pyrefly ruff typos pytest test format check-dev-deps
 
 check-dev-deps: # Check if development dependencies are properly installed
 	@set -euo pipefail
@@ -124,12 +124,12 @@ check-dev-deps: # Check if development dependencies are properly installed
 		exit 1
 	fi
 
-check: check-dev-deps typos ruff mypy # Run all linters
+check: check-dev-deps typos ruff pyrefly # Run all linters
 
 test: check pytest # Run all linters and test
 
-mypy: check-dev-deps # Lint with mypy (type checker)
-	mypy ulauncher
+pyrefly: check-dev-deps # Lint with pyrefly (type checker)
+	pyrefly check
 
 ruff: check-dev-deps # Lint with ruff
 	ruff check . && ruff format --check .

--- a/nix/default.nix
+++ b/nix/default.nix
@@ -16,10 +16,10 @@
 , libX11
 , libappindicator
 , librsvg
-, mypy
 , nix-update-script
 , procps
 , python3Packages
+, pyrefly
 , setuptools ? python3Packages.setuptools
 , setuptools-scm ? python3Packages.setuptools-scm
 , ruff
@@ -44,7 +44,7 @@ let
     pytest-mock
   ]);
   packages.tests.system = [
-    mypy
+    pyrefly
     ruff
     typos
     xvfb-run # xvfb-run tests fail

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,6 +23,14 @@ dynamic = ["version", "license"]
 [tool.setuptools.dynamic]
 version = {attr = "ulauncher.version"}
 
+[tool.pyrefly]
+python-platform = "linux"
+python-version = "3.8"
+project-includes = ["ulauncher"]
+
+[tool.pyrefly.errors]
+bad-param-name-override = false
+
 [tool.mypy]
 python_version = "3.8"
 strict = true

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,7 @@
 build
 lefthook
 mypy < 1.17.0
+pyrefly >= 0.42.0
 pytest
 pytest-mock
 ruff >= 0.14.4

--- a/ulauncher/app.py
+++ b/ulauncher/app.py
@@ -29,7 +29,7 @@ class UlauncherApp(Gtk.Application):
     # So all methods except __init__ runs on the main app
     query = ""
     windows: WeakValueDictionary[Literal["main", "preferences"], Gtk.ApplicationWindow] = WeakValueDictionary()
-    _tray_icon: ulauncher.ui.tray_icon.TrayIcon | None = None
+    _tray_icon: ulauncher.ui.tray_icon.TrayIcon | None = None  # pyrefly: ignore[implicit-import]
 
     def __call__(self, *args: Any, **kwargs: Any) -> UlauncherApp:
         return cast("UlauncherApp", get_instance(super(), self, *args, **kwargs))
@@ -171,5 +171,5 @@ class UlauncherApp(Gtk.Application):
         self.hold() if value else self.release()
 
     @events.on
-    def quit(self) -> None:
+    def quit(self) -> None:  # pyrefly: ignore[bad-override]
         super().quit()

--- a/ulauncher/modes/calc/calc_mode.py
+++ b/ulauncher/modes/calc/calc_mode.py
@@ -114,7 +114,8 @@ def _is_enabled(query_str: str) -> bool:
 
 def _eval(node: ast.expr) -> int | float | Decimal:
     if isinstance(node, ast.Constant):  # <constant> (number)
-        value = node.value if hasattr(node, "value") else node.n  # older versions of python has .n instead of .value
+        # older versions of python has .n instead of .value
+        value = node.value if hasattr(node, "value") else node.n  # pyrefly: ignore[deprecated]
         return Decimal(str(value))
     if isinstance(node, ast.BinOp):  # <left> <operator> <right>
         operator = operators.get(type(node.op))

--- a/ulauncher/modes/extensions/extension_mode.py
+++ b/ulauncher/modes/extensions/extension_mode.py
@@ -5,7 +5,7 @@ import contextlib
 import html
 import logging
 from threading import Thread
-from typing import Any, Iterator, Literal
+from typing import Any, Callable, Iterator, Literal, cast
 
 from ulauncher.internals.query import Query
 from ulauncher.internals.result import ActionMetadata, Result
@@ -98,7 +98,10 @@ class ExtensionMode(BaseMode, metaclass=Singleton):
         Called when a result is activated.
         Override this method to handle the activation of a result.
         """
-        handler = getattr(result, "on_alt_enter" if alt else "on_enter", DEFAULT_ACTION)
+        handler = cast(
+            "ActionMetadata | Callable[[Query], ActionMetadata]",
+            getattr(result, "on_alt_enter" if alt else "on_enter", DEFAULT_ACTION),
+        )
         return handler(query) if callable(handler) else handler
 
     def run_ext_batch_job(

--- a/ulauncher/ui/layer_shell.py
+++ b/ulauncher/ui/layer_shell.py
@@ -1,3 +1,4 @@
+# pyrefly: ignore-errors
 """
 Allows for a window to opt in to the wayland layer shell protocol.
 

--- a/ulauncher/ui/tray_icon.py
+++ b/ulauncher/ui/tray_icon.py
@@ -100,7 +100,11 @@ class TrayIcon(GObject.Object):
 
         elif tray_icon_lib == "AyatanaIndicator":
             app_status = AyatanaIndicator.IndicatorCategory.APPLICATION_STATUS
-            self.aya_indicator = AyatanaIndicator.Indicator.new("ulauncher", icon_name, app_status)
+            self.aya_indicator = AyatanaIndicator.Indicator.new(
+                "ulauncher",
+                icon_name,
+                app_status,  # pyrefly: ignore[ bad-argument-type]
+            )
             if icon_dir:
                 self.aya_indicator.set_icon_theme_path(icon_dir)
 

--- a/ulauncher/utils/ewmh.py
+++ b/ulauncher/utils/ewmh.py
@@ -1,3 +1,4 @@
+# pyrefly: ignore-errors
 # mypy: ignore-errors
 # ruff: noqa: PGH004
 # ruff: noqa
@@ -15,7 +16,7 @@ See the freedesktop.org `specification
 information.
 """
 
-from Xlib import display, X, protocol
+from Xlib import display, X, xobject, protocol
 import time
 
 
@@ -272,7 +273,7 @@ class EWMH:
         """
         return [self._createWindow(w) for w in self._getProperty("_NET_CLIENT_LIST")]
 
-    def getClientListStacking(self):
+    def getClientListStacking(self) -> list[xobject.drawable.Window]:
         """
         Get the list of windows maintained by the window manager for the
         property _NET_CLIENT_LIST_STACKING.

--- a/ulauncher/utils/load_icon_surface.py
+++ b/ulauncher/utils/load_icon_surface.py
@@ -7,7 +7,7 @@ from typing import TYPE_CHECKING
 from ulauncher import paths
 
 if TYPE_CHECKING:
-    from cairo import ImageSurface
+    from cairo import ImageSurface  # pyrefly: ignore - this fails in our docker image for some reason
 
 
 logger = logging.getLogger()


### PR DESCRIPTION
I tested Pyrefly when it was first released as alpha and was impressed, but it didn't seem to support out Gtk type stubs. [Now it just hit beta](https://github.com/facebook/pyrefly/releases/tag/0.42.0). I tested it again and it does support them now :+1:  It runs insanely fast, and it was even better in my IDE (Zed defaults to basedpyright, but the pyrefly extension made it **much** faster AND better)

I couldn't find any feature parity comparison with mypy, so I don't know if we should migrate away from mypy yet, so I didn't do that. But I noticed for example that despite being so fast, it had type inference for untyped code (which is why I had to add ignore comments, cast or similar.

To test it, run `make python-venv`  to install, then `pyrefly check` 

I also tested ty, which worked great and even ran faster, but it didn't feel as ready (more false positives), and it didn't infer untyped code to types.

The CI fails because it has an outdated ruff version in the dockerhub image, but it would still fail if it wasn't for that because we added pyrefly now which is not in ci either.