### PR TITLE
fix: local install OSError

### DIFF
--- a/ulauncher/paths.py
+++ b/ulauncher/paths.py
@@ -6,7 +6,7 @@ APPLICATION = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
 # ULAUNCHER_SYSTEM_PREFIX is used by a third party packagers like Nix
 SYSTEM_PREFIX = os.environ.get("ULAUNCHER_SYSTEM_PREFIX", sys.prefix)
 # ULAUNCHER_SYSTEM_DATA_DIR is used when running in dev mode from source and during tests
-ASSETS = os.path.abspath(os.environ.get("ULAUNCHER_SYSTEM_DATA_DIR", f"{SYSTEM_PREFIX}/share/ulauncher"))
+ASSETS = os.path.abspath(os.environ.get("ULAUNCHER_SYSTEM_DATA_DIR", f"{SYSTEM_PREFIX}/local/share/ulauncher"))
 HOME = os.path.expanduser("~")
 XDG_DATA_DIRS = os.environ.get("XDG_DATA_DIRS", f"/usr/local/share/{os.path.pathsep}/usr/share/").split(os.path.pathsep)
 CONFIG = os.path.join(os.environ.get("XDG_CONFIG_HOME", f"{HOME}/.config"), "ulauncher")


### PR DESCRIPTION
Local install of most recent ulauncher beta(27)  with `sudo pip install ./` from root of git repo resulted in error `OSError: usr/share/ulauncher` when  running `ulauncher` from terminal.  
This does not affect usage with `make run`, only local install.

Source of error:  
`ulauncher/paths.py`, line 9 - needs `/local`:  
`ASSETS = os.path.abspath(os.environ.get("ULAUNCHER_SYSTEM_DATA_DIR", f"{SYSTEM_PREFIX}/share/ulauncher"))`  
\>>> `ASSETS = os.path.abspath(os.environ.get("ULAUNCHER_SYSTEM_DATA_DIR", f"{SYSTEM_PREFIX}/local/share/ulauncher"))`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes OSError when running ulauncher after a local pip install. ASSETS now defaults to {SYSTEM_PREFIX}/local/share/ulauncher, matching XDG_DATA_DIRS and preventing missing path errors.

<sup>Written for commit 0f57780de47204ffd79a247fcfa7ced1401cf145. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

