### PR TITLE
feat: rename layer shell setting

### DIFF
--- a/ulauncher/ui/windows/preferences/views/preferences.py
+++ b/ulauncher/ui/windows/preferences/views/preferences.py
@@ -251,13 +251,13 @@ class PreferencesView(BaseView):
         self._add_setting_row(advanced_box, "Include foreign desktop apps", filters_switch, desc)
 
         # GTK Layer Shell
-        layer_switch = Gtk.Switch(active=self.settings.disable_layer_shell, sensitive=not IS_X11)
+        layer_switch = Gtk.Switch(active=self.settings.layer_shell, sensitive=not IS_X11)
         layer_switch.connect("notify::active", self._on_layer_toggled)
         desc = (
-            "Disables the GTK Layer Shell. Useful for window manager customisation and handling behavioural "
-            "quirks. Applies only to Wayland compositors."
+            "Use Layer Shell for positioning on Wayland (when supported). "
+            "Recommended unless your desktop handles Wayland positioning separately (Hyprland)"
         )
-        self._add_setting_row(advanced_box, "Disable GTK Layer Shell", layer_switch, desc)
+        self._add_setting_row(advanced_box, "Enable Layer Shell", layer_switch, desc)
 
         # Daemonless mode
         daemonless_switch = Gtk.Switch(active=self.settings.daemonless)
@@ -333,7 +333,7 @@ class PreferencesView(BaseView):
         self.settings.save({"max_recent_apps": count})
 
     def _on_layer_toggled(self, switch: Gtk.Switch, _: Any) -> None:
-        self.settings.save({"disable_layer_shell": switch.get_active()})
+        self.settings.save({"layer_shell": switch.get_active()})
 
     def _on_tray_toggled(self, switch: Gtk.Switch, _: Any) -> None:
         is_enabled = switch.get_active()

--- a/ulauncher/ui/windows/ulauncher_window.py
+++ b/ulauncher/ui/windows/ulauncher_window.py
@@ -59,12 +59,7 @@ class UlauncherWindow(Gtk.ApplicationWindow):
         )
 
         # avoid checking layer shell support for known cases it does not apply (for performance reasons)
-        if (
-            not IS_X11_COMPATIBLE
-            and DESKTOP_ID != "GNOME"
-            and not self.settings.disable_layer_shell
-            and layer_shell.is_supported()
-        ):
+        if not IS_X11_COMPATIBLE and DESKTOP_ID != "GNOME" and self.settings.layer_shell and layer_shell.is_supported():
             self.layer_shell_enabled = layer_shell.enable(self)
             if self.layer_shell_enabled:
                 logger.info("Layer shell support is enabled")

--- a/ulauncher/utils/settings.py
+++ b/ulauncher/utils/settings.py
@@ -15,11 +15,11 @@ class Settings(JsonConf):
     close_on_focus_out = True
     daemonless = False
     disable_desktop_filters = False
-    disable_layer_shell = False
     enable_application_mode = True
     grab_mouse_pointer = False
     hotkey_show_app = ""  # Note that this is no longer used, other than for migrating to the DE wrapper
     jump_keys = "1234567890abcdefghijklmnopqrstuvwxyz"
+    layer_shell = True
     max_recent_apps = 0
     raise_if_started = False
     render_on_screen = "mouse-pointer-monitor"


### PR DESCRIPTION
Simplify name and rephrase setting description

Avoids double negations, such as "not self.settings.disable_layer_shell" making code harder than necessary to read.

Similarly boolean options are rendered as switches in the settings UI, so an option to "disable" something shows the switch as enabled when you disable them, which is confusing.

Removes mention of GTK Layer Shell because that's an implementation detail.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Renamed the Layer Shell setting to an enable toggle to remove double negations and make the switch clearer on Wayland. Default remains enabled.

- **Refactors**
  - disable_layer_shell → layer_shell (default True).
  - Preferences: bind to layer_shell, label “Enable Layer Shell”, simpler Wayland-focused description.
  - Window logic: use settings.layer_shell instead of negation when enabling layer shell.

<sup>Written for commit e03cc92756a8622f81a40453cc45e04ce19c8999. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

