### PR TITLE
Enable AlmaLinux9 rpm build in draft-release workflow

### DIFF
--- a/.github/workflows/draft-release.yml
+++ b/.github/workflows/draft-release.yml
@@ -5,24 +5,91 @@ on:
     tags:
       - '*'
 
+  workflow_dispatch:
+    inputs:
+      ref_name:
+        description: 'Tag name to use instead of github.ref_name'
+        required: true
+        default: '5.15.15'
+
+env:
+  REF_NAME: "${{ inputs.ref_name || github.ref_name }}"
+
 jobs:
-  release:
+  build-deb:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v6
 
-      - name: Build release
+      - name: Build release packages
         run: |
-          echo "Tag is created: $GITHUB_REF_NAME"
+          echo "Tag is created: $REF_NAME"
           source ./scripts/common.sh
           docker pull $BUILD_IMAGE
-          ./ul build-release $GITHUB_REF_NAME
+          ./ul build-release $REF_NAME
 
-      - name: Make draft GitHub release
-        uses: softprops/action-gh-release@v1
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v4
         with:
-          draft: true
-          files: |
+          name: deb-artifacts
+          path: |
             *.tar.gz
             *.deb
+
+
+  build-rpm:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+
+      - name: Build rpm release (AlmaLinux 9.7)
+        run: |
+          docker run --rm \
+            -e REF_NAME="$REF_NAME" \
+            -v $PWD:/build \
+            -w /build \
+            almalinux:9.7 \
+            bash -c "
+              dnf -y install epel-release &&
+              dnf -y install rpm-build rpmdevtools python3 yarnpkg rsync python3-distutils-extra python3-gobject python3-websocket-client python3-pyxdg python3-inotify python3-pyxdameraulevenshtein gcc make &&
+              ./ul build-preferences &&
+              ./ul build-rpm "$REF_NAME" almalinux9 &&
+              cp /tmp/ulauncher_${REF_NAME}_almalinux9.rpm /build/
+            "
+
+      - name: Upload artifacts
+        id: upload
+        uses: actions/upload-artifact@v6
+        with:
+          name: rpm-artifact
+          path: |
+            *.rpm
+
+
+  release:
+    runs-on: ubuntu-latest
+    needs:
+      - build-deb
+      - build-rpm
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+
+      - name: Download artifacts
+        uses: actions/download-artifact@v7
+        with:
+          name: deb-artifacts
+          path: ./artifacts
+
+      - uses: actions/download-artifact@v7
+        with:
+          name: rpm-artifact
+          path: ./artifacts
+
+      - name: Make draft GitHub release
+        uses: softprops/action-gh-release@v2
+        with:
+          draft: true
+          files: ./artifacts/**

--- a/setup.cfg
+++ b/setup.cfg
@@ -46,3 +46,20 @@ requires = gobject-introspection
     python3-inotify
     python3-Levenshtein
     python3-websocket-client
+
+[bdist_rpm_almalinux9]
+release = 1
+packager = Aleksandr Gornostal <ulauncher.app@gmail.com>
+doc_files = LICENSE
+group = Applications/Productivity
+build_requires = gcc,make,python3-distutils-extra
+requires = gobject-introspection
+    keybinder3
+    webkitgtk4
+    python3-dbus
+    python3-cairo
+    python3-gobject
+    python3-pyxdg
+    python3-inotify
+    python3-pyxdameraulevenshtein
+    python3-websocket-client

--- a/ulauncher/utils/fuzzy_search.py
+++ b/ulauncher/utils/fuzzy_search.py
@@ -1,7 +1,11 @@
 import operator
 from functools import lru_cache
 # pylint: disable=no-name-in-module
-from Levenshtein import distance
+try:
+    from Levenshtein import distance
+
+except ImportError:
+    from pyxdameraulevenshtein import damerau_levenshtein_distance as distance
 
 
 @lru_cache(maxsize=150)


### PR DESCRIPTION
# RPM Build Pipeline

I mainly use RedHat based distributions like AlmaLinux9 right now and wanted to have a native rpm for Ulauncher to install on that platform.


## Summary of changes

- Added a try-except for the import of `Levenshtein` in `fuzzy_search.py`
- The above enables a fallback to `pyxdameraulevenshtein` which is available as [rpm](https://pkgs.org/download/python3-pyxdameraulevenshtein) on AlmaLinux9 natively while implementing supposedly the same logic as `Levenshtein` which is [not available as rpm](https://pkgs.org/download/python3-Levenshtein) on that platform
- Added a build section for `[bdist_rpm_almalinux9]` to `setup.cfg` including the required dependencies
- Extended the `draft-release.yml` worklfow to build the `.rpm` package in a dedicated job
- The rpm build process itself runs in an AlmaLinux9 container which also takes care of all dependencies on that platform
- Added a workflow dispatch for manual testing the workflow
- Added a dedicated release job to pull all artifacts together for the draft release

In terms of documentation, in case you guys accept this PR, only the [downloads section](https://ulauncher.io/#Download) would need to get extended for the additional package as manual rpm install.

## Testing

To make sure the installer works as expected I created a demo release on my [fork](https://github.com/philnewm/Ulauncher/releases/tag/5.15.15).
This testing RPM package was also integrated in this [Ansible role](https://github.com/philnewm/ansible-ulauncher) and the tests were successful. Meaning Ulauncher got installed and preconfigured on a fresh installed Almalinux9 system and worked as expected.

## Additional Notes

For testing the workflow changes I needed to add the `workflow_dispatch` and its inputs to the [main branch](https://github.com/philnewm/Ulauncher/blob/59b0db2d22545204196ce01a88b0c4d6cebf558d/.github/workflows/draft-release.yml#L8) - otherwise it did not show up but maybe there are better ways to achieve this.

With Ulauncher v6 getting closer to finish line I can also fully understand if you don't see a point in integrating this for version 5 at the moment.

Let me know what you think and how I can improve this implementation.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an AlmaLinux 9 RPM build to the draft-release workflow and makes fuzzy search fall back to pyxdameraulevenshtein when python-Levenshtein isn’t available. Draft releases now include .rpm alongside .deb and .tar.gz.

- **New Features**
  - Build RPM for AlmaLinux 9 in a container (almalinux:9.7).
  - Added [bdist_rpm_almalinux9] to setup.cfg with platform dependencies.
  - Release job bundles .rpm, .deb, and .tar.gz into the draft release.
  - Added workflow_dispatch with ref_name for manual runs.

- **Dependencies**
  - fuzzy_search.py tries Levenshtein, falls back to pyxdameraulevenshtein (Damerau distance).
  - RPM build uses python3-pyxdameraulevenshtein instead of python3-Levenshtein on AlmaLinux 9.

<sup>Written for commit b91563748a14ff2f5382fb1089747dd8e33d0ddc. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

