### PR TITLE
chore: more compact `make check` output

### DIFF
--- a/makefile
+++ b/makefile
@@ -135,8 +135,9 @@ check-dev-deps:
 # Run all linters
 lint: check-dev-deps typos ruff pyrefly rumdl
 
-# Run all linters and test
-check: lint pytest
+# Run all linters and unit tests (terse output, use `make pytest` for verbose)
+check: lint
+	@$(MAKE) --no-print-directory pytest PYTEST_ARGS="--no-header -q --override-ini=log_cli=false"
 
 # Lint with pyrefly (type checker)
 pyrefly: check-dev-deps
@@ -162,10 +163,10 @@ rumdl:
 pytest: check-dev-deps
 	@set -euo pipefail
 	if [ -z $(shell eval "command -v xvfb-run") ]; then
-		pytest -p no:cacheprovider tests
+		pytest -p no:cacheprovider $(PYTEST_ARGS) tests
 	else
 		echo -e "xvfb-run detected. Running pytest in a virtual X server environment."
-		xvfb-run --auto-servernum -- pytest -p no:cacheprovider tests
+		xvfb-run --auto-servernum -- pytest -p no:cacheprovider $(PYTEST_ARGS) tests
 	fi
 
 # Auto format the code

--- a/makefile
+++ b/makefile
@@ -140,15 +140,15 @@ check: lint pytest
 
 # Lint with pyrefly (type checker)
 pyrefly: check-dev-deps
-	pyrefly check
+	@pyrefly check
 
 # Lint with ruff
 ruff: check-dev-deps
-	ruff check . && ruff format --check .
+	@ruff check . && ruff format --check .
 
 # Lint with typos (typo checker)
 typos: check-dev-deps
-	typos .
+	@typos .
 
 # Lint markdown files with rumdl (optional, requires Python 3.9+)
 rumdl:


### PR DESCRIPTION
Makes `make check` much less verbose, while keeping `make pytest` the same (it might be good to have the details there).

**Current behavior in this PR**

<img width="1592" height="388" alt="image" src="https://github.com/user-attachments/assets/5378ffe2-dd93-4879-8dbe-7a55ffc37262" />

**With error** (I'd argue this is a lot more helpful than getting the error details drowned out by the successful tests)

<img width="1466" height="708" alt="image" src="https://github.com/user-attachments/assets/ee899be5-40a6-496c-81d3-19ad8a34c4ab" />


**Before (cut off due to being too long)**

<img width="1474" height="1600" alt="image" src="https://github.com/user-attachments/assets/1372f228-29cd-49d6-af2f-61f0aee28fbb" />


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make `make check` much less noisy by running tests in quiet mode and silencing linter command echoes. `make pytest` keeps its normal output by default and now accepts `PYTEST_ARGS` for custom flags.

- **Refactors**
  - Run tests in `make check` with `--no-header -q` and `--override-ini=log_cli=false`.
  - Prefix linter and test commands with `@` to hide command echo in `make` output.
  - Pass `PYTEST_ARGS` through to `pytest` in both normal and `xvfb-run` paths.
  - Keep `make pytest` behavior unchanged unless `PYTEST_ARGS` is provided.

<sup>Written for commit 44513e90ac6eaff3df07b1fa9feb4e59a6315453. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

