### PR TITLE
refactor: shortcuts improvements

### DIFF
--- a/tests/modes/shortcuts/test_shortcut_mode.py
+++ b/tests/modes/shortcuts/test_shortcut_mode.py
@@ -10,7 +10,7 @@ from ulauncher.internals.query import Query
 from ulauncher.internals.result import Result
 from ulauncher.modes.shortcuts.results import ShortcutResult, ShortcutStaticTrigger
 from ulauncher.modes.shortcuts.shortcut_mode import ShortcutMode
-from ulauncher.modes.shortcuts.shortcuts_db import Shortcut
+from ulauncher.modes.shortcuts.shortcuts import Shortcut
 
 
 def get_results(mode: ShortcutMode, query: Query) -> list[Result]:
@@ -26,8 +26,8 @@ class TestShortcutMode:
         return ShortcutMode()
 
     @pytest.fixture(autouse=True)
-    def shortcuts_db(self, mocker: MockerFixture) -> Any:
-        return mocker.patch("ulauncher.modes.shortcuts.shortcut_mode.ShortcutsDb.load").return_value
+    def shortcuts(self, mocker: MockerFixture) -> Any:
+        return mocker.patch("ulauncher.modes.shortcuts.shortcut_mode.Shortcuts.load").return_value
 
     @pytest.fixture(autouse=True)
     def run_shortcut(self, mocker: MockerFixture) -> Any:
@@ -37,55 +37,53 @@ class TestShortcutMode:
     def shortcut_result(self, mocker: MockerFixture) -> Any:
         return mocker.patch("ulauncher.modes.shortcuts.shortcut_mode.results.ShortcutResult")
 
-    def test_is_enabled__query_starts_with_query__returns_false(
-        self, mode: ShortcutMode, shortcuts_db: MagicMock
-    ) -> None:
+    def test_is_enabled__query_starts_with_query__returns_false(self, mode: ShortcutMode, shortcuts: MagicMock) -> None:
         query = "kw"
         shortcut = Shortcut(keyword="kw")
-        shortcuts_db.values.return_value = [shortcut]
+        shortcuts.values.return_value = [shortcut]
 
         assert not mode.matches_query_str(query)
 
     def test_is_enabled__query_doesnt_start_with_query__returns_false(
-        self, mode: ShortcutMode, shortcuts_db: MagicMock
+        self, mode: ShortcutMode, shortcuts: MagicMock
     ) -> None:
         query = "wk something"
         shortcut = Shortcut(keyword="kw")
-        shortcuts_db.values.return_value = [shortcut]
+        shortcuts.values.return_value = [shortcut]
 
         assert not mode.matches_query_str(query)
 
     def test_handle_query__return_value__is(
-        self, mode: ShortcutMode, shortcuts_db: MagicMock, shortcut_result: ShortcutResult
+        self, mode: ShortcutMode, shortcuts: MagicMock, shortcut_result: ShortcutResult
     ) -> None:
         query = Query("kw", "something")
         shortcut = Shortcut(keyword="kw")
-        shortcuts_db.values.return_value = [shortcut]
+        shortcuts.values.return_value = [shortcut]
 
         assert get_results(mode, query)[0] == shortcut_result.return_value
 
     def test_handle_query__shortcut_result__is_called(
-        self, mode: ShortcutMode, shortcuts_db: MagicMock, shortcut_result: ShortcutResult
+        self, mode: ShortcutMode, shortcuts: MagicMock, shortcut_result: ShortcutResult
     ) -> None:
         query = Query("kw", "something")
         shortcut = Shortcut(keyword="kw")
-        shortcuts_db.values.return_value = [shortcut]
+        shortcuts.values.return_value = [shortcut]
 
         get_results(mode, query)
 
         shortcut_result.assert_called_once_with(**shortcut, description="")
 
     def test_get_default_items__shortcut_results__returned(
-        self, mode: ShortcutMode, shortcuts_db: MagicMock, shortcut_result: ShortcutResult
+        self, mode: ShortcutMode, shortcuts: MagicMock, shortcut_result: ShortcutResult
     ) -> None:
         shortcut = Shortcut(keyword="kw", is_default_search=True)
-        shortcuts_db.values.return_value = [shortcut]
+        shortcuts.values.return_value = [shortcut]
 
         assert mode.get_fallback_results("") == [shortcut_result.return_value]
 
