### PR TITLE
fix(window): avoid callback keeping a reference to the window

### DIFF
--- a/ulauncher/app.py
+++ b/ulauncher/app.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import json
 import logging
-from typing import Any, Literal, cast
+from typing import Any, Iterable, Literal, cast
 from weakref import WeakValueDictionary
 
 from gi.repository import Gdk, Gio, Gtk
@@ -141,8 +141,8 @@ class UlauncherApp(Gtk.Application):
             self.windows["main"] = main_window
 
     @events.on
-    def show_results(self, results: list[Result]) -> None:
-        """Do not use. This is only needed because legacy ActionList can contain result lists"""
+    def show_results(self, results: Iterable[Result]) -> None:
+        """Render results in the launcher window if it is currently open."""
         if main_window := cast("UlauncherWindow | None", self.windows.get("main")):
             main_window.show_results(results)
 

--- a/ulauncher/ui/windows/ulauncher_window.py
+++ b/ulauncher/ui/windows/ulauncher_window.py
@@ -21,6 +21,12 @@ logger = logging.getLogger()
 events = EventBus()
 
 
+def emit_show_results(results: Iterable[Result]) -> None:
+    # Keep this callback outside the window class so async mode callbacks never
+    # retain a window instance through a bound method reference.
+    events.emit("app:show_results", list(results))
+
+
 class UlauncherWindow(Gtk.ApplicationWindow):
     _css_provider: Gtk.CssProvider | None = None
     _results_nav: ItemNavigation | None = None
@@ -57,7 +63,6 @@ class UlauncherWindow(Gtk.ApplicationWindow):
             height_request=height_request,
             **kwargs,
         )
-
         # avoid checking layer shell support for known cases it does not apply (for performance reasons)
         if not IS_X11_COMPATIBLE and DESKTOP_ID != "GNOME" and self.settings.layer_shell and layer_shell.is_supported():
             self.layer_shell_enabled = layer_shell.enable(self)
@@ -198,7 +203,7 @@ class UlauncherWindow(Gtk.ApplicationWindow):
             self.prompt_input.select_region(0, -1)
         self.apply_styling()
         self.core.load_triggers(force=True)
-        self.core.set_query(self.query_str, self.show_results)
+        self.core.set_query(self.query_str, emit_show_results)
 
     ######################################
     # GTK Signal Handlers
@@ -222,7 +227,7 @@ class UlauncherWindow(Gtk.ApplicationWindow):
         Triggered by user input
         """
         events.emit("app:set_query", self.prompt_input.get_text(), update_input=False)
-        self.core.set_query(self.query_str, self.show_results)
+        self.core.set_query(self.query_str, emit_show_results)
 
     def activate_result(self, alt: bool) -> None:
         """
@@ -231,7 +236,7 @@ class UlauncherWindow(Gtk.ApplicationWindow):
         if self._results_nav and (result := self._results_nav.get_active_result()):
             if not alt:
                 self._results_nav.remember_result_for_query(str(self.core.query), result)
-            self.core.activate_result(result, self.show_results, alt)
+            self.core.activate_result(result, emit_show_results, alt)
 
     def on_input_key_press(self, entry_widget: Gtk.Entry, event: Gdk.EventKey) -> bool:  # noqa: PLR0911
         """


### PR DESCRIPTION
Since the window is recreated every time it's opened we want to avoid keeping references to it.

Related to #1653, #1650 and 0ce08899

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents memory leaks by making sure async callbacks don’t hold references to UlauncherWindow. The result rendering callback is now module-level so windows can be garbage-collected when closed and reopened.

- **Bug Fixes**
  - Added emit_show_results() at module level to emit “app:show_results” without binding a window instance.
  - Updated set_query and activate_result to use emit_show_results instead of a bound method.
  - Relaxed app.show_results to Iterable[Result] and simplified the docstring; forwards results only if the window is open.

<sup>Written for commit a2c4ecfccf5f0cb5ef439318f648699385b5d5e4. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

