### PR TITLE
chore: cache container histfile in project env dir

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,6 +29,7 @@ yarn-debug.log*
 yarn-error.log*
 data/preferences
 .venv
+/.container-env
 /nix/result
 /nix/dev
 /result

--- a/makefile
+++ b/makefile
@@ -82,12 +82,14 @@ run:
 run-container:
 	@set -euo pipefail
 	SHELL_CMD=bash
+	HISTFILE_CONTAINER_PATH=/root/.bash_history
 	VOL_SUFFIX=""
 	if [ -z "${DOCKER_BIN}" ]; then
 		echo -e "${BOLD}You need podman or docker to run this command${RESET}"
 		exit 1
 	fi
 	if [[ "${DOCKER_BIN}" == $(shell eval "command -v docker") ]]; then
+		HISTFILE_CONTAINER_PATH=/home/ulauncher/.bash_history
 		SHELL_CMD="usermod -a -G sudo ulauncher; echo 'ulauncher ALL=(ALL) NOPASSWD:ALL' >> /etc/sudoers; sudo --preserve-env -H -u ulauncher bash"
 		if [[ $$UID != 1000 ]]; then
 			SHELL_CMD="usermod -u $$UID ulauncher; $$SHELL_CMD"
@@ -100,12 +102,13 @@ run-container:
 	if command -v selinuxenabled && selinuxenabled; then
 		VOL_SUFFIX=":z"
 	fi
+	mkdir -p .container-env && touch .container-env/.bash_history
 	# port 3002 is used for developing Preferences UI
 	exec ${DOCKER_BIN} run \
 		--rm \
 		-it \
 		-v "${PWD}:/src/ulauncher$$VOL_SUFFIX" \
-		-v "$$HOME/.bash_history:/home/ulauncher/.bash_history$$VOL_SUFFIX" \
+		-v "${PWD}/.container-env/.bash_history:$$HISTFILE_CONTAINER_PATH$$VOL_SUFFIX" \
 		-p 3002:3002 \
 		--name ulauncher \
 		"docker.io/${DOCKER_IMAGE}" \


### PR DESCRIPTION
Store histfile for the ulauncher container in a hidden gitignored project dir instead of syncing it with the host user bash histfile.

The old solution was handy if you didn't use bash on your host, but very strange to use the real user histfile. And it also didn't work for podman.

This should fix both of those issues and also support adding more data to this .container-env dir such as a .venv cache.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Move container bash history to `.container-env/.bash_history` in the project. This fixes `podman` runs and avoids mounting the host `~/.bash_history`.

- **Bug Fixes**
  - Select container history path per runtime: `/home/ulauncher/.bash_history` for `docker`, `/root/.bash_history` for `podman`.
  - Auto-create `.container-env` and history file; add `/.container-env` to `.gitignore`.
  - Update `make run-container` volume mount to the project-scoped file; SELinux handling unchanged.

<sup>Written for commit 170d9242cd625928022976b53e24f783bfb34dd4. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

