### PR TITLE
refactor: avoid item navigation needing access to core

### DIFF
--- a/tests/ui/test_item_navigation.py
+++ b/tests/ui/test_item_navigation.py
@@ -12,16 +12,12 @@ from ulauncher.ui.result_widget import ResultWidget
 
 class TestItemNavigation:
     @pytest.fixture
-    def core(self) -> MagicMock:
-        return MagicMock()
-
-    @pytest.fixture
     def items(self) -> list[MagicMock]:
         return [MagicMock() for _ in range(5)]
 
     @pytest.fixture
-    def nav(self, core: Any, items: list[ResultWidget]) -> ItemNavigation:
-        return ItemNavigation(core, items)
+    def nav(self, items: list[ResultWidget]) -> ItemNavigation:
+        return ItemNavigation(items)
 
     @pytest.fixture(autouse=True)
     def query_history(self, mocker: MockerFixture) -> Any:

--- a/ulauncher/ui/item_navigation.py
+++ b/ulauncher/ui/item_navigation.py
@@ -6,7 +6,7 @@ from ulauncher import paths
 from ulauncher.utils.json_utils import json_load, json_save
 
 if TYPE_CHECKING:
-    from ulauncher.core import UlauncherCore
+    from ulauncher.internals.result import Result
     from ulauncher.ui.result_widget import ResultWidget
 
 query_history_path = f"{paths.STATE}/query_history.json"
@@ -18,12 +18,10 @@ class ItemNavigation:
     Performs navigation through found results
     """
 
-    core: UlauncherCore
     result_widgets: list[ResultWidget]
     index = 0
 
-    def __init__(self, core: UlauncherCore, result_widgets: list[ResultWidget]) -> None:
-        self.core = core
+    def __init__(self, result_widgets: list[ResultWidget]) -> None:
         self.result_widgets = result_widgets
 
     @property
@@ -32,19 +30,19 @@ class ItemNavigation:
             return self.result_widgets[self.index]
         return None
 
-    def get_default(self) -> int:
+    def get_default(self, query: str) -> int:
         """
         Get the index of the result that should be selected (0 by default)
         """
-        previous_pick = query_history.get(str(self.core.query))
+        previous_pick = query_history.get(query)
 
         for index, widget in enumerate(self.result_widgets):
             if widget.result.searchable and widget.result.name == previous_pick:
                 return index
         return 0
 
-    def select_default(self) -> None:
-        self.select(self.get_default())
+    def select_default(self, query: str) -> None:
+        self.select(self.get_default(query))
 
     def select(self, index: int) -> None:
         if not 0 < index < len(self.result_widgets):
@@ -63,12 +61,13 @@ class ItemNavigation:
         next_result = (self.index or 0) + 1
         self.select(next_result if next_result < len(self.result_widgets) else 0)
 
-    def activate(self, alt: bool = False) -> None:
-        assert self.selected_item
-        result = self.selected_item.result
-        query_str = str(self.core.query)
-        if query_str and not alt and result.searchable:
-            query_history[query_str] = result.name
-            json_save(query_history, query_history_path)
+    def get_active_result(self) -> Result | None:
+        if self.selected_item:
+            return self.selected_item.result
+        return None
 
-        self.core.activate_result(result, alt)
+    def remember_result_for_query(self, query: str, result: Result) -> None:
+        """Mark as activated in query history"""
+        if query and result.searchable:
+            query_history[query] = result.name
+            json_save(query_history, query_history_path)

--- a/ulauncher/ui/windows/ulauncher_window.py
+++ b/ulauncher/ui/windows/ulauncher_window.py
@@ -229,8 +229,10 @@ class UlauncherWindow(Gtk.ApplicationWindow):
         """
         Activate the selected result
         """
-        if self._results_nav:
-            self._results_nav.activate(alt)
+        if self._results_nav and (result := self._results_nav.get_active_result()):
+            self.core.activate_result(result, alt)
+            if not alt:
+                self._results_nav.remember_result_for_query(str(self.core.query), result)
 
     def on_input_key_press(self, entry_widget: Gtk.Entry, event: Gdk.EventKey) -> bool:  # noqa: PLR0911
         """
@@ -285,7 +287,7 @@ class UlauncherWindow(Gtk.ApplicationWindow):
                 return True
 
             if keyname in ("Return", "KP_Enter"):
-                self._results_nav.activate(alt)
+                self.activate_result(alt)
                 return True
             if alt and event.string in jump_keys:
                 self.select_result(jump_keys.index(event.string))
@@ -418,8 +420,8 @@ class UlauncherWindow(Gtk.ApplicationWindow):
                 result_widgets.append(result_widget)
                 self.results.add(result_widget)
 
-            self._results_nav = ItemNavigation(self.core, result_widgets)
-            self._results_nav.select_default()
+            self._results_nav = ItemNavigation(result_widgets)
+            self._results_nav.select_default(str(self.core.query))
 
             self.results.set_margin_bottom(10)
             self.results.set_margin_top(3)


### PR DESCRIPTION
Isolating these for later benefits for the window -> core communication