### PR TITLE
fix: don't convert empty list to do_nothing action

### DIFF
--- a/ulauncher/modes/extensions/extension_mode.py
+++ b/ulauncher/modes/extensions/extension_mode.py
@@ -123,8 +123,8 @@ class ExtensionMode(BaseMode, metaclass=Singleton):
         Called when a result is activated.
         Override this method to handle the activation of a result.
         """
-        action = result.on_alt_enter if alt else result.on_enter
-        return action or actions.do_nothing()
+        action_msg = result.on_alt_enter if alt else result.on_enter
+        return actions.do_nothing() if action_msg is None else action_msg
 
     def run_ext_batch_job(
         self, extension_ids: list[str], jobs: list[Literal["start", "stop"]], callback: Callable[[], None] | None = None


### PR DESCRIPTION
If the action message would be an empty result list it would be converted to actions.do_nothing() here (introduced in [#1590](https://github.com/Ulauncher/Ulauncher/issues/1590)).