### PR TITLE
chore: auto-create/update .venv if missing or outdated

### DIFF
--- a/lefthook.toml
+++ b/lefthook.toml
@@ -6,6 +6,7 @@ output = ["failure", "success", "execution_out"]
 
 [[pre-commit.jobs]]
 name = "Creating venv (this can take a minute)"
+# simulate file change only if .venv is outdated (hooks into the lefthook skipped detection)
 files = "bash -c '[ -x .venv/bin/python ] && cmp -s requirements.txt .venv/.requirements.txt || echo requirements.txt'"
 run = "make venv QUIET=1"
 

--- a/lefthook.toml
+++ b/lefthook.toml
@@ -1,18 +1,27 @@
-# NOTE: These scripts are intended to run very fast , not to become frustrating,
+# NOTE: These scripts are intended to run very fast, not to become frustrating,
 # pytest was the clear bottleneck (and can't check only staged files), so it was not included.
 
 skip_lfs = true
+output = ["failure", "success", "execution_out"]
 
-[pre-commit.commands.creating-venv]
-# simulate file change only if needed, to skip step otherwise
+[[pre-commit.jobs]]
+name = "Creating venv (this can take a minute)"
 files = "bash -c '[ -x .venv/bin/python ] && cmp -s requirements.txt .venv/.requirements.txt || echo requirements.txt'"
 run = "make venv QUIET=1"
 
-[pre-commit.commands.typos]
+[[pre-commit.jobs]]
+name = "Checking"
+
+[pre-commit.jobs.group]
+parallel = true
+
+[[pre-commit.jobs.group.jobs]]
+name = "Spell checking"
 glob = "*"
 run = "./.venv/bin/typos --force-exclude {staged_files}"
 
-[pre-commit.commands.ruff]
+[[pre-commit.jobs.group.jobs]]
+name = "Linting (ruff)"
 glob = "*.py"
 run = """
   ./.venv/bin/ruff check --fix {staged_files} &&
@@ -20,7 +29,8 @@ run = """
   """
 stage_fixed = true
 
-[pre-commit.commands.pyrefly]
+[[pre-commit.jobs.group.jobs]]
+name = "Type checking"
 root = "ulauncher"
 glob = "*.py"
 run = "../.venv/bin/pyrefly check {staged_files}"

--- a/lefthook.toml
+++ b/lefthook.toml
@@ -3,20 +3,18 @@
 
 skip_lfs = true
 
-[pre-commit]
-# make sure to only run one job with stage_fixed, or disable parallel
-# otherwise one job might might overwrite the changes of another job
-# and jobs can fail because a previous job created the git lockfile,
-parallel = true
+[pre-commit.commands.creating-venv]
+# simulate file change only if needed, to skip step otherwise
+files = "bash -c '[ -x .venv/bin/python ] && cmp -s requirements.txt .venv/.requirements.txt || echo requirements.txt'"
+run = "make venv QUIET=1"
 
 [pre-commit.commands.typos]
 glob = "*"
-run = "make check-dev-deps && ./.venv/bin/typos --force-exclude {staged_files}"
+run = "./.venv/bin/typos --force-exclude {staged_files}"
 
 [pre-commit.commands.ruff]
 glob = "*.py"
 run = """
