### PR TITLE
refactor: extension custom exception handling rewrite

### DIFF
--- a/tests/modes/apps/extensions/test_extension_manifest.py
+++ b/tests/modes/apps/extensions/test_extension_manifest.py
@@ -4,11 +4,8 @@ import os
 
 import pytest
 
-from ulauncher.modes.extensions.extension_manifest import (
-    ExtensionIncompatibleRecoverableError,
-    ExtensionManifest,
-    ExtensionManifestError,
-)
+from ulauncher.modes.extensions import ext_exceptions
+from ulauncher.modes.extensions.extension_manifest import ExtensionManifest
 from ulauncher.utils.json_utils import json_stringify
 
 valid_manifest: dict[str, str | dict[str, dict[str, str]]] = {
@@ -28,7 +25,7 @@ class TestExtensionManifest:
 
     def test_validate__name_empty__exception_raised(self) -> None:
         manifest = ExtensionManifest({"api_version": "1"})
-        with pytest.raises(ExtensionManifestError):
+        with pytest.raises(ext_exceptions.ManifestError):
             manifest.validate()
 
     def test_validate__valid_manifest__no_exceptions_raised(self) -> None:
@@ -38,19 +35,19 @@ class TestExtensionManifest:
     def test_validate__prefs_incorrect_type__exception_raised(self) -> None:
         valid_manifest["preferences"] = {"id": {"type": "incorrect"}}
         manifest = ExtensionManifest(valid_manifest)
-        with pytest.raises(ExtensionManifestError):
+        with pytest.raises(ext_exceptions.ManifestError):
             manifest.validate()
 
     def test_validate__type_kw_empty_name__exception_raised(self) -> None:
         valid_manifest["preferences"] = {"id": {"type": "incorrect", "keyword": "kw"}}
         manifest = ExtensionManifest(valid_manifest)
-        with pytest.raises(ExtensionManifestError):
+        with pytest.raises(ext_exceptions.ManifestError):
             manifest.validate()
 
     def test_validate__raises_error_if_empty_default_value_for_keyword(self) -> None:
         valid_manifest["preferences"] = {"id": {"type": "keyword", "name": "My Keyword"}}
         manifest = ExtensionManifest(valid_manifest)
-        with pytest.raises(ExtensionManifestError):
+        with pytest.raises(ext_exceptions.ManifestError):
             manifest.validate()
 
     def test_validate__doesnt_raise_if_empty_default_value_for_non_keyword(self) -> None:
@@ -62,7 +59,7 @@ class TestExtensionManifest:
 
     def test_check_compatibility__manifest_version_0__exception_raised(self) -> None:
         manifest = ExtensionManifest({"name": "Test", "api_version": "0"})
-        with pytest.raises(ExtensionIncompatibleRecoverableError):
+        with pytest.raises(ext_exceptions.CompatibilityError):
             manifest.check_compatibility()
 
     def test_check_compatibility__api_version__no_exceptions(self) -> None:

--- a/tests/modes/apps/extensions/test_extension_remote.py
+++ b/tests/modes/apps/extensions/test_extension_remote.py
@@ -2,9 +2,9 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
+from ulauncher.modes.extensions import ext_exceptions
 from ulauncher.modes.extensions.extension_remote import (
     ExtensionRemote,
-    InvalidExtensionRecoverableError,
     parse_extension_url,
 )
 
@@ -17,7 +17,7 @@ class TestExtensionRemote:
         return ExtensionRemote("https://github.com/Ulauncher/ulauncher-timer")
 
     def test_invalid_url(self) -> None:
-        with pytest.raises(InvalidExtensionRecoverableError):
+        with pytest.raises(ext_exceptions.UrlError):
             ExtensionRemote("INVALID URL")
 
 

--- a/ulauncher/modes/extensions/ext_exceptions.py
+++ b/ulauncher/modes/extensions/ext_exceptions.py
@@ -1,0 +1,29 @@
+from __future__ import annotations
+
+
+class ExtensionError(Exception):
+    """Base class for all extension-related errors that can be caught together."""
+
+
+class ManifestError(ExtensionError):
+    """Raised when extension manifest is invalid or missing required fields."""
+
+
+class NetworkError(ExtensionError):
+    """Raised when there's a network error accessing the extension repository."""
+
+
+class UrlError(ExtensionError):
+    """Raised when extension URL/path cannot be parsed."""
+
+
+class RemoteError(ExtensionError):
+    """Raised when there's an error with the remote extension repository (not network-related)."""
+
+
+class CompatibilityError(ExtensionError):
+    """Raised when extension is incompatible with current Ulauncher API version."""
+
+
+class DependencyError(ExtensionError):
+    """Raised when extension Python dependencies cannot be installed."""

--- a/ulauncher/modes/extensions/extension_dependencies.py
+++ b/ulauncher/modes/extensions/extension_dependencies.py
@@ -5,11 +5,9 @@ import subprocess
 import sys
 from os.path import isdir, isfile
 
+from ulauncher.modes.extensions import ext_exceptions
+
 logger = logging.getLogger()
-
-
-class ExtensionDependenciesRecoverableError(Exception):
-    pass
 
 
 class ExtensionDependencies:
@@ -68,7 +66,7 @@ class ExtensionDependencies:
             logger.exception("Error during installation. Output: %s", e.stderr)
 
             err_msg = f"$ {command_str}\n{e.stderr}"
-            raise ExtensionDependenciesRecoverableError(err_msg) from e
+            raise ext_exceptions.DependencyError(err_msg) from e
 
     def _read_requirements(self) -> str | None:
         """


### PR DESCRIPTION
### Simplified/improved custom error handling

1. Made all exceptions inherit from one ExtensionError, so we can choose to catch that instead of multiple specific ones, or worse: catching "Exception".
1. Created module that defines all extension exceptions, so we don't have to import the error from the class it's thrown, as that caused a lot of import declarations
1. For similar reasons, import the whole module and use as a namespace.
1. Drop the "RecoverableError" namespace. It used to have some significance with the previous preferences web app. We used to check if the error name ended with that, but that error handling hack seems to have disappeared, and also, we only needed that due to losing the error details in the json serialization.  If we wanted this back, we should make RecoverableExtensionError inherit from ExtensuionError and the specific types deemed to be "recoverable" should inherit from RecoverableExtensionError.
1. Some unrelared name changed (after already dropping "Recoverable"):
    * `InvalidExtensionError` -> `UrlError` (because that's what it was used for)
    * `IncompatibleError` -> `CompatibilityError`
    * `DependenciesError` -> `DependencyError`