### PR TITLE
chore: make container and ci use venv too 

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -12,6 +12,12 @@ jobs:
     container: ulauncher/build-image:6.6
     steps:
       - uses: actions/checkout@v5
+      - uses: actions/cache@v4
+        with:
+          path: .venv
+          key: venv-${{ hashFiles('requirements.txt') }}
+      - name: venv
+        run: make venv QUIET=1
       - name: ruff
         run: make ruff
       - name: pyrefly

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -15,7 +15,7 @@ jobs:
       - uses: actions/cache@v4
         with:
           path: .venv
-          key: venv-${{ hashFiles('requirements.txt') }}
+          key: venv-${{ hashFiles('requirements.txt', '.github/workflows/tests.yml') }}
       - name: venv
         run: make venv QUIET=1
       - name: ruff

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,6 @@ LABEL maintainer="ulauncher.app@gmail.com"
 
 ENV LANG=C.UTF-8
 ENV DEBIAN_FRONTEND=noninteractive
-ENV NO_VENV=1
 
 RUN apt-get update --fix-missing
 RUN apt-get install -y tzdata
@@ -63,13 +62,10 @@ RUN apt-get update
 RUN apt-get autoremove -y
 RUN apt-get clean
 
-COPY [ "requirements.txt", "./" ]
-
 # Update /etc/dput.cf to use sftp for upload to ppa.launchpad.net
 COPY [ "scripts/dput.cf", "/etc" ]
 
 RUN apt-get install -y python3-pip
-RUN PYGOBJECT_STUB_CONFIG=Gtk3,Gdk3,Soup2 pip3 install -r requirements.txt
 
 # Create container dir for the repo root dir to mount to
 # This is needed because dpkg-buildpackage is stupid and outputs are hard coded to be the parent dir

--- a/makefile
+++ b/makefile
@@ -13,9 +13,7 @@ DEB_PACKAGER_NAME := "" # Will default to the user full name if empty
 DEB_PACKAGER_EMAIL := ulauncher.app@gmail.com
 VENV_REQUIREMENTS_SNAPSHOT := .venv/.requirements.txt
 PYTHON_BIN := $(shell command -v python3)
-ifndef NO_VENV
 export PATH := $(ROOT_DIR).venv/bin:$(PATH)
-endif
 
 # cli font vars
 BOLD := \\e[1m
@@ -53,9 +51,6 @@ version:
 # Creates or updates the Python virtual environment. Use NOCACHE=1 to force recreation and/or QUIET=1 to suppress output.
 venv:
 	@set -euo pipefail
-	if [ "$${GITHUB_ACTIONS:-}" = "true" ] || [ -n "$${NO_VENV:-}" ]; then
-	  exit 0
-	fi
 	if [ -z "$(NOCACHE)" ]; then
 	  if [ ! -x ".venv/bin/python" ]; then
 	    echo -e "$(BOLD)$(YELLOW)[!] Virtual environment missing$(RESET)"
@@ -107,12 +102,14 @@ run-container:
 	if command -v selinuxenabled && selinuxenabled; then
 		VOL_SUFFIX=":z"
 	fi
-	mkdir -p .container-env && touch .container-env/.bash_history
+	mkdir -p .container-env/.venv
+	touch .container-env/.bash_history
 	# port 3002 is used for developing Preferences UI
 	exec ${DOCKER_BIN} run \
 		--rm \
 		-it \
 		-v "${PWD}:/src/ulauncher$$VOL_SUFFIX" \
+		-v "${PWD}/.container-env/.venv:/src/ulauncher/.venv$$VOL_SUFFIX" \
 		-v "${PWD}/.container-env/.bash_history:$$HISTFILE_CONTAINER_PATH$$VOL_SUFFIX" \
 		-p 3002:3002 \
 		--name ulauncher \

--- a/makefile
+++ b/makefile
@@ -56,10 +56,16 @@ venv:
 	if [ "$${GITHUB_ACTIONS:-}" = "true" ] || [ -n "$${NO_VENV:-}" ]; then
 	  exit 0
 	fi
-	if [ -z "$(NOCACHE)" ] && [ -x ".venv/bin/python" ] && [ -f "$(VENV_REQUIREMENTS_SNAPSHOT)" ] && cmp -s requirements.txt "$(VENV_REQUIREMENTS_SNAPSHOT)"; then
-	  exit 0
+	if [ -z "$(NOCACHE)" ]; then
+	  if [ ! -x ".venv/bin/python" ]; then
+	    echo -e "$(BOLD)$(YELLOW)[!] Virtual environment missing$(RESET)"
+	  elif [ ! -f "$(VENV_REQUIREMENTS_SNAPSHOT)" ] || ! cmp -s requirements.txt "$(VENV_REQUIREMENTS_SNAPSHOT)"; then
+	    echo -e "$(BOLD)$(YELLOW)[!] Virtual environment outdated$(RESET)"
+	  else
+	    exit 0
+	  fi
 	fi
-	echo -e "$(BOLD)[+] Setting up Python virtual environment...$(RESET)"
+	echo -e "$(BOLD)[+] Setting up virtual environment...$(RESET)"
 	$(PYTHON_BIN) -m venv --clear --system-site-packages .venv
 	PYGOBJECT_STUB_CONFIG=Gtk3,Gdk3,Soup2 .venv/bin/python -m pip install --ignore-installed --no-warn-conflicts --upgrade $(if $(QUIET),-q) -r requirements.txt
 	# Keep a copy of the requirements used for this environment so make targets can


### PR DESCRIPTION
Make all environments use venv and align with the new `make venv` ways where we only create/update the venv if it's missing or outdated.

Pros:
1. No need to rebuild docker image after changing requirements.txt
2. We can restore the fix for pyrefly editor integrations without breaking CI

Cons:
1. CI will be slower on cache misses (GHA caches expire after 7 days of no access)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Unifies local, CI, and dev container to share the same Python virtualenv via `make venv`. The venv only rebuilds when missing or when `requirements.txt` changes, so no Docker rebuild is needed and the `pyrefly` editor fix stays enabled.

- **Refactors**
  - GitHub Actions: cache `.venv` keyed by `requirements.txt` and `.github/workflows/tests.yml`; run `make venv` quietly.
  - Dockerfile: remove baked dependency installs and `NO_VENV`; rely on runtime venv.
  - Makefile/container: `venv` prints why it rebuilds and skips when fresh; always add `.venv/bin` to `PATH`; persist venv in the container by mounting `.container-env/.venv`.

<sup>Written for commit ce1024eeacddca3a72584c707886dc2b59d867a6. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

