### PR TITLE
fix: misleading validation messages if passing falsy value that's not a str

### DIFF
--- a/ulauncher/internals/actions.py
+++ b/ulauncher/internals/actions.py
@@ -87,26 +87,26 @@ def copy(text: str) -> Copy:
 
 
 def open(item: str) -> Open:  # noqa: A001
-    if not item:
-        msg = "Open argument cannot be empty"
-        logger.error(msg)
-        raise ValueError(msg)
     if not isinstance(item, str):
         msg = f'Open argument "{item}" is invalid. It must be a string'
         logger.error(msg)
         raise TypeError(msg)
+    if not item:
+        msg = "Open argument cannot be empty"
+        logger.error(msg)
+        raise ValueError(msg)
     return {"type": "action:open", "data": item}
 
 
 def run_script(script: str, args: str = "") -> LegacyRunScript:
-    if not script:
-        msg = "Script argument cannot be empty"
-        logger.error(msg)
-        raise ValueError(msg)
     if not isinstance(script, str):
         msg = f'Script argument "{script}" is invalid. It must be a string'
         logger.error(msg)
         raise TypeError(msg)
+    if not script:
+        msg = "Script argument cannot be empty"
+        logger.error(msg)
+        raise ValueError(msg)
     return {"type": "action:legacy_run_script", "data": [script, args]}
 
 


### PR DESCRIPTION
If someone passas for example an empty list we should complain about the type first rather than guiding them in the wrong direction

[Suggested by coderabbit](https://github.com/Ulauncher/Ulauncher/pull/1586#pullrequestreview-3611200963), but out of scope for #1586

(#1586 must be merged before this). 