-    def test_get_triggers(self, mode: ShortcutMode, shortcuts_db: MagicMock) -> None:
+    def test_get_triggers(self, mode: ShortcutMode, shortcuts: MagicMock) -> None:
         shortcut = Shortcut(keyword="kw")
-        shortcuts_db.values.return_value = [shortcut]
+        shortcuts.values.return_value = [shortcut]
         assert next(mode.get_triggers()).keyword == "kw"
 
     def test_activate_static_trigger(self, mode: ShortcutMode, run_shortcut: MagicMock) -> None:

--- a/tests/modes/shortcuts/test_shortcut_mode.py
+++ b/tests/modes/shortcuts/test_shortcut_mode.py
@@ -10,7 +10,7 @@ from ulauncher.internals.query import Query
 from ulauncher.internals.result import Result
 from ulauncher.modes.shortcuts.results import ShortcutResult, ShortcutStaticTrigger
 from ulauncher.modes.shortcuts.shortcut_mode import ShortcutMode
-from ulauncher.modes.shortcuts.shortcuts_db import Shortcut as ShortcutRecord
+from ulauncher.modes.shortcuts.shortcuts_db import Shortcut
 
 
 def get_results(mode: ShortcutMode, query: Query) -> list[Result]:
@@ -41,7 +41,7 @@ class TestShortcutMode:
         self, mode: ShortcutMode, shortcuts_db: MagicMock
     ) -> None:
         query = "kw"
-        shortcut = ShortcutRecord(keyword="kw")
+        shortcut = Shortcut(keyword="kw")
         shortcuts_db.values.return_value = [shortcut]
 
         assert not mode.matches_query_str(query)
@@ -50,7 +50,7 @@ class TestShortcutMode:
         self, mode: ShortcutMode, shortcuts_db: MagicMock
     ) -> None:
         query = "wk something"
-        shortcut = ShortcutRecord(keyword="kw")
+        shortcut = Shortcut(keyword="kw")
         shortcuts_db.values.return_value = [shortcut]
 
         assert not mode.matches_query_str(query)
@@ -59,7 +59,7 @@ class TestShortcutMode:
         self, mode: ShortcutMode, shortcuts_db: MagicMock, shortcut_result: ShortcutResult
     ) -> None:
         query = Query("kw", "something")
-        shortcut = ShortcutRecord(keyword="kw")
+        shortcut = Shortcut(keyword="kw")
         shortcuts_db.values.return_value = [shortcut]
 
         assert get_results(mode, query)[0] == shortcut_result.return_value
@@ -68,7 +68,7 @@ class TestShortcutMode:
         self, mode: ShortcutMode, shortcuts_db: MagicMock, shortcut_result: ShortcutResult
     ) -> None:
         query = Query("kw", "something")
-        shortcut = ShortcutRecord(keyword="kw")
+        shortcut = Shortcut(keyword="kw")
         shortcuts_db.values.return_value = [shortcut]
 
         get_results(mode, query)
@@ -78,13 +78,13 @@ class TestShortcutMode:
     def test_get_default_items__shortcut_results__returned(
         self, mode: ShortcutMode, shortcuts_db: MagicMock, shortcut_result: ShortcutResult
     ) -> None:
-        shortcut = ShortcutRecord(keyword="kw", is_default_search=True)
+        shortcut = Shortcut(keyword="kw", is_default_search=True)
         shortcuts_db.values.return_value = [shortcut]
 
         assert mode.get_fallback_results("") == [shortcut_result.return_value]
 
     def test_get_triggers(self, mode: ShortcutMode, shortcuts_db: MagicMock) -> None:
-        shortcut = ShortcutRecord(keyword="kw")
+        shortcut = Shortcut(keyword="kw")
         shortcuts_db.values.return_value = [shortcut]
         assert next(mode.get_triggers()).keyword == "kw"
 

