### PR TITLE
fix: add missing decorator param generic types

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -141,6 +141,7 @@ select = [
 
 [tool.ruff.lint.flake8-tidy-imports.banned-api]
 "gi.repository" = {msg = "Import GI modules from ulauncher.gi, not gi.repository directly."}
+"functools.lru_cache" = {msg = "Use ulauncher.utils.lru_cache instead to preserve parameter types."}
 
 [tool.ruff.lint.per-file-ignores]
 "tests/**/*.py" = [  # Relax some linting rules for tests
@@ -150,6 +151,7 @@ select = [
   "T201",       # Allow print statements
 ]
 "ulauncher/gi.py" = ["TID251"]           # This IS the canonical gi import module
+"ulauncher/utils/lru_cache.py" = ["TID251"]  # This IS the lru_cache wrapper
 
 [tool.pytest.ini_options]
 log_cli = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -142,6 +142,8 @@ select = [
 [tool.ruff.lint.flake8-tidy-imports.banned-api]
 "gi.repository" = {msg = "Import GI modules from ulauncher.gi, not gi.repository directly."}
 "functools.lru_cache" = {msg = "Use ulauncher.utils.lru_cache instead to preserve parameter types."}
+"functools.cache" = {msg = "Use ulauncher.utils.lru_cache instead to preserve parameter types."}
+"functools.cached_property" = {msg = "cached_property erases property types. If you need to use this, create a typed wrapper similar to ulauncher.utils.lru_cache"}
 
 [tool.ruff.lint.per-file-ignores]
 "tests/**/*.py" = [  # Relax some linting rules for tests

--- a/tests/utils/test_lru_cache.py
+++ b/tests/utils/test_lru_cache.py
@@ -1,0 +1,27 @@
+from ulauncher.utils.lru_cache import lru_cache
+
+
+def test_lru_cache_without_parentheses_preserves_caching() -> None:
+    calls = 0
+
+    @lru_cache
+    def square(value: int) -> int:
+        nonlocal calls
+        calls += 1
+        return value * value
+
+    assert square(4) == 16
+    assert square(4) == 16
+    assert square.cache_info().hits == 1  # type: ignore[attr-defined]
+    assert calls == 1
+
+
+def test_lru_cache_supports_typed_keyword_argument() -> None:
+    @lru_cache(maxsize=None, typed=True)
+    def stringify(value: object) -> str:
+        return repr(value)
+
+    assert stringify(1) == "1"
+    assert stringify(True) == "True"
+    assert stringify.cache_info().misses == 2  # type: ignore[attr-defined]
+    assert stringify.cache_info().currsize == 2  # type: ignore[attr-defined]

--- a/ulauncher/cli.py
+++ b/ulauncher/cli.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import argparse
-from functools import lru_cache, partial
+from functools import partial
 
 from ulauncher import version
 from ulauncher.modes.extensions.extension_cli_handlers import (
@@ -11,6 +11,7 @@ from ulauncher.modes.extensions.extension_cli_handlers import (
     uninstall_extension,
     upgrade_extensions,
 )
+from ulauncher.utils.lru_cache import lru_cache
 
 
 class CLIArguments(argparse.Namespace):

--- a/ulauncher/core.py
+++ b/ulauncher/core.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 import itertools
 import logging
 from collections import defaultdict
-from functools import lru_cache
 from typing import Callable, Iterable
 from weakref import WeakKeyDictionary
 
@@ -12,6 +11,7 @@ from ulauncher.internals.query import Query
 from ulauncher.internals.result import ActionResult, KeywordTrigger, Result
 from ulauncher.modes.mode import Mode
 from ulauncher.utils.eventbus import EventBus
+from ulauncher.utils.lru_cache import lru_cache
 from ulauncher.utils.settings import Settings
 from ulauncher.utils.timer import TimerContext, timer
 

--- a/ulauncher/modes/calc/calc_mode.py
+++ b/ulauncher/modes/calc/calc_mode.py
@@ -6,7 +6,6 @@ import math
 import operator as op
 import re
 from decimal import Decimal
-from functools import lru_cache
 from typing import Callable
 
 from ulauncher.internals import effects
@@ -15,6 +14,7 @@ from ulauncher.internals.result import Result
 from ulauncher.modes.calc.calc_result import CalcErrorResult, CalcResult
 from ulauncher.modes.mode import Mode
 from ulauncher.utils.eventbus import EventBus
+from ulauncher.utils.lru_cache import lru_cache
 
 _events = EventBus()
 
@@ -151,7 +151,7 @@ class CalcMode(Mode):
 
     def handle_query(self, query: Query, callback: Callable[[effects.EffectMessage | list[Result]], None]) -> None:
         try:
-            calc_result = str(eval_expr(query.argument))
+            calc_result = str(eval_expr(query.argument or ""))
             result = CalcResult(
                 name=f"{Decimal(calc_result):n}",
                 description="Enter to copy to the clipboard",

--- a/ulauncher/ui/windows/preferences/views/extensions.py
+++ b/ulauncher/ui/windows/preferences/views/extensions.py
@@ -97,7 +97,7 @@ class ExtensionsView(BaseView):
         # Convert extensions to SidebarItems
         items: list[SidebarItem] = []
         for ext_id, (name, status, icon_path) in self.extension_cache.items():
-            icon_surface = load_icon_surface(icon_path, views.ICON_SIZE_M, self.get_scale_factor())
+            icon_surface = load_icon_surface(icon_path or "", views.ICON_SIZE_M, self.get_scale_factor())
             icon_image = Gtk.Image.new_from_surface(icon_surface)
 
             # Only show status badge if not "on" (enabled extensions don't need a badge)
@@ -201,7 +201,7 @@ class ExtensionsView(BaseView):
 
         # Large icon
         icon_path = ext.get_normalized_icon_path()
-        icon_surface = load_icon_surface(icon_path, views.ICON_SIZE_L, self.get_scale_factor())
+        icon_surface = load_icon_surface(icon_path or "", views.ICON_SIZE_L, self.get_scale_factor())
         icon_image = Gtk.Image.new_from_surface(icon_surface)
         left_box.pack_start(icon_image, False, False, 0)
 

--- a/ulauncher/utils/dbus.py
+++ b/ulauncher/utils/dbus.py
@@ -2,11 +2,11 @@ from __future__ import annotations
 
 import json
 import logging
-from functools import lru_cache
 from typing import Any
 
 import ulauncher
 from ulauncher.gi import Gio, GLib
+from ulauncher.utils.lru_cache import lru_cache
 
 logger = logging.getLogger(__name__)
 

--- a/ulauncher/utils/decorator/debounce.py
+++ b/ulauncher/utils/decorator/debounce.py
@@ -1,16 +1,23 @@
+from __future__ import annotations
+
 import contextlib
 from functools import wraps
-from typing import Any, Callable
+from typing import TYPE_CHECKING, Any, Callable, cast
 
 from ulauncher.utils.timer import timer
 
+if TYPE_CHECKING:
+    from typing_extensions import ParamSpec
 
-def debounce(wait: float) -> Callable[..., Callable[..., None]]:
+    P = ParamSpec("P")
+
+
+def debounce(wait: float) -> Callable[[Callable[P, Any]], Callable[P, None]]:
     """Decorator that will postpone a function
     execution until after wait seconds
     have elapsed since the last time it was invoked."""
 
-    def decorator(fn: Callable[..., None]) -> Callable[..., None]:
+    def decorator(fn: Callable[P, Any]) -> Callable[P, None]:
         @wraps(fn)
         def debounced(*args: Any, **kwargs: Any) -> None:
             def call_it() -> None:
@@ -21,6 +28,6 @@ def debounce(wait: float) -> Callable[..., Callable[..., None]]:
 
             debounced.t = timer(wait, call_it)  # type: ignore[attr-defined]
 
-        return debounced
+        return cast("Callable[P, None]", debounced)
 
-    return decorator
+    return decorator  # type: ignore[return-value]

--- a/ulauncher/utils/decorator/run_async.py
+++ b/ulauncher/utils/decorator/run_async.py
@@ -1,9 +1,16 @@
+from __future__ import annotations
+
 from functools import wraps
 from threading import Thread
-from typing import Any, Callable
+from typing import TYPE_CHECKING, Any, Callable, cast
+
+if TYPE_CHECKING:
+    from typing_extensions import ParamSpec
+
+    P = ParamSpec("P")
 
 
-def run_async(func: Callable[..., Any]) -> Callable[..., Thread]:
+def run_async(func: Callable[P, Any]) -> Callable[P, Thread]:
     """
     Function decorator, intended to make a callable run in a separate thread (asynchronously).
     We still need this because asyncio is absolutely garbage when you want to know
@@ -26,4 +33,4 @@ def run_async(func: Callable[..., Any]) -> Callable[..., Thread]:
         thread.start()
         return thread
 
-    return async_func
+    return cast("Callable[P, Thread]", async_func)

--- a/ulauncher/utils/eventbus.py
+++ b/ulauncher/utils/eventbus.py
@@ -2,7 +2,15 @@ from __future__ import annotations
 
 from collections import defaultdict
 from functools import wraps
-from typing import Any, Callable
+from typing import TYPE_CHECKING, Any, Callable
+
+if TYPE_CHECKING:
+    from typing import TypeVar
+
+    from typing_extensions import ParamSpec
+
+    P = ParamSpec("P")
+    R = TypeVar("R")
 
 _listeners: dict[str, set[Callable[..., Any]]] = defaultdict(set)
 
@@ -23,7 +31,7 @@ class EventBus:
     def _full_event_name(self, event_name: str) -> str:
         return ":".join(filter(None, (self.namespace, event_name)))
 
-    def on(self, listener: Callable[..., Any]) -> Callable[..., Any]:
+    def on(self, listener: Callable[P, R]) -> Callable[P, R]:
         @wraps(listener)
         def wrapper(*args: Any, **kwargs: Any) -> None:
             if self.skip_if_not_bound and not self.self_arg:

--- a/ulauncher/utils/fuzzy_search.py
+++ b/ulauncher/utils/fuzzy_search.py
@@ -3,7 +3,8 @@ from __future__ import annotations
 import logging
 import unicodedata
 from difflib import Match, SequenceMatcher
-from functools import lru_cache
+
+from ulauncher.utils.lru_cache import lru_cache
 
 logger = logging.getLogger()
 

--- a/ulauncher/utils/load_icon_surface.py
+++ b/ulauncher/utils/load_icon_surface.py
@@ -1,10 +1,10 @@
 from __future__ import annotations
 
 import logging
-from functools import lru_cache
 from typing import TYPE_CHECKING
 
 from ulauncher import paths
+from ulauncher.utils.lru_cache import lru_cache
 
 if TYPE_CHECKING:
     from cairo import ImageSurface  # pyrefly: ignore - this fails in our docker image for some reason

--- a/ulauncher/utils/lru_cache.py
+++ b/ulauncher/utils/lru_cache.py
@@ -1,0 +1,23 @@
+from __future__ import annotations
+
+from functools import lru_cache as _lru_cache
+from typing import TYPE_CHECKING, cast
+
+if TYPE_CHECKING:
+    from typing import Callable, TypeVar
+
+    from typing_extensions import ParamSpec
+
+    P = ParamSpec("P")
+    R = TypeVar("R")
+
+
+# functools.lru_cache wraps functions in _lru_cache_wrapper whose __call__ is typed as
+# (*args: Hashable, **kwargs: Hashable) -> T, erasing all parameter types.
+# This wrapper uses ParamSpec to preserve the original signature so type
+# checkers can enforce argument types at every call site.
+def lru_cache(maxsize: int | None = 128) -> Callable[[Callable[P, R]], Callable[P, R]]:
+    def decorator(func: Callable[P, R]) -> Callable[P, R]:
+        return cast("Callable[P, R]", _lru_cache(maxsize=maxsize)(func))
+
+    return decorator  # type: ignore[return-value]

--- a/ulauncher/utils/lru_cache.py
+++ b/ulauncher/utils/lru_cache.py
@@ -4,7 +4,7 @@ from functools import lru_cache as _lru_cache
 from typing import TYPE_CHECKING, cast
 
 if TYPE_CHECKING:
-    from typing import Callable, TypeVar
+    from typing import Callable, TypeVar, overload
 
     from typing_extensions import ParamSpec
 
@@ -16,8 +16,22 @@ if TYPE_CHECKING:
 # (*args: Hashable, **kwargs: Hashable) -> T, erasing all parameter types.
 # This wrapper uses ParamSpec to preserve the original signature so type
 # checkers can enforce argument types at every call site.
-def lru_cache(maxsize: int | None = 128) -> Callable[[Callable[P, R]], Callable[P, R]]:
+if TYPE_CHECKING:
+
+    @overload
+    def lru_cache(maxsize: Callable[P, R]) -> Callable[P, R]: ...
+
+    @overload
+    def lru_cache(maxsize: int | None = 128, typed: bool = False) -> Callable[[Callable[P, R]], Callable[P, R]]: ...
+
+
+def lru_cache(
+    maxsize: Callable[P, R] | int | None = 128, typed: bool = False
+) -> Callable[[Callable[P, R]], Callable[P, R]] | Callable[P, R]:
     def decorator(func: Callable[P, R]) -> Callable[P, R]:
-        return cast("Callable[P, R]", _lru_cache(maxsize=maxsize)(func))
+        return cast("Callable[P, R]", _lru_cache(maxsize=maxsize, typed=typed)(func))
+
+    if callable(maxsize):
+        return cast("Callable[P, R]", _lru_cache(typed=typed)(maxsize))
 
     return decorator  # type: ignore[return-value]


### PR DESCRIPTION
Add generic types for lru_cache and other decorators with broken types (including our own).
Ban the unsafe APIs.
Fix existing errors caused by this.
 
Fixes #1686


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Introduce a typed `lru_cache` wrapper and migrate all uses to keep function parameter types intact and prevent type erasure. Tightened types for `debounce`, `run_async`, and event listeners; banned unsafe `functools` cache APIs. Fixes #1686.

- **New Features**
  - Added `ulauncher.utils.lru_cache` that preserves parameter types; supports bare `@lru_cache` and `typed=True`.
  - Added tests for caching behavior and typed keyword support.

- **Refactors**
  - Replaced all `functools.lru_cache` uses with `ulauncher.utils.lru_cache`; lint-ban `functools.lru_cache`, `functools.cache`, and `functools.cached_property`.
  - Typed `debounce`, `run_async`, and `EventBus.on` with `ParamSpec` to retain call signatures.
  - Small fixes: pass "" when icon paths are missing and handle empty calc queries safely.

<sup>Written for commit 4beb1b811ed199400d6b1ba9ddac36841c65f539. Summary will update on new commits. <a href="https://cubic.dev/pr/Ulauncher/Ulauncher/pull/1687?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

