### PR TITLE
chore: set mainProgram in nix package

### DIFF
--- a/nix/default.nix
+++ b/nix/default.nix
@@ -198,6 +198,7 @@ let
       homepage = "https://ulauncher.io/";
       license = licenses.gpl3;
       platforms = platforms.linux;
+      mainProgram = "ulauncher";
       maintainers = with maintainers; [ nazarewk ];
     };
   };


### PR DESCRIPTION
By setting `mainProgram`, we're clearing a warning from `lib.getExe`. It assumes `mainProgram = pname` when `mainProgram` is not set, but this is deprecated behavior. This doesn't change any functionality, only removes an evaluation warning when using the beta ulauncher6 nix package.

The same `mainProgram` value is in the nixpkgs ulauncher package: https://github.com/NixOS/nixpkgs/blob/master/pkgs/by-name/ul/ulauncher/package.nix#L150


Before:
```sh
$ nix eval --impure --expr 'with import <nixpkgs> { }; pkgs.lib.getExe (import ./default.nix { })'
evaluation warning: getExe: Package "python3.13-ulauncher-v6" does not have the meta.mainProgram attribute. We'll assume that the main program has the same name for now, but this behavior is deprecated, because it leads to surprising errors when the assumption does not hold. If the package has a main program, please set `meta.mainProgram` in its definition to make this warning go away. Otherwise, if the package does not have a main program, or if you don't control its definition, use getExe' to specify the name to the program, such as lib.getExe' foo "bar".
"/nix/store/pfb6dr52n0xm3s6n7b7b3ghw2ap68xc2-python3.13-ulauncher-v6/bin/ulauncher"
```

After:
```sh
$ nix eval --impure --expr 'with import <nixpkgs> { }; pkgs.lib.getExe (import ./default.nix { })'
"/nix/store/gf85g37c7xr734vphwzdjwqalqpackl1-python3.13-ulauncher-v6/bin/ulauncher"
```
 


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Set `meta.mainProgram = "ulauncher"` in the Nix package to remove the deprecated `lib.getExe` warning. No functional changes; aligns with the `nixpkgs` `ulauncher` package definition.

<sup>Written for commit 1351a105849235e31c0cb9ae6523f9014d4c0a5b. Summary will update on new commits. <a href="https://cubic.dev/pr/Ulauncher/Ulauncher/pull/1685?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

