### PR TITLE
refactor: rename BaseMode to Mode and make it an abstract class

### DIFF
--- a/ulauncher/modes/apps/app_mode.py
+++ b/ulauncher/modes/apps/app_mode.py
@@ -9,14 +9,18 @@ from ulauncher.internals.query import Query
 from ulauncher.internals.result import Result
 from ulauncher.modes.apps.app_result import AppResult
 from ulauncher.modes.apps.launch_app import launch_app
-from ulauncher.modes.base_mode import BaseMode
+from ulauncher.modes.mode import Mode
 from ulauncher.utils.desktopappinfo import DesktopAppInfo
 from ulauncher.utils.settings import Settings
 
 logger = logging.getLogger()
 
 
-class AppMode(BaseMode):
+class AppMode(Mode):
+    def handle_query(self, _query: Query, callback: Callable[[effects.EffectMessage | list[Result]], None]) -> None:
+        # App mode contributes search triggers but does not handle direct query-mode execution.
+        callback([])
+
     def get_triggers(self) -> Iterator[AppResult]:
         settings = Settings.load()
 

--- a/ulauncher/modes/calc/calc_mode.py
+++ b/ulauncher/modes/calc/calc_mode.py
@@ -12,8 +12,8 @@ from typing import Callable
 from ulauncher.internals import effects
 from ulauncher.internals.query import Query
 from ulauncher.internals.result import Result
-from ulauncher.modes.base_mode import BaseMode
 from ulauncher.modes.calc.calc_result import CalcErrorResult, CalcResult
+from ulauncher.modes.mode import Mode
 from ulauncher.utils.eventbus import EventBus
 
 _events = EventBus()
@@ -145,7 +145,7 @@ def _eval(node: ast.expr) -> int | float | Decimal:
     raise TypeError(node)
 
 
-class CalcMode(BaseMode):
+class CalcMode(Mode):
     def matches_query_str(self, query_str: str) -> bool:
         return _is_enabled(query_str)
 

--- a/ulauncher/modes/extensions/extension_mode.py
+++ b/ulauncher/modes/extensions/extension_mode.py
@@ -13,9 +13,9 @@ from ulauncher.internals import effect_utils, effects
 from ulauncher.internals.effects import EffectMessage, EffectType
 from ulauncher.internals.query import Query
 from ulauncher.internals.result import KeywordTrigger, Result
-from ulauncher.modes.base_mode import BaseMode
 from ulauncher.modes.extensions import extension_registry
 from ulauncher.modes.extensions.extension_controller import ExtensionController
+from ulauncher.modes.mode import Mode
 from ulauncher.utils.eventbus import EventBus
 from ulauncher.utils.singleton import Singleton
 
@@ -36,7 +36,7 @@ class ExtensionLaunchTrigger(Result):
     actions = {"__launch__": {"name": "Launch"}}
 
 
-class ExtensionMode(BaseMode, metaclass=Singleton):
+class ExtensionMode(Mode, metaclass=Singleton):
     """
     Mode that handles extension triggers and communication with extensions.
     Is singleton because it owns the ExtensionSocketServer instance.

--- a/ulauncher/modes/file_browser/file_browser_mode.py
+++ b/ulauncher/modes/file_browser/file_browser_mode.py
@@ -9,8 +9,8 @@ from typing import Callable
 from ulauncher.internals import effects
 from ulauncher.internals.query import Query
 from ulauncher.internals.result import Result
-from ulauncher.modes.base_mode import BaseMode
 from ulauncher.modes.file_browser.results import FileResult, FolderResult
+from ulauncher.modes.mode import Mode
 from ulauncher.utils.eventbus import EventBus
 from ulauncher.utils.fold_user_path import fold_user_path
 
@@ -18,7 +18,7 @@ _events = EventBus()
 logger = logging.getLogger()
 
 
-class FileBrowserMode(BaseMode):
+class FileBrowserMode(Mode):
     LIMIT = 50
     THRESHOLD = 40
 

--- a/ulauncher/modes/mode.py
+++ b/ulauncher/modes/mode.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from abc import ABC, abstractmethod
 from typing import Callable, Iterable
 
 from ulauncher.internals.effects import EffectMessage
@@ -7,10 +8,10 @@ from ulauncher.internals.query import Query
 from ulauncher.internals.result import Result
 
 
-class BaseMode:
+class Mode(ABC):
     def matches_query_str(self, _query_str: str) -> bool:
         """
