### PR TITLE
feat: alt+enter to toggle showing result actions for the current results

### DIFF
--- a/tests/modes/shortcuts/test_shortcut_mode.py
+++ b/tests/modes/shortcuts/test_shortcut_mode.py
@@ -35,7 +35,7 @@ class TestShortcutMode:
 
     @pytest.fixture(autouse=False)
     def shortcut_result(self, mocker: MockerFixture) -> Any:
-        return mocker.patch("ulauncher.modes.shortcuts.shortcut_mode.ShortcutResult")
+        return mocker.patch("ulauncher.modes.shortcuts.shortcut_mode.results.ShortcutResult")
 
     def test_is_enabled__query_starts_with_query__returns_false(
         self, mode: ShortcutMode, shortcuts_db: MagicMock
@@ -91,19 +91,19 @@ class TestShortcutMode:
     def test_activate_static_trigger(self, mode: ShortcutMode, run_shortcut: MagicMock) -> None:
         query = Query("kw", None)
         result = ShortcutStaticTrigger(cmd="/bin/asdf", run_without_argument=True)
-        mode.activate_result(result, query, False, lambda _: None)
+        mode.activate_result("run_static", result, query, lambda _: None)
         run_shortcut.assert_called_once_with("/bin/asdf")
 
     def test_activate_shortcutresult_cmd(self, mode: ShortcutMode, run_shortcut: MagicMock) -> None:
         query = Query("kw", "arg")
         result = ShortcutResult(keyword="kw", cmd="/bin/asdf")
-        mode.activate_result(result, query, False, lambda _: None)
+        mode.activate_result("run", result, query, lambda _: None)
         run_shortcut.assert_called_once_with("/bin/asdf", "arg")
 
     def test_activate_shortcutresult_cmd_missing_arg(self, mode: ShortcutMode, run_shortcut: MagicMock) -> None:
         query = Query("kw", None)
         result = ShortcutResult(keyword="kw", cmd="/bin/asdf")
-        mode.activate_result(result, query, False, lambda _: None)
+        mode.activate_result("run", result, query, lambda _: None)
         run_shortcut.assert_not_called()
 
     def test_activate_shortcutresult_run_without_args_no_op(self, mode: ShortcutMode, run_shortcut: MagicMock) -> None:
@@ -111,5 +111,5 @@ class TestShortcutMode:
         # it would be weird if typing without pressing enter would run a command
         query = Query("kw", None)
         result = ShortcutResult(keyword="kw", cmd="/bin/asdf", run_without_argument=True)
-        mode.activate_result(result, query, False, lambda _: None)
+        mode.activate_result("run", result, query, lambda _: None)
         run_shortcut.assert_not_called()

--- a/ulauncher/api/extension.py
+++ b/ulauncher/api/extension.py
@@ -56,6 +56,8 @@ class Extension:
             self.subscribe(events[EventType.UNLOAD], "on_unload")
         if self.__class__.on_preferences_update is not Extension.on_preferences_update:
             self.subscribe(events[EventType.UPDATE_PREFERENCES], "on_preferences_update")
+        if self.__class__.on_result_activation is not Extension.on_result_activation:
+            self.subscribe(events[EventType.RESULT_ACTIVATION], "on_result_activation")
 
     def subscribe(self, event_type: type[BaseEvent], listener: str | object) -> None:
         """
@@ -160,6 +162,15 @@ class Extension:
 
     def on_preferences_update(self, pref_id: str, value: str | int | bool, previous_value: str | int | bool) -> None:
         pass
+
+    def on_result_activation(self, action_id: str, result: dict[str, Any]) -> ActionMessageInput | None:
+        """
+        Called when user activates a result action.
+
+        :param action_id: The ID of the action that was activated (key from Result.actions dict)
+        :param result: The result data as a dict
+        :return: The action to execute
+        """
 
     def on_unload(self) -> None:
         pass

--- a/ulauncher/api/extension.py
+++ b/ulauncher/api/extension.py
@@ -7,13 +7,14 @@ import os
 import signal
 import threading
 from collections import defaultdict
-from typing import Any, Callable
+from typing import Any, Callable, cast
 
 from ulauncher.api.client.Client import Client
 from ulauncher.api.client.EventListener import EventListener
 from ulauncher.api.shared.action.ExtensionCustomAction import custom_data_store
 from ulauncher.api.shared.event import BaseEvent, EventType, KeywordQueryEvent, PreferencesUpdateEvent, events
 from ulauncher.internals.action_input import ActionMessageInput, convert_to_action_message
+from ulauncher.internals.result import Result
 from ulauncher.utils.logging_color_formatter import ColoredFormatter
 from ulauncher.utils.timer import TimerContext, timer
 
@@ -41,6 +42,7 @@ class Extension:
         self.preferences = {}
         self._input_debounce_timer: TimerContext | None = None
         self._input_debounce_delay = float(os.getenv("ULAUNCHER_INPUT_DEBOUNCE", "0.05"))
+        self._result_cache: dict[int, Result] = {}
         signal.signal(signal.SIGTERM, lambda *_: self._client.unload())
         with contextlib.suppress(Exception):
             self.preferences = json.loads(os.environ.get("EXTENSION_PREFERENCES", "{}"))
@@ -86,6 +88,15 @@ class Extension:
             custom_data_store.clear()
             custom_data_store[ref] = data
             args = [data]
+        elif event_type == EventType.RESULT_ACTIVATION:
+            # Restore actual Result instance from cache using the result_id
+            action_id, result_dict = cast("tuple[str, dict[str, Any]]", args)
+            result_id: int | None = result_dict.get("__result_id__")
+            if result_id and (result := self._result_cache.get(result_id)):
+                args = [action_id, result]
+            else:
+                err_msg = f"Result with id {result_id} not found"
+                raise ValueError(err_msg)
 
         if callable(event_constructor):
             return event_constructor(args)
@@ -142,6 +153,16 @@ class Extension:
         # ignore outdated responses
         if current_input == self._input:
             action_msg = convert_to_action_message(input_action_msg if input_action_msg is not None else False)
+
+            # Cache Result objects before sending them, keyed by their Python object ID
+            if isinstance(action_msg, list):
+                self._result_cache.clear()
+                for result in action_msg:
+                    result_id = id(result)
+                    self._result_cache[result_id] = result
+                    # Add the result_id to the dict representation so Ulauncher can send it back
+                    result["__result_id__"] = result_id
+
             self._client.send({"event": event, "action": action_msg})
 
     def run(self) -> None:
@@ -163,12 +184,12 @@ class Extension:
     def on_preferences_update(self, pref_id: str, value: str | int | bool, previous_value: str | int | bool) -> None:
         pass
 
-    def on_result_activation(self, action_id: str, result: dict[str, Any]) -> ActionMessageInput | None:
+    def on_result_activation(self, action_id: str, result: Result) -> ActionMessageInput | None:
         """
         Called when user activates a result action.
 
         :param action_id: The ID of the action that was activated (key from Result.actions dict)
-        :param result: The result data as a dict
+        :param result: The Result object that was activated
         :return: The action to execute
         """
 

--- a/ulauncher/api/shared/event.py
+++ b/ulauncher/api/shared/event.py
@@ -70,10 +70,10 @@ class ItemEnterEvent(BaseEvent):
 class ResultActivationEvent(BaseEvent):
     """
     Is triggered when user activates a result action.
-    Args: [action_id: str, result_data: dict]
+    Args: [action_id: str, result: Result]
 
     :param str action_id: The ID of the action that was activated
-    :param dict result_data: The result data as a dict
+    :param Result result: The Result object that was activated
     """
 
 

--- a/ulauncher/api/shared/event.py
+++ b/ulauncher/api/shared/event.py
@@ -67,6 +67,16 @@ class ItemEnterEvent(BaseEvent):
         return self.args[0]
 
 
+class ResultActivationEvent(BaseEvent):
+    """
+    Is triggered when user activates a result action.
+    Args: [action_id: str, result_data: dict]
+
+    :param str action_id: The ID of the action that was activated
+    :param dict result_data: The result data as a dict
+    """
+
+
 class UnloadEvent(BaseEvent):
     """
     Is triggered when extension is about to be unloaded (terminated).
@@ -112,6 +122,7 @@ class EventType:
     INPUT_TRIGGER: Final = "event:input_trigger"
     ACTIVATE_CUSTOM: Final = "event:activate_custom"
     LAUNCH_TRIGGER: Final = "event:launch_trigger"
+    RESULT_ACTIVATION: Final = "event:result_activation"
     UPDATE_PREFERENCES: Final = "event:update_preferences"
     LEGACY_PREFERENCES_LOAD: Final = "event:legacy_preferences_load"
     UNLOAD: Final = "event:unload"
@@ -124,4 +135,5 @@ events = {
     EventType.UNLOAD: UnloadEvent,
     EventType.INPUT_TRIGGER: InputTriggerEvent,
     EventType.ACTIVATE_CUSTOM: ItemEnterEvent,
+    EventType.RESULT_ACTIVATION: ResultActivationEvent,
 }

--- a/ulauncher/core.py
+++ b/ulauncher/core.py
@@ -47,6 +47,11 @@ class UlauncherCore:
     _mode_map: WeakKeyDictionary[Result, BaseMode] = WeakKeyDictionary()
     query: Query = Query(None, "")
     _placeholder_timer: TimerContext | None = None
+    _base_results: list[Result]  # Store original results before expansion
+    _expanded_result: Result | None = None  # Track which result has expanded actions
+
+    def __init__(self) -> None:
+        self._base_results = []
 
     def load_triggers(self, force: bool = False) -> None:
         """Load or refresh triggers from modes that have changes."""
@@ -90,6 +95,10 @@ class UlauncherCore:
             callback(self.get_result_for_empty_query())
             return
 
+        # Reset expansion when query changes
+        self._expanded_result = None
+        self._base_results = []
+
         self._mode = None
         self.query = Query(None, query_str)
 
@@ -131,8 +140,21 @@ class UlauncherCore:
                 yield app_result
 
     def _show_results(self, results: Iterable[Result], callback: Callable[[Iterable[Result]], None]) -> None:
+        """Show results, expanding actions inline if a result is marked for expansion."""
         self._clear_placeholder_timer()
-        callback(results)
+        self._base_results = list(results)
+
+        # If a result is expanded, insert its actions inline
+        if self._expanded_result and self._expanded_result in self._base_results:
+            active_result_index = self._base_results.index(self._expanded_result) + 1
+            # Create new list with action results after the selected result
+            callback(
+                self._base_results[:active_result_index]
+                + list(self._get_action_results(self._expanded_result))
+                + self._base_results[active_result_index:]
+            )
+        else:
+            callback(self._base_results)
 
     def _show_placeholder(self, callback: Callable[[Iterable[Result]], None]) -> None:
         placeholder = Result(name="Loading...", icon=self._mode.get_placeholder_icon() if self._mode else None)
@@ -188,6 +210,8 @@ class UlauncherCore:
         if isinstance(result, ActionResult) and result.parent_result and result.action_id:
             mode = self._mode_map.get(result.parent_result, self._mode)
             if mode:
+                # Collapse the action list after activating
+                self._expanded_result = None
                 mode.activate_result(
                     result.action_id, result.parent_result, self.query, self._mode_callback(mode, callback)
                 )
@@ -200,9 +224,19 @@ class UlauncherCore:
             return
 
         if result.actions:
-            if alt:
-                self._show_results(self._get_action_results(result), callback)
+            # Hide result actions if they are showing
+            if self._expanded_result is result:
+                self._expanded_result = None
+                self._show_results(self._base_results, callback)
                 return
+
+            # Show result actions if alt is pressed
+            if alt:
+                self._expanded_result = result
+                self._show_results(self._base_results, callback)
+                return
+
+            # Normal activation: execute first action
             first_action_id = next(iter(result.actions))
             mode.activate_result(first_action_id, result, self.query, self._mode_callback(mode, callback))
             return

--- a/ulauncher/modes/apps/app_mode.py
+++ b/ulauncher/modes/apps/app_mode.py
@@ -47,12 +47,17 @@ class AppMode(BaseMode):
         return list(filter(None, map(AppResult.from_id, AppResult.get_top_app_ids())))[:limit]
 
     def activate_result(
-        self, result: Result, _query: Query, _alt: bool, callback: Callable[[ActionMessage | list[Result]], None]
+        self,
+        action_id: str,
+        result: Result,
+        _query: Query,
+        callback: Callable[[ActionMessage | list[Result]], None],
     ) -> None:
-        if isinstance(result, AppResult):
+        if action_id == "launch":
             result.bump_starts()
             if not launch_app(result.app_id):
                 logger.error("Could not launch app %s", result.app_id)
             callback(actions.close_window())
             return
+        logger.error("Unexpected action '%s' for App mode result '%s'", action_id, result)
         callback(actions.do_nothing())

--- a/ulauncher/modes/apps/app_result.py
+++ b/ulauncher/modes/apps/app_result.py
@@ -19,6 +19,7 @@ class AppResult(Result):
     searchable = True
     app_id = ""
     _executable = ""
+    actions = {"launch": {"name": "Launch application", "icon": "system-run"}}
 
     def __init__(self, app_info: DesktopAppInfo) -> None:
         super().__init__(

--- a/ulauncher/modes/base_mode.py
+++ b/ulauncher/modes/base_mode.py
@@ -57,11 +57,19 @@ class BaseMode:
 
     def activate_result(
         self,
+        action_id: str,
         result: Result,
         query: Query,
-        alt: bool,
         callback: Callable[[ActionMessage | list[Result]], None],
     ) -> None:
+        """
+        Called when a result is activated.
+
+        :param action_id: The ID of the action to perform, or empty string for the default action
+        :param result: The result that was activated
+        :param query: The current query
+        :param callback: Callback to return the action or new results
+        """
         error_msg = (
             f"{self.__class__.__name__}.activate_result() is not implemented. "
             "You should override this method to handle result activation."

--- a/ulauncher/modes/calc/calc_result.py
+++ b/ulauncher/modes/calc/calc_result.py
@@ -3,7 +3,16 @@ from __future__ import annotations
 from ulauncher import paths
 from ulauncher.internals.result import Result
 
+calc_icon = f"{paths.ASSETS}/icons/calculator.png"
+
 
 class CalcResult(Result):
-    icon = f"{paths.ASSETS}/icons/calculator.png"
-    result: str | None = None
+    icon = calc_icon
+    result = ""
+    actions = {"copy": {"name": "Copy to clipboard", "icon": "edit-copy"}}
+
+
+class CalcErrorResult(Result):
+    name = "Error!"
+    description = "Invalid expression"
+    icon = calc_icon

--- a/ulauncher/modes/extensions/extension_mode.py
+++ b/ulauncher/modes/extensions/extension_mode.py
@@ -143,8 +143,9 @@ class ExtensionMode(BaseMode, metaclass=Singleton):
         elif action_id == "__legacy_on_alt_enter__" and "on_alt_enter" in result:
             action_msg = result.on_alt_enter
         else:
-            logger.error("Unexpected action '%s' for Extension mode result '%s'", action_id, result)
-            callback(actions.do_nothing())
+            event_type = EventType.RESULT_ACTIVATION
+            event_args = [action_id, result]
+            self.trigger_event({"type": event_type, "args": event_args}, callback)
             return
 
         if (

--- a/ulauncher/modes/file_browser/results.py
+++ b/ulauncher/modes/file_browser/results.py
@@ -10,6 +10,11 @@ class FileResult(Result):
     compact = True
     highlightable = True
     path = ""
+    actions = {
+        "open": {"name": "Open file", "icon": "document-open"},
+        "open_parent": {"name": "Open containing folder", "icon": "folder-open"},
+        "copy_path": {"name": "Copy path", "icon": "edit-copy"},
+    }
 
     def __init__(self, path: str) -> None:
         super().__init__(
@@ -22,14 +27,9 @@ class FileResult(Result):
         return basename(query_str)
 
 
-class CopyPath(Result):
-    compact = True
-    name = "Copy Path to Clipboard"
-    icon = "edit-copy"
-    path = ""
-
-
-class OpenFolder(Result):
-    compact = True
-    icon = "system-file-manager"
-    path = ""
+class FolderResult(FileResult):
+    actions = {
+        "go_to": {"name": "Open", "icon": "folder-open"},
+        "open": {"name": "Open in file manager", "icon": "system-file-manager"},
+        "copy_path": {"name": "Copy path", "icon": "edit-copy"},
+    }

--- a/ulauncher/modes/shortcuts/results.py
+++ b/ulauncher/modes/shortcuts/results.py
@@ -5,11 +5,15 @@ from ulauncher.internals.result import Result
 
 class ShortcutResult(Result):
     is_default_search = False
-    run_without_argument = False
     cmd = ""
+    actions = {"run": {"name": "Run shortcut", "icon": "system-run"}}
 
 
 class ShortcutStaticTrigger(Result):
     searchable = True
-    run_without_argument = False
     cmd = ""
+    actions = {"run_static": {"name": "Run shortcut", "icon": "system-run"}}
+
+
+class StaticShortcutResult(ShortcutResult):
+    actions = {"run_static": {"name": "Run shortcut", "icon": "system-run"}}

--- a/ulauncher/ui/windows/ulauncher_window.py
+++ b/ulauncher/ui/windows/ulauncher_window.py
@@ -394,6 +394,10 @@ class UlauncherWindow(Gtk.ApplicationWindow):
         self.prompt_input.set_position(-1)
 
     def show_results(self, results: Iterable[Result]) -> None:
+        """Render the result list. Core handles expansion logic."""
+        from ulauncher.internals.result import ActionResult
+        from ulauncher.ui.result_widget import ResultWidget
+
         self._results_nav = None
         self.results.foreach(lambda w: w.destroy())
 
@@ -401,11 +405,14 @@ class UlauncherWindow(Gtk.ApplicationWindow):
         result_list = list(results)[:limit]
 
         if result_list:
-            from ulauncher.ui.result_widget import ResultWidget
-
             result_widgets: list[ResultWidget] = []
             for index, result in enumerate(result_list):
                 result_widget = ResultWidget(result, index, self.core.query)
+
+                # Add left margin for ActionResults to show they're nested
+                if isinstance(result, ActionResult):
+                    result_widget.set_property("margin-start", 10)
+
                 result_widgets.append(result_widget)
                 self.results.add(result_widget)
 

--- a/ulauncher/ui/windows/ulauncher_window.py
+++ b/ulauncher/ui/windows/ulauncher_window.py
@@ -417,7 +417,20 @@ class UlauncherWindow(Gtk.ApplicationWindow):
                 self.results.add(result_widget)
 
             self._results_nav = ItemNavigation(result_widgets)
-            self._results_nav.select_default(str(self.core.query))
+
+            # Check if Core marked a result as selected (after toggle/expansion)
+            selected_index = None
+            for index, widget in enumerate(result_widgets):
+                if widget.result.get("selected"):
+                    selected_index = index
+                    # Clear the selected property after using it
+                    del widget.result["selected"]
+                    break
+
+            if selected_index is not None:
+                self._results_nav.select(selected_index)
+            else:
+                self._results_nav.select_default(str(self.core.query))
 
             self.results.set_margin_bottom(10)
             self.results.set_margin_top(3)


### PR DESCRIPTION
Status: Marking as draft. Going to get #1613 merged first. Then will rebase this over that.

One possible implementation to solve the core problems detailed in #931 (this PR doesn't implement all of #931)

This is a lot to cover.

* The first commit is a complete rewrite of how Ulauncher handles actions internally using the new `actions` dict format.
* The following two are to add support for extensions too.
* :warning:  The backwards compatibility with extensions using on_alt_enter does not look great now when you use alt+enter now, because we want to make sure users can safely press alt+enter and be sure it's not a destructive action like deleting the result. So we now list the legacy actions here. But since they don't have names, it just says "primary action" and "secondary action". I think this is the best we can do for now and it should motivate extension developers to migrate to the new API.
* :construction: The last two commits changes the UX experience to show the action list with an indentation below the result they represent. I'm not sure if this is what we really want to do, but it has some benefits:
     1. You can go back
     2. You clearly see what result the actions are for.

You can test the behavior before the UX changes by checking out the branch locally and checking out the state before. I think I actually prefer a different solution but I wanted to explore this first.

Alternatively, we can keep track of the result history instead so we can "Go back" (by pressing esc and/or a result inserted last in the list). I think we also need one "Title" or "breadcrumb" result to show which result these actions apply for. For example if there is an option saying "Delete file" I want to know which file.

I don't want to have to make the action names include the file name in this case for several reasons. For starters, because all the actions apply to the file, so then that would have to be repeated in all the results. And because then you have to create the actions dynamically. I prefer to make a Result subclass to define them in (as you can see in the first commit).

So test it out with the last two commits and without and let me know @gornostal 