### PR TITLE
refactor: rename ExtensionManifestTrigger.keyword to default_keyword

### DIFF
--- a/ulauncher/modes/extensions/extension_controller.py
+++ b/ulauncher/modes/extensions/extension_controller.py
@@ -18,7 +18,6 @@ from ulauncher.modes.extensions.extension_dependencies import ExtensionDependenc
 from ulauncher.modes.extensions.extension_manifest import (
     ExtensionManifest,
     ExtensionManifestPreference,
-    ExtensionManifestTrigger,
 )
 from ulauncher.modes.extensions.extension_remote import ExtensionRemote
 from ulauncher.modes.extensions.extension_runtime import ExtensionRuntime
@@ -32,8 +31,12 @@ class ExtensionPreference(ExtensionManifestPreference):
     value: str | int | None = None
 
 
-class ExtensionControllerTrigger(ExtensionManifestTrigger):
-    pass
+class ExtensionControllerTrigger(JsonConf):
+    name = ""
+    description = ""
+    default_keyword = ""
+    icon = ""
+    keyword = ""
 
 
 class ExtensionState(JsonConf):
@@ -153,8 +156,7 @@ class ExtensionController:
         triggers = {}
         for t_id, manifest_trigger in self.manifest.triggers.items():
             trigger = ExtensionControllerTrigger(manifest_trigger)
-            if user_keyword := user_prefs_json.get("triggers", {}).get(t_id, {}).get("keyword", trigger.keyword):
-                trigger.keyword = user_keyword
+            trigger.keyword = user_prefs_json.get("triggers", {}).get(t_id, {}).get("keyword", trigger.default_keyword)
             triggers[t_id] = trigger
 
         return triggers
@@ -278,7 +280,7 @@ class ExtensionController:
                 cmd = [sys.executable, "-m", "debugpy", "--listen", "0.0.0.0:5678", "--wait-for-client", extension_main]
 
             prefs = {p_id: pref.value for p_id, pref in self.preferences.items()}
-            triggers = {t_id: t.keyword for t_id, t in self.manifest.triggers.items() if t.keyword}
+            triggers = {t_id: t.default_keyword for t_id, t in self.manifest.triggers.items() if t.default_keyword}
             # backwards compatible v2 preferences format (with keywords added back)
             v2_prefs = {**triggers, **prefs}
             env = {

--- a/ulauncher/modes/extensions/extension_manifest.py
+++ b/ulauncher/modes/extensions/extension_manifest.py
@@ -29,8 +29,14 @@ class ExtensionManifestPreference(JsonConf):
 class ExtensionManifestTrigger(JsonConf):
     name = ""
     description = ""
-    keyword = ""
+    default_keyword = ""
     icon = ""
+
+    def __setitem__(self, key: str, value: Any) -> None:  # type: ignore[override]
+        # Backwards compatibility: rename "keyword" to "default_keyword"
+        if key == "keyword":
+            key = "default_keyword"
+        super().__setitem__(key, value)
 
 
 class ExtensionManifest(JsonConf):
@@ -76,7 +82,7 @@ class ExtensionManifest(JsonConf):
                                 self.triggers[p_id] = ExtensionManifestTrigger(
                                     name=pref.name,
                                     description=pref.description,
-                                    keyword=pref.default_value,
+                                    default_keyword=pref.default_value,
                                     icon=pref.get("icon", ""),
                                 )
                 value = prefs


### PR DESCRIPTION
Renamed `ExtensionManifestTrigger.keyword` to `ExtensionManifestTrigger.default_keyword` to clarify that this property represents the default keyword defined in the extension's manifest, not the actual keyword being used (which may be customized by users).

Old manifests using `"keyword"` are automatically converted to `"default_keyword"` via `__setitem__()` override
ExtensionControllerTrigger no longer inherits from ExtensionManifestTrigger because we don't want the same conversion to apply for that class ^

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Renamed ExtensionManifestTrigger.keyword to default_keyword to clarify it stores the manifest’s default keyword, not the user’s chosen keyword. Added backward compatibility and separated controller trigger logic to keep default and user keywords distinct.

- **Refactors**
  - Renamed keyword -> default_keyword in ExtensionManifestTrigger, with automatic conversion on load.
  - ExtensionControllerTrigger no longer inherits from ExtensionManifestTrigger; now has default_keyword and keyword fields.
  - Controller sets trigger.keyword from user prefs, falling back to default_keyword.
  - Env/v2 prefs now send triggers using default_keyword.

- **Migration**
  - Read manifest triggers from default_keyword instead of keyword.
  - Old manifests using "keyword" still work.
  - Use ExtensionControllerTrigger.keyword to access the active (user) keyword.

<sup>Written for commit 4f88638f9763c43b5fe2aa721d71ece3b94b1d6e. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

