### PR TITLE
chore: rename make check -> make lint, and make test -> make check

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -8,6 +8,6 @@ https://github.com/Ulauncher/Ulauncher#code-contribution
 * When applicable, please update the documentation according to your changes.
 * Ensure that the PR doesn't break existing tests, and please add your own if applicable.
 
-A git action will verify your PR, but you can also test locally with `make test`
+A git action will verify your PR, but you can also test locally with `make check`
 
 -->

--- a/.github/workflows/draft-release.yml
+++ b/.github/workflows/draft-release.yml
@@ -11,8 +11,8 @@ jobs:
     container: ulauncher/build-image:6.4
     steps:
       - uses: actions/checkout@v5
-      - name: Test
-        run: make test
+      - name: Check
+        run: make check
       - name: Build release
         run: |
           VERSION=$(make version)

--- a/makefile
+++ b/makefile
@@ -103,7 +103,7 @@ run-container: # Start a bash session in the Ulauncher Docker build container (U
 
 #=Lint/test Commands
 
-.PHONY: check pyrefly ruff typos pytest test format check-dev-deps
+.PHONY: check lint format pyrefly ruff typos pytest check-dev-deps
 
 check-dev-deps: # Check if development dependencies are properly installed
 	@set -euo pipefail
@@ -124,9 +124,9 @@ check-dev-deps: # Check if development dependencies are properly installed
 		exit 1
 	fi
 
-check: check-dev-deps typos ruff pyrefly # Run all linters
+lint: check-dev-deps typos ruff pyrefly # Run all linters
 
-test: check pytest # Run all linters and test
+check: lint pytest # Run all linters and test
 
 pyrefly: check-dev-deps # Lint with pyrefly (type checker)
 	pyrefly check

--- a/nix/default.nix
+++ b/nix/default.nix
@@ -136,7 +136,7 @@ let
 
         makeWrapper "$(command -v make)" "$test_dir/bin/make" "''${makeWrapperArgs[@]}"
         export PATH="$test_dir/bin:$PATH"
-        #make test
+        #make check
         rm -r "$test_dir"
       )
 


### PR DESCRIPTION
Having the command for running all checks named "test" was confusing imo. "test" is easy to confuse with (unit) tests.

Now there is no `make test`, which is intentional. If someone runs it they will realize it's gone and they have to check the makefile or docs again.

In the future I think it makes sense to rename `make pytest` into `make test`

The nixfile change looks like commented out code, but since I'm not sure it's better to update it imo.