### PR TITLE
refactor: use dunder all for extension module wrappers

### DIFF
--- a/ulauncher/api/__init__.py
+++ b/ulauncher/api/__init__.py
@@ -1,7 +1,8 @@
-# ruff: noqa: F401
 from ulauncher.api.extension import Extension
 from ulauncher.internals import effects
 from ulauncher.internals.result import Result
+
+__all__ = ["Extension", "ExtensionResult", "ExtensionSmallResult", "Result", "effects"]
 
 
 class ExtensionResult(Result):

--- a/ulauncher/api/client/Extension.py
+++ b/ulauncher/api/client/Extension.py
@@ -1,1 +1,3 @@
-from ulauncher.api.extension import Extension  # noqa: F401, N999
+from ulauncher.api.extension import Extension  # noqa: N999
+
+__all__ = ["Extension"]

--- a/ulauncher/api/shared/action/DoNothingAction.py
+++ b/ulauncher/api/shared/action/DoNothingAction.py
@@ -1,1 +1,3 @@
-from ulauncher.internals.effects import do_nothing as DoNothingAction  # noqa: F401, N812, N999
+from ulauncher.internals.effects import do_nothing as DoNothingAction  # noqa: N812, N999
+
+__all__ = ["DoNothingAction"]

--- a/ulauncher/api/shared/action/HideWindowAction.py
+++ b/ulauncher/api/shared/action/HideWindowAction.py
@@ -1,1 +1,3 @@
-from ulauncher.internals.effects import close_window as HideWindowAction  # noqa: F401, N812, N999
+from ulauncher.internals.effects import close_window as HideWindowAction  # noqa: N812, N999
+
+__all__ = ["HideWindowAction"]

--- a/ulauncher/api/shared/action/OpenAction.py
+++ b/ulauncher/api/shared/action/OpenAction.py
@@ -1,1 +1,3 @@
-from ulauncher.internals.effects import open as OpenAction  # noqa: F401, N999, N812
+from ulauncher.internals.effects import open as OpenAction  # noqa: N812, N999
+
+__all__ = ["OpenAction"]

--- a/ulauncher/api/shared/action/OpenUrlAction.py
+++ b/ulauncher/api/shared/action/OpenUrlAction.py
@@ -1,1 +1,3 @@
-from ulauncher.internals.effects import open as OpenUrlAction  # noqa: F401, N999, N812
+from ulauncher.internals.effects import open as OpenUrlAction  # noqa: N812, N999
+
+__all__ = ["OpenUrlAction"]

--- a/ulauncher/api/shared/action/SetUserQueryAction.py
+++ b/ulauncher/api/shared/action/SetUserQueryAction.py
@@ -1,1 +1,3 @@
-from ulauncher.internals.effects import set_query as SetUserQueryAction  # noqa: F401, N812, N999
+from ulauncher.internals.effects import set_query as SetUserQueryAction  # noqa: N812, N999
+
+__all__ = ["SetUserQueryAction"]

--- a/ulauncher/api/shared/query.py
+++ b/ulauncher/api/shared/query.py
@@ -1,2 +1,4 @@
 # Only for backward compatibility with extensions that imported this for types
-from ulauncher.internals.query import Query  # noqa: F401
+from ulauncher.internals.query import Query
+
+__all__ = ["Query"]


### PR DESCRIPTION
Python's `__all__` is the standard, PEP 8 recommended way to declare a module's public API

This lets us remove the F401 suppression comments


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Use __all__ to declare public exports for extension API wrappers, replacing F401 ignores and clarifying the API surface. No behavior change; existing imports remain compatible.

- **Refactors**
  - Added __all__ to api/__init__.py and wrapper modules (Extension, action wrappers, shared/query).
  - Removed F401 suppressions; kept N812/N999 where appropriate.
  - Clarifies public API and reduces linter noise.

<sup>Written for commit 40a6450add25f4063b675d26c19df2ef4b9fdc84. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

