### PR TITLE
refactor: remove misleading result callback handling

### DIFF
--- a/ulauncher/modes/extensions/extension_mode.py
+++ b/ulauncher/modes/extensions/extension_mode.py
@@ -4,7 +4,7 @@ import asyncio
 import html
 import logging
 from threading import Thread
-from typing import Any, Callable, Iterable, Iterator, Literal, cast
+from typing import Any, Callable, Iterable, Iterator, Literal
 
 from gi.repository import GLib
 
@@ -115,17 +115,12 @@ class ExtensionMode(BaseMode, metaclass=Singleton):
             return self.active_ext.get_normalized_icon_path()
         return None
 
-    def activate_result(self, result: Result, query: Query, alt: bool) -> ActionMessage | list[Result]:
+    def activate_result(self, result: Result, _query: Query, alt: bool) -> ActionMessage | list[Result]:
         """
         Called when a result is activated.
         Override this method to handle the activation of a result.
         """
-        # TODO: Try to improve the type and avoid casting
-        handler = cast(
-            "ActionMessage | list[Result] | Callable[[Query], ActionMessage | list[Result]]",
-            getattr(result, "on_alt_enter" if alt else "on_enter", actions.do_nothing()),
-        )
-        return handler(query) if callable(handler) else handler
+        return getattr(result, "on_alt_enter" if alt else "on_enter", actions.do_nothing())
 
     def run_ext_batch_job(
         self, extension_ids: list[str], jobs: list[Literal["start", "stop"]], callback: Callable[[], None] | None = None


### PR DESCRIPTION
This was a remainder from the v5 implementation details. It confused me because there is no way for the extension result to still have callback after going through JSON serialization. No one has complained about extensions breaking in v6, even though we probably switched to use JSON a couple of years ago.

Then I looked into it:
In v5, the ResultItem class itself had an "on_enter" method. Our internal result items like CalcResultItem etc used that directly. The ExtensionResultItem took an `on_enter` constructor param and the constructor stored it as `_on_enter`. Then `on_enter()` for extension results just returned self._on_enter. So in effect this was a callback then, but only because of the internal implementation details, which we have changed (for the better).

Getting rid of the "cast" is great too, but the typing is still weak (Any)