### PR TITLE
feat(dbus): support multiple arguments to dbus_trigger_event

### DIFF
--- a/ulauncher/app.py
+++ b/ulauncher/app.py
@@ -169,11 +169,13 @@ class UlauncherApp(Gtk.Application):
     def delegate_custom_message(self, json_message: str) -> None:
         """Parses and delegates custom JSON messages to the EventBus listener (if any)"""
         try:
-            data = json.loads(json_message)
-            if isinstance(data, dict) and "name" in data:
-                events.emit(data["name"], data.get("message"))
-                return
-            logger.error("Custom message missing required 'name' field: %s", json_message)
+            if (data := json.loads(json_message)) and isinstance(data, dict):
+                name = data.get("name")
+                args = data.get("args")
+                if isinstance(name, str) and isinstance(args, list):
+                    events.emit(name, *args)
+                    return
+            logger.error("Custom message fields 'name' or 'args' are missing or invalid: %s", json_message)
         except json.JSONDecodeError:
             logger.exception("Failed to parse custom message as JSON: %s", json_message)
 

--- a/ulauncher/utils/dbus.py
+++ b/ulauncher/utils/dbus.py
@@ -66,7 +66,7 @@ def get_ulauncher_dbus_action_group(bus: Gio.DBusConnection) -> Gio.DBusActionGr
     return Gio.DBusActionGroup.get(bus, ulauncher.app_id, ulauncher.dbus_path)
 
 
-def dbus_trigger_event(name: str, message: Any | None = None) -> None:
+def dbus_trigger_event(name: str, *args: Any) -> None:
     """Sends a D-Bus message to the Ulauncher App, which is delegated to the EventBus listener matching the name."""
     bus = Gio.bus_get_sync(Gio.BusType.SESSION)
 
@@ -74,5 +74,5 @@ def dbus_trigger_event(name: str, message: Any | None = None) -> None:
         logger.debug("Ulauncher app is not running, skipping D-Bus trigger event: %s", name)
         return
 
-    json_message = json.dumps({"name": name, "message": message})
+    json_message = json.dumps({"name": name, "args": list(args)})
     get_ulauncher_dbus_action_group(bus).activate_action("trigger-event", GLib.Variant.new_string(json_message))


### PR DESCRIPTION
rework dbus_trigger_event to support multiple arguments, and make the app.delegate_custom_message handler that receives the messages handle this.