--- a/tests/modes/shortcuts/test_shortcuts.py
+++ b/tests/modes/shortcuts/test_shortcuts.py
@@ -1,0 +1,47 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from ulauncher.modes.shortcuts.shortcuts import Shortcut, Shortcuts
+
+
+class TestShortcut:
+    def test_coerces_legacy_icon_path(self) -> None:
+        shortcut = Shortcut(icon="/media/google-search-icon.svg")
+
+        assert shortcut.icon == "/icons/google-search.svg"
+
+    def test_folds_user_icon_path(self) -> None:
+        shortcut = Shortcut(icon=str(Path.home() / "icons" / "custom.png"))
+
+        assert shortcut.icon == "~/icons/custom.png"
+
+    def test_converts_legacy_float_timestamp(self) -> None:
+        shortcut = Shortcut(added=123.5)
+
+        assert shortcut.added == 123
+
+
+class TestShortcuts:
+    def test_dict_values_are_coerced_on_set(self) -> None:
+        shortcuts = Shortcuts({"first": {"name": "first"}})
+        shortcuts["second"] = {"name": "second"}
+
+        assert isinstance(shortcuts["first"], Shortcut)
+        assert shortcuts["first"].name == "first"
+        assert isinstance(shortcuts["second"], Shortcut)
+        assert shortcuts["second"].name == "second"
+
+    def test_accepts_shortcut_instances(self) -> None:
+        shortcut = Shortcut(name="Test")
+        shortcuts = Shortcuts({"test": shortcut})
+
+        assert shortcuts["test"] == shortcut
+
+    def test_none_value_deletes_key(self) -> None:
+        shortcuts = Shortcuts()
+        shortcuts["custom"] = {"keyword": "c"}
+
+        shortcuts["custom"] = None
+
+        assert "custom" not in shortcuts

--- a/tests/modes/shortcuts/test_shortcuts.py
+++ b/tests/modes/shortcuts/test_shortcuts.py
@@ -39,9 +39,10 @@ class TestShortcuts:
         assert shortcuts["test"] == shortcut
 
     def test_none_value_deletes_key(self) -> None:
-        shortcuts = Shortcuts()
-        shortcuts["custom"] = {"keyword": "c"}
+        shortcuts = Shortcuts({"custom": {"keyword": "c"}})
 
         shortcuts["custom"] = None
 
         assert "custom" not in shortcuts
+
+        shortcuts["custom"] = None  # ensure it does not raise KeyError if key already deleted

--- a/ulauncher/modes/shortcuts/shortcut_mode.py
+++ b/ulauncher/modes/shortcuts/shortcut_mode.py
@@ -9,7 +9,7 @@ from ulauncher.internals.result import KeywordTrigger, Result
 from ulauncher.modes.mode import Mode
 from ulauncher.modes.shortcuts import results
 from ulauncher.modes.shortcuts.run_shortcut import run_shortcut
-from ulauncher.modes.shortcuts.shortcuts_db import Shortcut, ShortcutsDb
+from ulauncher.modes.shortcuts.shortcuts import Shortcut, Shortcuts
 
 logger = logging.getLogger()
 
@@ -33,13 +33,13 @@ def convert_to_result(shortcut: Shortcut, query: Query | None = None) -> results
 
 
 class ShortcutMode(Mode):
-    shortcuts_db: dict[str, Shortcut]
+    shortcuts: dict[str, Shortcut]
 
     def __init__(self) -> None:
-        self.shortcuts_db = ShortcutsDb.load()
+        self.shortcuts = Shortcuts.load()
 
     def _get_active_shortcut(self, query: Query) -> Shortcut | None:
-        for s in self.shortcuts_db.values():
+        for s in self.shortcuts.values():
             if query.keyword == s.keyword and (query.is_active or s.run_without_argument):
                 return s
 
@@ -55,10 +55,10 @@ class ShortcutMode(Mode):
 
     def get_fallback_results(self, query_str: str) -> list[results.ShortcutResult]:
         query = Query(None, query_str)
-        return [convert_to_result(s, query) for s in self.shortcuts_db.values() if s["is_default_search"]]
+        return [convert_to_result(s, query) for s in self.shortcuts.values() if s["is_default_search"]]
 
     def get_triggers(self) -> Iterator[Result]:
