### PR TITLE
perf(json_conf): replace O(n) scan with O(1) id lookup in save()

### DIFF
--- a/ulauncher/utils/json_conf.py
+++ b/ulauncher/utils/json_conf.py
@@ -9,6 +9,7 @@ from ulauncher.utils.json_utils import json_load, json_save
 
 # See https://stackoverflow.com/a/63237226/633921 for why JsonConf is quoted
 _file_instances: dict[tuple[Path, type], JsonConf] = {}
+_instance_paths: dict[int, Path] = {}
 logger = logging.getLogger()
 T = TypeVar("T", bound="JsonConf")
 
@@ -46,11 +47,12 @@ class JsonConf(BaseDataClass):
         instance = _file_instances.get(key, cls())
         instance.update(data)
         _file_instances[key] = instance
+        _instance_paths[id(instance)] = file_path
         return cast("T", instance)
 
     def save(self, *args: Any, **kwargs: Any) -> bool:
         self.update(*args, **kwargs)
-        file_path = next((key[0] for key, inst in _file_instances.items() if inst is self), None)
+        file_path = _instance_paths.get(id(self))
         if file_path is None:
             logger.error("Could not resolve file path for JsonConf instance %s", self.__class__.__name__)
             return False


### PR DESCRIPTION
Replace O(n) scan with O(1) id lookup in save()

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaced the O(n) scan in JsonConf.save() with an O(1) lookup using an instance-id map, improving save performance when many configs are loaded.

- **Refactors**
  - Added `_instance_paths: dict[int, Path]` and populate it in `load()`.
  - `save()` now resolves the file path via `_instance_paths.get(id(self))` instead of scanning `_file_instances`.

<sup>Written for commit 52c737ff1963648c33926a8585918a4330a1b2b8. Summary will update on new commits. <a href="https://cubic.dev/pr/Ulauncher/Ulauncher/pull/1683?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

