### PR TITLE
refactor: rename ACTIVATE_CUSTOM -> LEGACY_ACTIVATE_CUSTOM

### DIFF
--- a/ulauncher/api/extension.py
+++ b/ulauncher/api/extension.py
@@ -53,7 +53,7 @@ class Extension:
         if self.__class__.on_launch is not Extension.on_launch:
             self.subscribe(events[EventType.LAUNCH_TRIGGER], "on_launch")
         if self.__class__.on_item_enter is not Extension.on_item_enter:
-            self.subscribe(events[EventType.ACTIVATE_CUSTOM], "on_item_enter")
+            self.subscribe(events[EventType.LEGACY_ACTIVATE_CUSTOM], "on_item_enter")
         if self.__class__.on_unload is not Extension.on_unload:
             self.subscribe(events[EventType.UNLOAD], "on_unload")
         if self.__class__.on_preferences_update is not Extension.on_preferences_update:
@@ -81,7 +81,7 @@ class Extension:
             argument, trigger_id = args
             return KeywordQueryEvent(f"{self.preferences[trigger_id]} {argument}")
 
-        if event_type == EventType.ACTIVATE_CUSTOM:
+        if event_type == EventType.LEGACY_ACTIVATE_CUSTOM:
             ref = event.get("ref", "")
             data = custom_data_store.get(ref)
             # Remove all entries except the one the user choose, because get_data can be called more than once

--- a/ulauncher/api/shared/action/ExtensionCustomAction.py
+++ b/ulauncher/api/shared/action/ExtensionCustomAction.py
@@ -16,4 +16,4 @@ def ExtensionCustomAction(data: Any, keep_app_open: bool = False) -> dict[str, A
     """
     ref = id(data)
     custom_data_store[ref] = data
-    return {"type": ActionType.ACTIVATE_CUSTOM, "ref": ref, "keep_app_open": keep_app_open}
+    return {"type": ActionType.LEGACY_ACTIVATE_CUSTOM, "ref": ref, "keep_app_open": keep_app_open}

--- a/ulauncher/api/shared/event.py
+++ b/ulauncher/api/shared/event.py
@@ -120,20 +120,20 @@ SystemExitEvent = UnloadEvent
 
 class EventType:
     INPUT_TRIGGER: Final = "event:input_trigger"
-    ACTIVATE_CUSTOM: Final = "event:activate_custom"
     LAUNCH_TRIGGER: Final = "event:launch_trigger"
     RESULT_ACTIVATION: Final = "event:result_activation"
     UPDATE_PREFERENCES: Final = "event:update_preferences"
-    LEGACY_PREFERENCES_LOAD: Final = "event:legacy_preferences_load"
     UNLOAD: Final = "event:unload"
+    LEGACY_ACTIVATE_CUSTOM: Final = "event:legacy_activate_custom"
+    LEGACY_PREFERENCES_LOAD: Final = "event:legacy_preferences_load"
 
 
 events = {
-    EventType.LAUNCH_TRIGGER: LaunchTriggerEvent,
-    EventType.UPDATE_PREFERENCES: PreferencesUpdateEvent,
-    EventType.LEGACY_PREFERENCES_LOAD: PreferencesEvent,
-    EventType.UNLOAD: UnloadEvent,
     EventType.INPUT_TRIGGER: InputTriggerEvent,
-    EventType.ACTIVATE_CUSTOM: ItemEnterEvent,
+    EventType.LAUNCH_TRIGGER: LaunchTriggerEvent,
     EventType.RESULT_ACTIVATION: ResultActivationEvent,
+    EventType.UPDATE_PREFERENCES: PreferencesUpdateEvent,
+    EventType.UNLOAD: UnloadEvent,
+    EventType.LEGACY_ACTIVATE_CUSTOM: ItemEnterEvent,
+    EventType.LEGACY_PREFERENCES_LOAD: PreferencesEvent,
 }

--- a/ulauncher/internals/actions.py
+++ b/ulauncher/internals/actions.py
@@ -8,12 +8,12 @@ class ActionType:
     DO_NOTHING: Final = "action:do_nothing"
     CLOSE_WINDOW: Final = "action:close_window"
     SET_QUERY: Final = "action:set_query"
+    LAUNCH_TRIGGER: Final = "action:launch_trigger"
     OPEN: Final = "action:open"
     COPY: Final = "action:clipboard_store"
     LEGACY_RUN_SCRIPT: Final = "action:legacy_run_script"
     LEGACY_RUN_MANY: Final = "action:legacy_run_many"
-    ACTIVATE_CUSTOM: Final = "action:activate_custom"
-    LAUNCH_TRIGGER: Final = "action:launch_trigger"
+    LEGACY_ACTIVATE_CUSTOM: Final = "action:legacy_activate_custom"
 
 
 class DoNothing(TypedDict):
@@ -50,7 +50,7 @@ class LegacyRunMany(TypedDict):
 
 
 class ActivateCustom(TypedDict):
-    type: Literal["action:activate_custom"]
+    type: Literal["action:legacy_activate_custom"]
     ref: int
     keep_app_open: bool
 

--- a/ulauncher/modes/extensions/extension_mode.py
+++ b/ulauncher/modes/extensions/extension_mode.py
@@ -35,7 +35,7 @@ class ExtensionResponse(TypedDict, total=False):
 
 # Maps action types that require async extension communication to their event types
 ASYNC_ACTION_TYPES = {
-    ActionType.ACTIVATE_CUSTOM: EventType.ACTIVATE_CUSTOM,
+    ActionType.LEGACY_ACTIVATE_CUSTOM: EventType.LEGACY_ACTIVATE_CUSTOM,
     ActionType.LAUNCH_TRIGGER: EventType.LAUNCH_TRIGGER,
 }
 


### PR DESCRIPTION
As of the new Result.actions we recommend against using custom actions
because it's more complicated, more limited and leads to a worse user experience.

I also reordered the action and event union types by relevance.