-        for shortcut in self.shortcuts_db.values():
+        for shortcut in self.shortcuts.values():
             yield (
                 results.ShortcutStaticTrigger(**shortcut, description=get_description(shortcut))
                 if shortcut.run_without_argument

--- a/ulauncher/modes/shortcuts/shortcuts.py
+++ b/ulauncher/modes/shortcuts/shortcuts.py
@@ -61,7 +61,7 @@ class Shortcut(JsonConf):
 
 class Shortcuts(JsonConf):
     # Coerce all dict values to Shortcut instances
-    def __setitem__(self, key: str, value: dict[str, Any], validate_type: bool = True) -> None:
+    def __setitem__(self, key: str, value: dict[str, Any] | None, validate_type: bool = True) -> None:
         if value is None:
             del self[key]
             return

--- a/ulauncher/modes/shortcuts/shortcuts.py
+++ b/ulauncher/modes/shortcuts/shortcuts.py
@@ -63,7 +63,7 @@ class Shortcuts(JsonConf):
     # Coerce all dict values to Shortcut instances
     def __setitem__(self, key: str, value: dict[str, Any] | None, validate_type: bool = True) -> None:
         if value is None:
-            del self[key]
+            self.pop(key, None)
             return
         super().__setitem__(key, Shortcut(value), validate_type)
 

--- a/ulauncher/modes/shortcuts/shortcuts.py
+++ b/ulauncher/modes/shortcuts/shortcuts.py
@@ -9,6 +9,33 @@ from ulauncher import paths
 from ulauncher.utils.fold_user_path import fold_user_path
 from ulauncher.utils.json_conf import JsonConf
 
+INITIAL_SHORTCUTS = [
+    {
+        "id": "googlesearch",
+        "keyword": "g",
+        "name": "Google Search",
+        "cmd": "https://google.com/search?q=%s",
+        "icon": f"{paths.ASSETS}/icons/google-search.png",
+        "is_default_search": True,
+    },
+    {
+        "id": "stackoverflow",
+        "keyword": "so",
+        "name": "Stack Overflow",
+        "cmd": "https://stackoverflow.com/search?q=%s",
+        "icon": f"{paths.ASSETS}/icons/stackoverflow.svg",
+        "is_default_search": True,
+    },
+    {
+        "id": "wikipedia",
+        "keyword": "wiki",
+        "name": "Wikipedia",
+        "cmd": "https://en.wikipedia.org/wiki/%s",
+        "icon": f"{paths.ASSETS}/icons/wikipedia.png",
+        "is_default_search": True,
+    },
+]
+
 
 class Shortcut(JsonConf):
     name = ""
@@ -46,35 +73,7 @@ class Shortcuts(JsonConf):
         instance = super().load(file_path)
         if not file_path.exists():
             added = int(time())
-            keywords = [
-                Shortcut(
-                    id="googlesearch",
-                    added=added,
-                    keyword="g",
-                    name="Google Search",
-                    cmd="https://google.com/search?q=%s",
-                    icon=f"{paths.ASSETS}/icons/google-search.png",
-                    is_default_search=True,
-                ),
-                Shortcut(
-                    id="stackoverflow",
-                    added=added,
-                    keyword="so",
-                    name="Stack Overflow",
-                    cmd="https://stackoverflow.com/search?q=%s",
-                    icon=f"{paths.ASSETS}/icons/stackoverflow.svg",
-                    is_default_search=True,
-                ),
-                Shortcut(
-                    id="wikipedia",
-                    added=added,
-                    keyword="wiki",
-                    name="Wikipedia",
-                    cmd="https://en.wikipedia.org/wiki/%s",
-                    icon=f"{paths.ASSETS}/icons/wikipedia.png",
-                    is_default_search=True,
-                ),
-            ]
+            keywords = [Shortcut(**kw, added=added) for kw in INITIAL_SHORTCUTS]
             instance.save({keyword.id: keyword for keyword in keywords})
 
         return instance

--- a/ulauncher/modes/shortcuts/shortcuts.py
+++ b/ulauncher/modes/shortcuts/shortcuts.py
@@ -21,23 +21,23 @@ class Shortcut(JsonConf):
     id = ""
 
     def __setitem__(self, key: str, value: Any) -> None:  # type: ignore[override]
+        if key == "added" and isinstance(value, float):
+            # convert legacy float timestamps ulauncher used
+            value = int(value)
+
         # icon path has changed in v6, from /media/{google-search,stackoverflow,wikipedia}-icon.svg to /icons/*.svg
-        if key == "icon":
+        if key == "icon" and isinstance(value, str):
+            value = fold_user_path(value)
             value = re.sub(r"/media/(.*?)-icon", "/icons/\\1", value)
         super().__setitem__(key, value)
 
 
 class Shortcuts(JsonConf):
-    # Coerce all values to Shortcuts instead of dict and fold the icon path
+    # Coerce all dict values to Shortcut instances
     def __setitem__(self, key: str, value: dict[str, Any], validate_type: bool = True) -> None:
         if value is None:
             del self[key]
             return
-        if "added" in value and isinstance(value.get("added"), float):
-            # convert legacy float timestamps ulauncher used
-            value["added"] = int(value["added"])
-        if "icon" in value:
-            value["icon"] = fold_user_path(value["icon"])
         super().__setitem__(key, Shortcut(value), validate_type)
 
     @classmethod

--- a/ulauncher/modes/shortcuts/shortcuts.py
+++ b/ulauncher/modes/shortcuts/shortcuts.py
@@ -27,7 +27,7 @@ class Shortcut(JsonConf):
         super().__setitem__(key, value)
 
 
-class ShortcutsDb(JsonConf):
+class Shortcuts(JsonConf):
     # Coerce all values to Shortcuts instead of dict and fold the icon path
     def __setitem__(self, key: str, value: dict[str, Any], validate_type: bool = True) -> None:
         if value is None:
@@ -41,7 +41,7 @@ class ShortcutsDb(JsonConf):
         super().__setitem__(key, Shortcut(value), validate_type)
 
     @classmethod
-    def load(cls) -> ShortcutsDb:  # type: ignore[override]
+    def load(cls) -> Shortcuts:  # type: ignore[override]
         file_path = Path(f"{paths.CONFIG}/shortcuts.json")
         instance = super().load(file_path)
         if not file_path.exists():

--- a/ulauncher/ui/windows/preferences/views/shortcuts.py
+++ b/ulauncher/ui/windows/preferences/views/shortcuts.py
@@ -5,7 +5,7 @@ from time import time
 from typing import cast
 
 from ulauncher.gi import Gtk, Pango
-from ulauncher.modes.shortcuts.shortcuts_db import Shortcut, ShortcutsDb
+from ulauncher.modes.shortcuts.shortcuts import Shortcut, Shortcuts
 from ulauncher.ui.windows.preferences import views
 from ulauncher.ui.windows.preferences.utils.ext_utils import autofmt_pango_code_block
 from ulauncher.ui.windows.preferences.utils.sidebar_layout import SidebarItem, SidebarLayout
@@ -230,7 +230,7 @@ class ShortcutsView(views.BaseView):
     def _load_shortcut_list(self) -> None:
         """Load shortcuts from database and populate sidebar"""
         # Load shortcuts data
-        self.shortcuts = cast("dict[str, Shortcut]", ShortcutsDb.load())
+        self.shortcuts = cast("dict[str, Shortcut]", Shortcuts.load())
 
         # Convert shortcuts to SidebarItems
         items: list[SidebarItem] = []
@@ -280,8 +280,8 @@ class ShortcutsView(views.BaseView):
         )
         if response == Gtk.ResponseType.YES:
             # Remove from database