-  make check-dev-deps &&
   ./.venv/bin/ruff check --fix {staged_files} &&
   ./.venv/bin/ruff format {staged_files}
   """
@@ -25,4 +23,4 @@ stage_fixed = true
 [pre-commit.commands.pyrefly]
 root = "ulauncher"
 glob = "*.py"
-run = "make -C .. check-dev-deps && ../.venv/bin/pyrefly check {staged_files}"
+run = "../.venv/bin/pyrefly check {staged_files}"

--- a/makefile
+++ b/makefile
@@ -59,12 +59,7 @@ venv:
 	if [ -z "$(NOCACHE)" ] && [ -x ".venv/bin/python" ] && [ -f "$(VENV_REQUIREMENTS_SNAPSHOT)" ] && cmp -s requirements.txt "$(VENV_REQUIREMENTS_SNAPSHOT)"; then
 	  exit 0
 	fi
-	MSG="[+] Setting up Python virtual environment..."
-	if [ -n "$(QUIET)" ]; then
-		echo "$$MSG"
-	else
-		echo -e "$(GREEN)$$MSG$(RESET)"
-	fi
+	echo -e "$(GREEN)[+] Setting up Python virtual environment...$(RESET)"
 	$(PYTHON_BIN) -m venv --clear --system-site-packages .venv
 	if [ -z "$(QUIET)" ]; then echo -e "$(GREEN)[+] Installing dependencies from requirements.txt...$(RESET)"; fi
 	PYGOBJECT_STUB_CONFIG=Gtk3,Gdk3,Soup2 .venv/bin/python -m pip install --ignore-installed --no-warn-conflicts --upgrade $(if $(QUIET),-q) -r requirements.txt
@@ -72,7 +67,7 @@ venv:
 	# tell when the local venv needs to be refreshed.
 	cp requirements.txt "$(VENV_REQUIREMENTS_SNAPSHOT)"
 	if [ -n "$(QUIET)" ]; then
-		echo "[✓] Virtual environment set up"
+		echo -e "$(GREEN)[✓] Virtual environment set up$(RESET)"
 	else
 		echo -e "\n$(GREEN)[✓] Virtual environment has been set up and is ready to use.$(RESET)"
 		echo -e "$(GREEN)[✓] make commands and the pre-commit hook will use it automatically.$(RESET)"

--- a/makefile
+++ b/makefile
@@ -50,22 +50,36 @@ help:
 version:
 	@echo ${VERSION}
 
-# Creates a python virtual environment and installs dependencies
+# Creates or updates the Python virtual environment. Use NOCACHE=1 to force recreation and/or QUIET=1 to suppress output.
 venv:
 	@set -euo pipefail
-	echo -e "$(GREEN)[+] Setting up Python virtual environment...$(RESET)"
+	if [ "$${GITHUB_ACTIONS:-}" = "true" ] || [ -n "$${NO_VENV:-}" ]; then
+	  exit 0
+	fi
+	if [ -z "$(NOCACHE)" ] && [ -x ".venv/bin/python" ] && [ -f "$(VENV_REQUIREMENTS_SNAPSHOT)" ] && cmp -s requirements.txt "$(VENV_REQUIREMENTS_SNAPSHOT)"; then
+	  exit 0
+	fi
+	MSG="[+] Setting up Python virtual environment..."
+	if [ -n "$(QUIET)" ]; then
+		echo "$$MSG"
+	else
+		echo -e "$(GREEN)$$MSG$(RESET)"
+	fi
 	$(PYTHON_BIN) -m venv --clear --system-site-packages .venv
-	echo -e "$(GREEN)[+] Installing dependencies from requirements.txt...$(RESET)"
-	PYGOBJECT_STUB_CONFIG=Gtk3,Gdk3,Soup2 .venv/bin/python -m pip install --ignore-installed --no-warn-conflicts --upgrade -r requirements.txt
+	if [ -z "$(QUIET)" ]; then echo -e "$(GREEN)[+] Installing dependencies from requirements.txt...$(RESET)"; fi
+	PYGOBJECT_STUB_CONFIG=Gtk3,Gdk3,Soup2 .venv/bin/python -m pip install --ignore-installed --no-warn-conflicts --upgrade $(if $(QUIET),-q) -r requirements.txt
 	# Keep a copy of the requirements used for this environment so make targets can
 	# tell when the local venv needs to be refreshed.
 	cp requirements.txt "$(VENV_REQUIREMENTS_SNAPSHOT)"
-
-	echo -e "\n$(GREEN)[✓] Virtual environment has been set up and is ready to use.$(RESET)"
-	echo -e "$(GREEN)[✓] make commands and the pre-commit hook will use it automatically.$(RESET)"
-	echo -e "\nIf you need direct access to the underlying CLI tools, you can manually load the venv:"
-	echo -e "* Bash/Zsh: $(BOLD)source .venv/bin/activate$(RESET)"
-	echo -e "* Fish: $(BOLD)source .venv/bin/activate.fish$(RESET)"
+	if [ -n "$(QUIET)" ]; then
+		echo "[✓] Virtual environment set up"
+	else
+		echo -e "\n$(GREEN)[✓] Virtual environment has been set up and is ready to use.$(RESET)"
+		echo -e "$(GREEN)[✓] make commands and the pre-commit hook will use it automatically.$(RESET)"
+		echo -e "\nIf you need direct access to the underlying CLI tools, you can manually load the venv:"
+		echo -e "* Bash/Zsh: $(BOLD)source .venv/bin/activate$(RESET)"
+		echo -e "* Fish: $(BOLD)source .venv/bin/activate.fish$(RESET)"
+	fi
 
 
 # Run ulauncher from source
@@ -116,42 +130,25 @@ run-container:
 
 #=Lint/test Commands
 
-.PHONY: check lint format pyrefly ruff rumdl typos pytest check-dev-deps
-
-# Check if the development environment exists and matches requirements.txt
-check-dev-deps:
-	@set -euo pipefail
-	if [ "$${GITHUB_ACTIONS:-}" = "true" ] || [ -n "$${NO_VENV:-}" ]; then
-	  exit 0
-	fi
-	if [ ! -x ".venv/bin/python" ]; then
-		echo -e "${BOLD}${RED}Development environment not set up.${RESET}" >&2
-		echo -e "${YELLOW}Please run 'make venv' to set up the development environment.${RESET}\n" >&2
-		exit 1
-	fi
-	if [ ! -f "$(VENV_REQUIREMENTS_SNAPSHOT)" ] || ! cmp -s requirements.txt "$(VENV_REQUIREMENTS_SNAPSHOT)"; then
-		echo -e "${BOLD}${RED}Development environment is out of date.${RESET}" >&2
-		echo -e "${YELLOW}Please run 'make venv' to refresh the development environment.${RESET}\n" >&2
-		exit 1
-	fi
+.PHONY: check lint format pyrefly ruff rumdl typos pytest
 
 # Run all linters
-lint: check-dev-deps typos ruff pyrefly rumdl
+lint: venv typos ruff pyrefly rumdl
 
 # Run all linters and unit tests (terse output, use `make pytest` for verbose)
 check: lint
 	@$(MAKE) --no-print-directory pytest PYTEST_ARGS="--no-header -q --override-ini=log_cli=false"
 
 # Lint with pyrefly (type checker)
-pyrefly: check-dev-deps
+pyrefly: venv
 	@pyrefly check
 
 # Lint with ruff
-ruff: check-dev-deps
+ruff: venv
 	@ruff check . && ruff format --check .
 
 # Lint with typos (typo checker)
-typos: check-dev-deps
+typos: venv
 	@typos .
 
 # Lint markdown files with rumdl (optional, requires Python 3.9+)
@@ -163,7 +160,7 @@ rumdl:
 	fi
 
 # Run unit tests
-pytest: check-dev-deps
+pytest: venv
 	@set -euo pipefail
 	if [ -z $(shell eval "command -v xvfb-run") ]; then
 		pytest -p no:cacheprovider $(PYTEST_ARGS) tests
@@ -173,7 +170,7 @@ pytest: check-dev-deps
 	fi
 
 # Auto format the code
-format: check-dev-deps
+format: venv
 	@ruff check . --fix
 	ruff format .
 	if command -v rumdl >/dev/null 2>&1; then \


### PR DESCRIPTION
* Change `make venv` to skip if not needed, unless passing NOCACHE=1 argument
* Move this into a separate step for lefthook and use the `files` directive to skip the step if not needed (counts as a skip in the lefthook output), and move the rest as a new group after that step.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Auto-creates or refreshes the Python `.venv` only when needed and wires it into `lefthook`, so contributors always run the right tools. Skips work when `requirements.txt` hasn’t changed and avoids CI overhead.

- **New Features**
  - `make venv` no-ops if `.venv` matches `requirements.txt`; use `NOCACHE=1` to force, `QUIET=1` for quieter output; skips in CI or with `NO_VENV=1`.
  - Added a "Creating venv (this can take a minute)" pre-commit job using a `files` probe that runs first and shows as skipped when up to date; the remaining checks run in parallel with clear names.
  - Removed `check-dev-deps`; `ruff`, `pyrefly`, `typos`, `pytest`, and `format` now depend on `venv` and use tools from `.venv`.

<sup>Written for commit 9353059bc1b41f3de7fa805b7925f29cec359538. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

