### PR TITLE
feat: implement algorithm for app ranking based on recent launch history

### DIFF
--- a/ulauncher/modes/apps/app_result.py
+++ b/ulauncher/modes/apps/app_result.py
@@ -3,7 +3,9 @@ from __future__ import annotations
 import contextlib
 import logging
 import operator
+import time
 from os.path import basename
+from typing import TypedDict
 
 from ulauncher import paths
 from ulauncher.gi import GioUnix
@@ -12,7 +14,18 @@ from ulauncher.utils.json_utils import json_load, json_save
 
 logger = logging.getLogger()
 app_starts_path = f"{paths.STATE}/app_starts.json"
-app_starts: dict[str, int] = json_load(app_starts_path)
+
+class AppStartData(TypedDict):
+    count: int
+    last_launches: list[float]
+
+_raw_app_starts = json_load(app_starts_path)
+app_starts: dict[str, AppStartData] = {}
+for _app_id, _data in _raw_app_starts.items():
+    if isinstance(_data, int):
+        app_starts[_app_id] = {"count": _data, "last_launches": []}
+    elif isinstance(_data, dict):
+        app_starts[_app_id] = {"count": _data.get("count", 0), "last_launches": _data.get("last_launches", [])}
 
 
 class AppResult(Result):
@@ -44,8 +57,29 @@ class AppResult(Result):
 
     @staticmethod
     def get_top_app_ids() -> list[str]:
-        sorted_tuples = sorted(app_starts.items(), key=operator.itemgetter(1), reverse=True)
-        return [*map(operator.itemgetter(0), sorted_tuples)]
+        scores = {app_id: AppResult._calculate_score(data) for app_id, data in app_starts.items()}
+        sorted_ids = sorted(scores.items(), key=operator.itemgetter(1), reverse=True)
+        return [app_id for app_id, score in sorted_ids]
+
+    @staticmethod
+    def _calculate_score(data: AppStartData) -> float:
+        now = time.time()
+        score = data["count"] * 0.1
+        for launch_time in data["last_launches"]:
+            diff = now - launch_time
+            if diff < 86400:
+                score += 100
+            elif diff < 259200:
+                score += 80
+            elif diff < 604800:
+                score += 60
+            elif diff < 1209600:
+                score += 40
+            elif diff < 2592000:
+                score += 20
+            else:
+                score += 10
+        return score
 
     def get_searchable_fields(self) -> list[tuple[str, float]]:
         frequency_weight = 1.0
@@ -62,6 +96,11 @@ class AppResult(Result):
         ]
 
     def bump_starts(self) -> None:
-        starts = app_starts.get(self.app_id, 0)
-        app_starts[self.app_id] = starts + 1
+        data = app_starts.get(self.app_id, {"count": 0, "last_launches": []})
+        data["count"] += 1
+        data["last_launches"].append(time.time())
+        if len(data["last_launches"]) > 10:
+            data["last_launches"].pop(0)
+
+        app_starts[self.app_id] = data
         json_save(app_starts, app_starts_path)

--- a/ulauncher/modes/apps/app_result.py
+++ b/ulauncher/modes/apps/app_result.py
@@ -5,27 +5,41 @@ import logging
 import operator
 import time
 from os.path import basename
-from typing import TypedDict
 
 from ulauncher import paths
 from ulauncher.gi import GioUnix
 from ulauncher.internals.result import Result
+from ulauncher.utils.basedataclass import BaseDataClass
 from ulauncher.utils.json_utils import json_load, json_save
 
 logger = logging.getLogger()
 app_starts_path = f"{paths.STATE}/app_starts.json"
 
-class AppStartData(TypedDict):
-    count: int
-    last_launches: list[float]
+
+class AppStartData(BaseDataClass):
+    count = 0
+    last_launches: list[float] = []
 
 _raw_app_starts = json_load(app_starts_path)
 app_starts: dict[str, AppStartData] = {}
 for _app_id, _data in _raw_app_starts.items():
+    _valid_count = 0
+    _valid_launches: list[float] = []
+
     if isinstance(_data, int):
-        app_starts[_app_id] = {"count": _data, "last_launches": []}
+        _valid_count = _data
     elif isinstance(_data, dict):
-        app_starts[_app_id] = {"count": _data.get("count", 0), "last_launches": _data.get("last_launches", [])}
+        _raw_count = _data.get("count")
+        if isinstance(_raw_count, int):
+            _valid_count = _raw_count
+        elif isinstance(_raw_count, str) and _raw_count.isdigit():
+            _valid_count = int(_raw_count)
+
+        _raw_launches = _data.get("last_launches")
+        if isinstance(_raw_launches, (list, tuple)):
+            _valid_launches = [float(_x) for _x in _raw_launches if isinstance(_x, (int, float))][-10:]
+
+    app_starts[_app_id] = AppStartData(count=_valid_count, last_launches=_valid_launches)
 
 
 class AppResult(Result):
@@ -96,11 +110,14 @@ class AppResult(Result):
         ]
 
     def bump_starts(self) -> None:
-        data = app_starts.get(self.app_id, {"count": 0, "last_launches": []})
-        data["count"] += 1
-        data["last_launches"].append(time.time())
-        if len(data["last_launches"]) > 10:
-            data["last_launches"].pop(0)
+        data = app_starts.get(self.app_id)
+        if not data:
+            data = AppStartData()
+            app_starts[self.app_id] = data
 
-        app_starts[self.app_id] = data
+        data.count += 1
+        data.last_launches.append(time.time())
+        if len(data.last_launches) > 10:
+            data.last_launches.pop(0)
+
         json_save(app_starts, app_starts_path)


### PR DESCRIPTION
<!--
Thank you for submitting a PR to Ulauncher!

Please read our contribution instructions if you haven't:
https://github.com/Ulauncher/Ulauncher#code-contribution

* Explain the changes in this PR and link to related issue(s) if applicable
* When applicable, please update the documentation according to your changes.
* Ensure that the PR doesn't break existing tests, and please add your own if applicable.

A git action will verify your PR, but you can also test locally with `make check`

-->

Closes: #1434

Description:
This PR improves the frequent apps logic by replacing the launch counter with a scoring algorithm. Currently, Ulauncher only stores the total number of launches, which means old favorite apps can remain at the top of the search results even after the user has switched to a new frequent app.

This change introduces a more dynamic system that weights recent launches much more heavily than old ones ensuring the list stays correct to current usage patterns. Last 10 app launch timestamps are stored to calculate the score.

I made this scoring pattern:

< 1 day = 100
< 3 day = 80
< 7 day = 60
< 14 day = 40
< 30 day = 20
older than that = 10

Total Count = 0.1/launch

Final Score = (total_count * 0.1) + sum(points_for_each_recent_launch)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaces the simple launch counter with a recency‑weighted ranking so recently used apps appear first. Stores the last 10 launches and computes a score that better reflects current usage.

- **New Features**
  - Recency-based scoring per launch: <1d 100, <3d 80, <7d 60, <14d 40, <30d 20, else 10; plus 0.1 per total launch.
  - Persists last 10 launch timestamps and trims the list on bump.
  - Ranks apps by computed score in `get_top_app_ids`.
  - Backward-compatible load of `app_starts.json` (int-only entries mapped to `{count, last_launches: []}`).

- **Bug Fixes**
  - Hardened data loading: uses `BaseDataClass`; validates and coerces `count` (int or digit string) and `last_launches` (int/float to float), trimming to 10.

<sup>Written for commit 59d9f7559a1806fd88fcd6c07e27b2c00a1ab2af. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

