### PR TITLE
feat: resolve sys prefix from binary path

### DIFF
--- a/ulauncher/paths.py
+++ b/ulauncher/paths.py
@@ -3,10 +3,10 @@ import sys
 
 # spec: https://specifications.freedesktop.org/menu-spec/latest/ar01s02.html
 APPLICATION = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
-BIN_DIR = os.path.abspath(sys.argv[0])
+BIN_DIR = os.path.dirname(os.path.abspath(sys.argv[0]))
 # ULAUNCHER_SYSTEM_PREFIX can be used by third party packagers like Nix
 # If not set, derive sys prefix from binary location likely /usr, /usr/local, or ~/.local
-SYSTEM_PREFIX = os.environ.get("ULAUNCHER_SYSTEM_PREFIX", os.path.dirname(os.path.dirname(BIN_DIR)))
+SYSTEM_PREFIX = os.environ.get("ULAUNCHER_SYSTEM_PREFIX", os.path.dirname(BIN_DIR))
 # ULAUNCHER_SYSTEM_DATA_DIR is used when running in dev mode from source and during tests
 ASSETS = os.path.abspath(os.environ.get("ULAUNCHER_SYSTEM_DATA_DIR", f"{SYSTEM_PREFIX}/share/ulauncher"))
 HOME = os.path.expanduser("~")


### PR DESCRIPTION
Ulauncher should be installed with the prefix `/usr` if it's from a package, but if installed with pip it will be `~/.local/` or `/usr/local/` with sudo pip. So to work with all we can't use sys.prefix. We have to resolve relative to the binary.

closes #1648


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Resolve SYSTEM_PREFIX from the parent directory of the Ulauncher binary (sys.argv[0]) instead of sys.prefix, with ULAUNCHER_SYSTEM_PREFIX as an override. Fixes asset path resolution for distro packages (/usr) and pip installs (~/.local or /usr/local), closing #1648.

<sup>Written for commit bea32f27978f1bd8db7e23163ad027ad77660488. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

