### PR TITLE
refactor: simplify glib timer wrapper

### DIFF
--- a/tests/utils/test_timer.py
+++ b/tests/utils/test_timer.py
@@ -12,22 +12,11 @@ class TestTimer:
     def glib(self, mocker: MockerFixture) -> MagicMock:
         return mocker.patch("ulauncher.utils.timer.GLib")
 
-    def test_timer_subsecond(self, glib: MagicMock) -> None:
+    def test_timer(self, glib: MagicMock) -> None:
         func = Mock()
-        subsecond_time = 0.5
-        ctx = timer(subsecond_time, func)
-        glib.timeout_source_new.assert_called_with(subsecond_time * 1000)
-        src: Any = ctx.source
-        ctx.trigger(None)
-        func.assert_called_once()
-        ctx.cancel()
-        src.destroy.assert_called_once()
-
-    def test_timer_second(self, glib: MagicMock) -> None:
-        func = Mock()
-        seconds_time = 2
-        ctx = timer(seconds_time, func)
-        glib.timeout_source_new_seconds.assert_called_with(seconds_time)
+        time = 0.1
+        ctx = timer(time, func)
+        glib.timeout_source_new.assert_called_with(time * 1000)
         src: Any = ctx.source
         ctx.trigger(None)
         func.assert_called_once()

--- a/ulauncher/utils/timer.py
+++ b/ulauncher/utils/timer.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import math
 from typing import Any, Callable
 
 from gi.repository import GLib
@@ -41,11 +40,6 @@ def timer(delay_sec: float, func: Callable[[], None], repeat: bool = False) -> T
     To cancel the timer, call `.cancel()` on the returned object.
 
     """
-    frac, _ = math.modf(delay_sec)
-    source = (
-        GLib.timeout_source_new_seconds(int(delay_sec))
-        if frac == 0
-        else GLib.timeout_source_new(int(delay_sec * 1000.0))
-    )
+    source = GLib.timeout_source_new(int(delay_sec * 1000.0))
 
     return TimerContext(source, func, repeat)


### PR DESCRIPTION
I think this should work the same? Unless there is some benefit to using `timeout_source_new_seconds(1)` over `timeout_source_new(1000)`

Also, there is already a simplified GLib method for this `GLib.timeout_add(timeout_ms, callback)` . When using that the timeout will repeat when the callback returns `True` though. I think that feels a bit risky, but that's also how `GLib.idle_add()` works, so it's a footgun we already have to be aware of.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Streamlined internal timer implementation logic while maintaining existing functionality.

* **Tests**
  * Consolidated timer test scenarios for improved test suite efficiency.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->