### PR TITLE
fix: find unused port

### DIFF
--- a/ulauncher/api/server/port_finder.py
+++ b/ulauncher/api/server/port_finder.py
@@ -23,6 +23,9 @@ def is_port_in_use(port, host='127.0.0.1'):
     """
     :rtype bool:
     """
-    sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-    result = sock.connect_ex((host, port))
-    return result == 0
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
+        try:
+            sock.bind((host, port))
+            return False
+        except OSError:
+            return True


### PR DESCRIPTION
- Replace connect_ex with bind to reliably detect available ports. connect_ex can falsely report ports as in-use on some loopback configurations. (on my machine socket.connect always returns success, no matter what port number I pass).
  - Without this fix, find_unused_port always raised an exception
- Also fix socket leak in is_port_in_use by using a context manager


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix unreliable port checks that caused `find_unused_port` to fail on some systems, and stop a socket leak.

- **Bug Fixes**
  - `is_port_in_use` now uses `bind` instead of `connect_ex`, preventing false “in use” results on some loopback setups and allowing `find_unused_port` to work.
  - Use a context manager to ensure the socket is closed.

<sup>Written for commit e2e2734b81cac91e52ae30e5348f797df20b66ff. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

