### PR TITLE
chore: fix pyrefly path resolution for editors

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,6 +24,7 @@ dynamic = ["version", "license"]
 version = {attr = "ulauncher._version.version"}
 
 [tool.pyrefly]
+python-interpreter-path = ".venv/bin/python"
 python-platform = "linux"
 python-version = "3.8"
 project-includes = ["ulauncher", "tests"]


### PR DESCRIPTION
This was pushed to main before, but reverted due to ci not using venv. That was fixed in #1681, so we should be able to bring it back now.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Point `pyrefly` at the project’s venv to fix editor path resolution and keep local/CI behavior consistent. Set `python-interpreter-path` to `.venv/bin/python` in `pyproject.toml`.

<sup>Written for commit 4cd4e74a46e80c9a98fdd2ed3587e1979bcea92a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

