### PR TITLE
refactor: move query debounce to the extension

### DIFF
--- a/ulauncher/modes/extensions/extension_controller.py
+++ b/ulauncher/modes/extensions/extension_controller.py
@@ -22,7 +22,6 @@ from ulauncher.modes.extensions.extension_manifest import (
 )
 from ulauncher.modes.extensions.extension_remote import ExtensionRemote
 from ulauncher.modes.extensions.extension_runtime import ExtensionRuntime
-from ulauncher.utils.decorator.debounce import debounce
 from ulauncher.utils.eventbus import EventBus
 from ulauncher.utils.get_icon_path import get_icon_path
 from ulauncher.utils.json_conf import JsonConf
@@ -77,7 +76,6 @@ class ExtensionController:
     is_manageable: bool
     is_preview: bool = False
     shadowed_by_preview: bool = False
-    debounced_send_message: Callable[[dict[str, Any]], None]
     _state_path: Path
 
     def __init__(self, ext_id: str, path: str) -> None:
@@ -85,7 +83,6 @@ class ExtensionController:
         self.path = path
         self.manifest = ExtensionManifest.load(path)
         self.is_manageable = extension_finder.is_manageable(path)
-        self.debounced_send_message = debounce(self.manifest.input_debounce)(self.send_message)
         self._state_path = Path(f"{paths.EXTENSIONS_STATE}/{self.id}.json")
         self.state = ExtensionState.load(self._state_path)
 
@@ -289,6 +286,7 @@ class ExtensionController:
                 "PYTHONPATH": ":".join(x for x in [paths.APPLICATION, ext_deps.get_dependencies_path()] if x),
                 "EXTENSION_PREFERENCES": json.dumps(v2_prefs, separators=(",", ":")),
                 "ULAUNCHER_EXTENSION_ID": self.id,
+                "ULAUNCHER_INPUT_DEBOUNCE": str(self.manifest.input_debounce),
             }
 
             extension_runtimes[self.id] = ExtensionRuntime(self.id, cmd, env, exit_handler)

--- a/ulauncher/modes/extensions/extension_mode.py
+++ b/ulauncher/modes/extensions/extension_mode.py
@@ -83,7 +83,7 @@ class ExtensionMode(BaseMode, metaclass=Singleton):
                     "interaction_id": self._interaction_id,
                 }
 
-                self.active_ext.debounced_send_message(event)
+                self.active_ext.send_message(event)
                 return
 
         msg = f"Query not valid for extension mode '{query}'"


### PR DESCRIPTION
This is arguably also a fix: We use the incoming input (query) change events to invalidate outdated responses, but when we also debounce from the app, it means this information is not current, so we send responses unnecessaily.

One could argue that this change means we instead send events from the app to the extension unnecessarily, which is true. But I do think it makes a more consistent control flow for both sides if we send all event types the same way and can rely on them to be recieved in time.

Additionally, we could use this information to cancel ongoing threads (I just think that needs more refactoring first).