### PR TITLE
feat: add shadow size setting

### DIFF
--- a/data/themes/adwaita.css
+++ b/data/themes/adwaita.css
@@ -31,7 +31,7 @@
 @define-color item_highlight_selected @item_highlight;
 
 .app {
-  box-shadow: 0 0 5px @window_shadow;
+  /* Note: box-shadow is now controlled by the application based on user settings */
   background-color: @window_bg;
   border: 1px solid @window_border_color;
   border-radius: 4px;

--- a/data/themes/dark.css
+++ b/data/themes/dark.css
@@ -31,7 +31,7 @@
 @define-color item_highlight_selected @item_highlight;
 
 .app {
-  box-shadow: 0 0 5px @window_shadow;
+  /* Note: box-shadow is now controlled by the application based on user settings */
   background-color: @window_bg;
   border: 1px solid @window_border_color;
   border-radius: 4px;

--- a/data/themes/light.css
+++ b/data/themes/light.css
@@ -31,7 +31,7 @@
 @define-color item_highlight_selected @item_highlight;
 
 .app {
-  box-shadow: 0 0 5px @window_shadow;
+  /* Note: box-shadow is now controlled by the application based on user settings */
   background-color: @window_bg;
   border: 1px solid @window_border_color;
   border-radius: 4px;

--- a/data/themes/ubuntu.css
+++ b/data/themes/ubuntu.css
@@ -31,7 +31,7 @@
 @define-color item_highlight_selected #ffcbbd;
 
 .app {
-  box-shadow: 0 0 5px @window_shadow;
+  /* Note: box-shadow is now controlled by the application based on user settings */
   background-color: @window_bg;
   border: 1px solid @window_border_color;
   border-radius: 4px;

--- a/ulauncher/ui/windows/preferences/views/preferences.py
+++ b/ulauncher/ui/windows/preferences/views/preferences.py
@@ -250,6 +250,16 @@ class PreferencesView(BaseView):
         desc = "Show applications that are hidden for your desktop environment by ignoring desktop filters."
         self._add_setting_row(advanced_box, "Include foreign desktop apps", filters_switch, desc)
 
+        # Window shadow
+        shadow_adjustment = Gtk.Adjustment(value=self.settings.window_shadow, lower=0, upper=25, step_increment=1)
+        shadow_spin = Gtk.SpinButton(adjustment=shadow_adjustment)
+        shadow_spin.connect("value-changed", self._on_shadow_changed)
+        desc = (
+            "The window shadow size. Set to 0 to disable. "
+            "Shadows are also disabled if we detect your window manager cannot support them."
+        )
+        self._add_setting_row(advanced_box, "Window shadow size", shadow_spin, desc)
+
         # GTK Layer Shell
         layer_switch = Gtk.Switch(active=self.settings.layer_shell, sensitive=not IS_X11)
         layer_switch.connect("notify::active", self._on_layer_toggled)
@@ -331,6 +341,9 @@ class PreferencesView(BaseView):
     def _on_recent_apps_changed(self, spin: Gtk.SpinButton) -> None:
         count = spin.get_value_as_int()
         self.settings.save({"max_recent_apps": count})
+
+    def _on_shadow_changed(self, spin: Gtk.SpinButton) -> None:
+        self.settings.save({"window_shadow": spin.get_value_as_int()})
 
     def _on_layer_toggled(self, switch: Gtk.Switch, _: Any) -> None:
         self.settings.save({"layer_shell": switch.get_active()})

--- a/ulauncher/utils/settings.py
+++ b/ulauncher/utils/settings.py
@@ -27,6 +27,7 @@ class Settings(JsonConf):
     terminal_command = ""
     theme_name = "light"
     tray_icon_name = "ulauncher-indicator-symbolic"
+    window_shadow = 5
 
     # Convert dash to underscore
     def __setitem__(self, key: str, value: Any) -> None:  # type: ignore[override]


### PR DESCRIPTION
Add new setting to set the shadow size. Mainly this is to provide the option to disable the shadow, even for users that has a compositor as requested in #1632.

Before this, the theme controlled the shadow and we added 20px margin to the window for it (making an unsafe assumption that it will always be less than 20px). This change overrides the theme shadows and adds a setting so that users can control it instead (I added max 25px but that was mainly random).

It also adds a new dedicated wrapper for the shadow, to avoid confusion with the Gnome wayland positioning hack using margins.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a user setting to control window shadow size, including disabling it, addressing #1632. Moves shadow rendering from themes to the app for consistent and predictable behavior.

- **New Features**
  - Added “Window shadow size” (0–25, default 5). Set 0 to disable; auto-disabled when no compositor is detected.
  - App now applies the shadow via CSS based on the setting; themes no longer define box-shadow.

- **Refactors**
  - Introduced a shadow_container to manage shadow space and removed the old fixed 20px margin hack.
  - Updated theme loading to get_css(shadow_size) and removed box-shadow from built-in themes; GNOME Wayland positioning now uses frame margins.

<sup>Written for commit 38ab2081a25698fdf18bfd8a1983b8e7b2560b4c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

