### PR TITLE
chore: make container and ci use venv too

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -12,6 +12,12 @@ jobs:
     container: ulauncher/build-image:6.6
     steps:
       - uses: actions/checkout@v5
+      - uses: actions/cache@v4
+        with:
+          path: .venv
+          key: venv-${{ hashFiles('requirements.txt', 'makefile', '.github/workflows/tests.yml') }}
+      - name: venv
+        run: make venv QUIET=1
       - name: ruff
         run: make ruff
       - name: pyrefly

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,6 @@ LABEL maintainer="ulauncher.app@gmail.com"
 
 ENV LANG=C.UTF-8
 ENV DEBIAN_FRONTEND=noninteractive
-ENV NO_VENV=1
 
 RUN apt-get update --fix-missing
 RUN apt-get install -y tzdata
@@ -63,13 +62,10 @@ RUN apt-get update
 RUN apt-get autoremove -y
 RUN apt-get clean
 
-COPY [ "requirements.txt", "./" ]
-
 # Update /etc/dput.cf to use sftp for upload to ppa.launchpad.net
 COPY [ "scripts/dput.cf", "/etc" ]
 
 RUN apt-get install -y python3-pip
-RUN PYGOBJECT_STUB_CONFIG=Gtk3,Gdk3,Soup2 pip3 install -r requirements.txt
 
 # Create container dir for the repo root dir to mount to
 # This is needed because dpkg-buildpackage is stupid and outputs are hard coded to be the parent dir

--- a/makefile
+++ b/makefile
@@ -13,9 +13,7 @@ DEB_PACKAGER_NAME := "" # Will default to the user full name if empty
 DEB_PACKAGER_EMAIL := ulauncher.app@gmail.com
 VENV_REQUIREMENTS_SNAPSHOT := .venv/.requirements.txt
 PYTHON_BIN := $(shell command -v python3)
-ifndef NO_VENV
 export PATH := $(ROOT_DIR).venv/bin:$(PATH)
-endif
 
 # cli font vars
 BOLD := \\e[1m
@@ -53,9 +51,6 @@ version:
 # Creates or updates the Python virtual environment. Use NOCACHE=1 to force recreation and/or QUIET=1 to suppress output.
 venv:
 	@set -euo pipefail
-	if [ "$${GITHUB_ACTIONS:-}" = "true" ] || [ -n "$${NO_VENV:-}" ]; then
-	  exit 0
-	fi
 	if [ -z "$(NOCACHE)" ]; then
 	  if [ ! -x ".venv/bin/python" ]; then
 	    echo -e "$(BOLD)$(YELLOW)[!] Virtual environment missing$(RESET)"
@@ -107,12 +102,14 @@ run-container:
 	if command -v selinuxenabled && selinuxenabled; then
 		VOL_SUFFIX=":z"
 	fi
-	mkdir -p .container-env && touch .container-env/.bash_history
+	mkdir -p .container-env/.venv
+	touch .container-env/.bash_history
 	# port 3002 is used for developing Preferences UI
 	exec ${DOCKER_BIN} run \
 		--rm \
 		-it \
 		-v "${PWD}:/src/ulauncher$$VOL_SUFFIX" \
+		-v "${PWD}/.container-env/.venv:/src/ulauncher/.venv$$VOL_SUFFIX" \
 		-v "${PWD}/.container-env/.bash_history:$$HISTFILE_CONTAINER_PATH$$VOL_SUFFIX" \
 		-p 3002:3002 \
 		--name ulauncher \

--- a/makefile
+++ b/makefile
@@ -56,10 +56,16 @@ venv:
 	if [ "$${GITHUB_ACTIONS:-}" = "true" ] || [ -n "$${NO_VENV:-}" ]; then
 	  exit 0
 	fi
-	if [ -z "$(NOCACHE)" ] && [ -x ".venv/bin/python" ] && [ -f "$(VENV_REQUIREMENTS_SNAPSHOT)" ] && cmp -s requirements.txt "$(VENV_REQUIREMENTS_SNAPSHOT)"; then
-	  exit 0
+	if [ -z "$(NOCACHE)" ]; then
+	  if [ ! -x ".venv/bin/python" ]; then
+	    echo -e "$(BOLD)$(YELLOW)[!] Virtual environment missing$(RESET)"
+	  elif [ ! -f "$(VENV_REQUIREMENTS_SNAPSHOT)" ] || ! cmp -s requirements.txt "$(VENV_REQUIREMENTS_SNAPSHOT)"; then
+	    echo -e "$(BOLD)$(YELLOW)[!] Virtual environment outdated$(RESET)"
+	  else
+	    exit 0
+	  fi
 	fi
-	echo -e "$(BOLD)[+] Setting up Python virtual environment...$(RESET)"
+	echo -e "$(BOLD)[+] Setting up virtual environment...$(RESET)"
 	$(PYTHON_BIN) -m venv --clear --system-site-packages .venv
 	PYGOBJECT_STUB_CONFIG=Gtk3,Gdk3,Soup2 .venv/bin/python -m pip install --ignore-installed --no-warn-conflicts --upgrade $(if $(QUIET),-q) -r requirements.txt
 	# Keep a copy of the requirements used for this environment so make targets can


### PR DESCRIPTION
Make all environments use venv and align with the new `make venv` ways where we only create/update the venv if it's missing or outdated.

CI caches based on requirements.txt and tests.yml hash as cache key so changing deps or container busts the cache.

Pros:
1. No need to rebuild docker image after changing requirements.txt
2. We can restore the fix for pyrefly editor integrations without breaking ci

Cons:
1. CI will be slower on cache misses (GHA caches expire after 7 days of no access). In tests this just added 20 seconds though.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Unifies Python venv across local dev, CI, and Docker via `make venv`, which only rebuilds when missing or outdated. Removes in-image installs and uses a mounted venv; restores the `pyrefly` editor integration; CI cache misses add ~20s.

- **Refactors**
  - CI: cache `.venv` with `actions/cache@v4` keyed by `requirements.txt`, `makefile`, and `.github/workflows/tests.yml`; run `make venv QUIET=1`.
  - Dockerfile: remove `NO_VENV`, stop copying `requirements.txt` and in-image `pip install`; rely on mounted venv.
  - Makefile: always add `.venv/bin` to `PATH`; `venv` target detects missing/outdated env, prints why, and supports `NOCACHE=1` / `QUIET=1`.
  - Container: persist `.container-env/.venv` and mount to `/src/ulauncher/.venv`.

<sup>Written for commit 374c22df037c39666119a46f52354e35159332ee. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