-            shortcuts_db = ShortcutsDb.load()
-            shortcuts_db.save({self.active_shortcut_id: None})
+            shortcuts = Shortcuts.load()
+            shortcuts.save({self.active_shortcut_id: None})
             self.active_shortcut_id = None
             self._load_shortcut_list()
             # Show placeholder after deletion
@@ -341,8 +341,8 @@ class ShortcutsView(views.BaseView):
             added=existing_shortcut.get("added", int(time())),
         )
 
-        shortcuts_db = ShortcutsDb.load()
-        shortcuts_db.save({shortcut_id: shortcut})
+        shortcuts = Shortcuts.load()
+        shortcuts.save({shortcut_id: shortcut})
 
         # Disable save button after successful save
         save_button.set_sensitive(False)


### PR DESCRIPTION
Main change is renaming ShortcutDb to Shortcuts. The other stuff is minor.

This is in preparation for an helper class for KeyValue JSON configs as Shortcuts is untyped now.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Renamed shortcuts storage to `Shortcuts` and centralized legacy data coercion in `Shortcut`. This simplifies the API and keeps old configs working while preparing for a typed KeyValue JSON helper.

- **Refactors**
  - Renamed `ShortcutsDb` to `Shortcuts`; updated imports in `shortcut_mode` and preferences view.
  - Moved icon path folding, legacy `/media/*-icon` to `/icons/*` conversion, and float timestamp to int conversion into `Shortcut.__setitem__`.
  - Introduced `INITIAL_SHORTCUTS` and seeded config in `Shortcuts.load()` when missing.
  - Updated `Shortcuts.__setitem__` to coerce dicts to `Shortcut`.

- **Bug Fixes**
  - Made `None`-as-delete idempotent in `Shortcuts.__setitem__` to avoid errors when the key is missing.

<sup>Written for commit 88ad44e3acf37d0caf7c1b6f55bf91e46dcdc058. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