-        Returns if the input should be handled by the mode.
+        Returns if the input should be handled by the mode (only for dynamic modes without extensions).
         """
         return False
 
@@ -20,11 +21,12 @@ class BaseMode:
         """
         return None
 
+    @abstractmethod
     def handle_query(self, _query: Query, callback: Callable[[EffectMessage | list[Result]], None]) -> None:
         """
         Handle a query and provide the result list via callback.
         """
-        callback([])
+        ...
 
     def get_placeholder_icon(self) -> str | None:
         """
@@ -33,6 +35,9 @@ class BaseMode:
         return None
 
     def get_triggers(self) -> Iterable[Result]:
+        """
+        Return keyword triggers provided by this mode.
+        """
         return []
 
     def has_trigger_changes(self) -> bool:
@@ -53,6 +58,7 @@ class BaseMode:
     def get_fallback_results(self, _query_str: str) -> Iterable[Result]:
         return []
 
+    @abstractmethod
     def activate_result(
         self,
         action_id: str,
@@ -68,8 +74,4 @@ class BaseMode:
         :param query: The current query
         :param callback: Callback to return the action or new results
         """
-        error_msg = (
-            f"{self.__class__.__name__}.activate_result() is not implemented. "
-            "You should override this method to handle result activation."
-        )
-        raise NotImplementedError(error_msg)
+        ...

--- a/ulauncher/modes/shortcuts/shortcut_mode.py
+++ b/ulauncher/modes/shortcuts/shortcut_mode.py
@@ -6,7 +6,7 @@ from typing import Callable, Iterator
 from ulauncher.internals import effects
 from ulauncher.internals.query import Query
 from ulauncher.internals.result import KeywordTrigger, Result
-from ulauncher.modes.base_mode import BaseMode
+from ulauncher.modes.mode import Mode
 from ulauncher.modes.shortcuts import results
 from ulauncher.modes.shortcuts.run_shortcut import run_shortcut
 from ulauncher.modes.shortcuts.shortcuts_db import Shortcut, ShortcutsDb
@@ -32,7 +32,7 @@ def convert_to_result(shortcut: Shortcut, query: Query | None = None) -> results
     )
 
 
-class ShortcutMode(BaseMode):
+class ShortcutMode(Mode):
     shortcuts_db: dict[str, Shortcut]
 
     def __init__(self) -> None:

--- a/ulauncher/utils/singleton.py
+++ b/ulauncher/utils/singleton.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from abc import ABCMeta
 from typing import Any
 
 # Store singleton instances with proper type tracking to prevent type confusion
@@ -14,6 +15,6 @@ def get_instance(supercls: Any, cls: Any, *args: Any, **kwargs: Any) -> Any:
 
 
 # Use with metaclass=Singleton (not possible when inheriting from Gtk classes for example)
-class Singleton(type):
+class Singleton(ABCMeta):
     def __call__(cls, *args: Any, **kwargs: Any) -> Any:
         return get_instance(super(), cls, *args, **kwargs)


### PR DESCRIPTION
Making the class an abstract class instead of having to clarify it in the name.

This looks better in the type declarations imo, ex: `list[Mode]`, and it forces some methods to be explicitly declared.

Singleton(type) didn't work with base classes so had to switch ABCMeta

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Renamed BaseMode to Mode and made it an abstract class to enforce required methods and improve type hints. Updated imports across core and modes; switched Singleton to ABCMeta for compatibility with abstract classes.

- **Refactors**
  - Introduced Mode(ABC) with abstract handle_query and activate_result.
  - Updated AppMode, CalcMode, ExtensionMode, FileBrowserMode, and ShortcutMode to inherit Mode; added a no-op handle_query in AppMode.
  - Adjusted type hints in core (e.g., list[Mode]) and replaced base_mode imports with mode.
  - Updated Singleton to subclass ABCMeta to work with abstract Mode while preserving behavior.

- **Migration**
  - Replace BaseMode with Mode and import from ulauncher.modes.mode.
  - Implement handle_query and activate_result in any new Mode subclasses.

<sup>Written for commit b021670df4070e59cddd37205d2e925d841d39b6. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

