### PR TITLE
fix: RunScriptAction runs too early

### DIFF
--- a/ulauncher/api/shared/action/RunScriptAction.py
+++ b/ulauncher/api/shared/action/RunScriptAction.py
@@ -1,19 +1,11 @@
-from __future__ import annotations  # noqa: N999
-
-import logging
-
-from ulauncher.internals import effects
-from ulauncher.modes.shortcuts.run_script import run_script
-
-logger = logging.getLogger()
+from ulauncher.internals import effects  # noqa: N999
 
 
-def RunScriptAction(script: str, arg: str = "") -> effects.CloseWindow:  # noqa: N802
+def RunScriptAction(script: str, arg: str = "") -> effects.LegacyRunScript:  # noqa: N802
     if not isinstance(script, str):
         msg = f'Script argument "{script}" is invalid. It must be a string'
         raise TypeError(msg)
     if not script:
         msg = "Script argument cannot be empty"
         raise ValueError(msg)
-    run_script(script, arg)
-    return effects.close_window()
+    return {"type": effects.EffectType.LEGACY_RUN_SCRIPT, "data": [script, arg]}

--- a/ulauncher/internals/effect_utils.py
+++ b/ulauncher/internals/effect_utils.py
@@ -55,6 +55,10 @@ def handle(effect_msg: EffectMessage, prevent_close: bool = False) -> None:
     elif event_type == EffectType.LEGACY_COPY and isinstance(data, str):
         _events.emit("app:clipboard_store", data)
 
+    elif event_type == EffectType.LEGACY_RUN_SCRIPT and isinstance(data, list):
+        from ulauncher.modes.shortcuts.run_script import run_script
+
+        run_script(*data)
     elif event_type == EffectType.LEGACY_RUN_MANY and isinstance(data, list):
         for effect in cast("list[EffectMessage | list[Result]]", data):
             if isinstance(effect, list):

--- a/ulauncher/internals/effects.py
+++ b/ulauncher/internals/effects.py
@@ -13,6 +13,7 @@ class EffectType:
     SET_QUERY: Final = "effect:set_query"
     OPEN: Final = "effect:open"
     LEGACY_COPY: Final = "effect:legacy_copy"
+    LEGACY_RUN_SCRIPT: Final = "effect:legacy_run_script"
     LEGACY_RUN_MANY: Final = "effect:legacy_run_many"
     LEGACY_ACTIVATE_CUSTOM: Final = "effect:legacy_activate_custom"
 
@@ -40,6 +41,11 @@ class LegacyCopy(TypedDict):
     data: str
 
 
+class LegacyRunScript(TypedDict):
+    type: Literal["effect:legacy_run_script"]
+    data: list[str]
+
+
 class LegacyRunMany(TypedDict):
     type: Literal["effect:legacy_run_many"]
     data: list[Any]  # list of other EffectMessages (can't be expressed with TypedDict)
@@ -57,6 +63,7 @@ EffectMessage = Union[
     SetQuery,
     Open,
     LegacyCopy,
+    LegacyRunScript,
     LegacyRunMany,
     LegacyActivateCustom,
 ]


### PR DESCRIPTION
Restores old RunScriptAction logic, undoing 1dbb9882adac7cdbe016f5348ddf59e830b7c21b, because RunScript needs to run when activated

fixes: #1633


