### PR TITLE
refactor: move app starts to its own module

### DIFF
--- a/tests/modes/apps/test_app_result.py
+++ b/tests/modes/apps/test_app_result.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from pathlib import Path
-from typing import Any, Dict
+from typing import Any
 
 import pytest
 from pytest_mock import MockerFixture
@@ -22,35 +22,9 @@ class TestAppResult:
 
         return mocker.patch("ulauncher.modes.apps.app_result.GioUnix.DesktopAppInfo.new", new=mkappinfo)
 
-    @pytest.fixture(autouse=True)
-    def patch_desktop_app_info_get_all(self, mocker: MockerFixture) -> Any:
-        def get_all_appinfo() -> list[GioUnix.DesktopAppInfo]:
-            return [
-                app_info
-                for path in ["trueapp.desktop", "falseapp.desktop"]
-                if (app_info := GioUnix.DesktopAppInfo.new_from_filename(f"{ENTRIES_DIR}/{path}"))
-            ]
-
-        return mocker.patch("ulauncher.modes.apps.app_result.GioUnix.DesktopAppInfo.get_all", new=get_all_appinfo)
-
     @pytest.fixture
     def app1(self) -> AppResult | None:
         return AppResult.from_id("trueapp.desktop")
-
-    @pytest.fixture
-    def app2(self) -> AppResult | None:
-        return AppResult.from_id("falseapp.desktop")
-
-    @pytest.fixture(autouse=True)
-    def mock_app_starts(self, mocker: MockerFixture) -> Any:
-        class _MockStarts(Dict[str, int]):
-            def save(self) -> None:
-                pass
-
-        app_starts_data = _MockStarts({"falseapp.desktop": 3000, "trueapp.desktop": 765})
-        mocker.spy(app_starts_data, "save")
-        mocker.patch("ulauncher.modes.apps.app_result.app_starts", app_starts_data)
-        return app_starts_data
 
     def test_get_name(self, app1: AppResult) -> None:
         assert app1.name == "TrueApp - Full Name"
@@ -63,8 +37,3 @@ class TestAppResult:
 
     def test_search_score(self, app1: AppResult) -> None:
         assert app1.search_score("true") > app1.search_score("trivago")
-
-    def test_bump(self, app1: AppResult, mock_app_starts: Any) -> None:
-        app1.bump_starts()
-        assert mock_app_starts.get("trueapp.desktop") == 766
-        mock_app_starts.save.assert_called_once()

--- a/tests/modes/apps/test_app_starts.py
+++ b/tests/modes/apps/test_app_starts.py
@@ -30,7 +30,6 @@ class TestAppStarts:
         assert mock_app_starts.get("trueapp.desktop") == 766
         self.save_spy.assert_called_once()
 
-    def test_bump_invalidates_cache(self, mock_app_starts: AppStarts) -> None:
-        mock_app_starts.get_top_app_ids()  # populate cache
+    def test_bump_updates_top_app_ids(self, mock_app_starts: AppStarts) -> None:
         mock_app_starts.bump("trueapp.desktop")
-        assert mock_app_starts._top_ids is None
+        assert mock_app_starts.get_top_app_ids() == ["falseapp.desktop", "trueapp.desktop"]

--- a/tests/modes/apps/test_app_starts.py
+++ b/tests/modes/apps/test_app_starts.py
@@ -1,0 +1,36 @@
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+from pytest_mock import MockerFixture
+
+from ulauncher.modes.apps.app_starts import AppStarts
+
+
+class TestAppStarts:
+    @pytest.fixture(autouse=True)
+    def mock_app_starts(self, mocker: MockerFixture) -> AppStarts:
+        class _MockStarts(AppStarts):
+            def save(self) -> None:  # type: ignore[override]
+                pass
+
+        instance = _MockStarts()
+        instance.update({"falseapp.desktop": 3000, "trueapp.desktop": 765})
+        self.save_spy: MagicMock = mocker.spy(instance, "save")
+        return instance
+
+    def test_get_top_app_ids_sorted_by_count(self, mock_app_starts: AppStarts) -> None:
+        ids = mock_app_starts.get_top_app_ids()
+        assert ids[0] == "falseapp.desktop"
+        assert ids[1] == "trueapp.desktop"
+
+    def test_bump_increments_count(self, mock_app_starts: AppStarts) -> None:
+        mock_app_starts.bump("trueapp.desktop")
+        assert mock_app_starts.get("trueapp.desktop") == 766
+        self.save_spy.assert_called_once()
+
+    def test_bump_invalidates_cache(self, mock_app_starts: AppStarts) -> None:
+        mock_app_starts.get_top_app_ids()  # populate cache
+        mock_app_starts.bump("trueapp.desktop")
+        assert mock_app_starts._top_ids is None

--- a/tests/modes/apps/test_app_starts.py
+++ b/tests/modes/apps/test_app_starts.py
@@ -1,35 +1,26 @@
 from __future__ import annotations
 
-from unittest.mock import MagicMock
+from ulauncher.modes.apps.app_starts import AppStarts as AppStarts_
 
-import pytest
-from pytest_mock import MockerFixture
 
-from ulauncher.modes.apps.app_starts import AppStarts
+class AppStarts(AppStarts_):
+    def save(self) -> bool:
+        return False
 
 
 class TestAppStarts:
-    @pytest.fixture(autouse=True)
-    def mock_app_starts(self, mocker: MockerFixture) -> AppStarts:
-        class _MockStarts(AppStarts):
-            def save(self) -> None:  # type: ignore[override]
-                pass
+    def test_get_top_app_ids_sorted_by_count(self) -> None:
+        app_starts = AppStarts({"app1.desktop": 3000, "app2.desktop": 765})
+        ids = app_starts.get_top_app_ids()
+        assert ids[0] == "app1.desktop"
+        assert ids[1] == "app2.desktop"
 
-        instance = _MockStarts()
-        instance.update({"falseapp.desktop": 3000, "trueapp.desktop": 765})
-        self.save_spy: MagicMock = mocker.spy(instance, "save")
-        return instance
+    def test_bump_increments_count(self) -> None:
+        app_starts = AppStarts({"app.desktop": 100})
+        app_starts.bump("app.desktop")
+        assert app_starts.get("app.desktop") == 101
 
-    def test_get_top_app_ids_sorted_by_count(self, mock_app_starts: AppStarts) -> None:
-        ids = mock_app_starts.get_top_app_ids()
-        assert ids[0] == "falseapp.desktop"
-        assert ids[1] == "trueapp.desktop"
-
-    def test_bump_increments_count(self, mock_app_starts: AppStarts) -> None:
-        mock_app_starts.bump("trueapp.desktop")
-        assert mock_app_starts.get("trueapp.desktop") == 766
-        self.save_spy.assert_called_once()
-
-    def test_bump_updates_top_app_ids(self, mock_app_starts: AppStarts) -> None:
-        mock_app_starts.bump("trueapp.desktop")
-        assert mock_app_starts.get_top_app_ids() == ["falseapp.desktop", "trueapp.desktop"]
+    def test_bump_updates_top_app_ids(self) -> None:
+        app_starts = AppStarts({"app1.desktop": 1, "app2.desktop": 1})
+        app_starts.bump("app2.desktop")
+        assert app_starts.get_top_app_ids() == ["app2.desktop", "app1.desktop"]

--- a/ulauncher/modes/apps/app_mode.py
+++ b/ulauncher/modes/apps/app_mode.py
@@ -9,6 +9,7 @@ from ulauncher.internals import effects
 from ulauncher.internals.query import Query
 from ulauncher.internals.result import Result
 from ulauncher.modes.apps.app_result import AppResult
+from ulauncher.modes.apps.app_starts import app_starts
 from ulauncher.modes.apps.launch_app import launch_app
 from ulauncher.modes.mode import Mode
 from ulauncher.utils.settings import Settings
@@ -47,7 +48,7 @@ class AppMode(Mode):
     def get_home_results(self, limit: int) -> list[AppResult]:
         """Get the top {N} apps (based on number of launches) to show when the query is empty"""
         # TODO: filter out old apps
-        return list(filter(None, map(AppResult.from_id, AppResult.get_top_app_ids())))[:limit]
+        return list(filter(None, map(AppResult.from_id, app_starts.get_top_app_ids())))[:limit]
 
     def activate_result(
         self,
@@ -61,7 +62,7 @@ class AppMode(Mode):
                 logger.error("Expected AppResult but got %s", type(result).__name__)
                 callback(effects.do_nothing())
                 return
-            result.bump_starts()
+            app_starts.bump(result.app_id)
             if not launch_app(result.app_id):
                 logger.error("Could not launch app %s", result.app_id)
             callback(effects.close_window())

--- a/ulauncher/modes/apps/app_result.py
+++ b/ulauncher/modes/apps/app_result.py
@@ -2,23 +2,13 @@ from __future__ import annotations
 
 import contextlib
 import logging
-import operator
 from os.path import basename
 
-from ulauncher import paths
 from ulauncher.gi import GioUnix
 from ulauncher.internals.result import Result
-from ulauncher.utils.json_conf import JsonKeyValueConf
+from ulauncher.modes.apps.app_starts import app_starts
 
 logger = logging.getLogger()
-app_starts_path = f"{paths.STATE}/app_starts.json"
-
-
-class AppStarts(JsonKeyValueConf[str, int]):
-    pass
-
-
-app_starts = AppStarts.load(app_starts_path)
 
 
 class AppResult(Result):
@@ -48,14 +38,9 @@ class AppResult(Result):
                 return AppResult(app_info)
         return None
 
-    @staticmethod
-    def get_top_app_ids() -> list[str]:
-        sorted_tuples = sorted(app_starts.items(), key=operator.itemgetter(1), reverse=True)
-        return [*map(operator.itemgetter(0), sorted_tuples)]
-
     def get_searchable_fields(self) -> list[tuple[str, float]]:
         frequency_weight = 1.0
-        sorted_app_ids = AppResult.get_top_app_ids()
+        sorted_app_ids = app_starts.get_top_app_ids()
         if count := len(sorted_app_ids):
             index = sorted_app_ids.index(self.app_id) if self.app_id in sorted_app_ids else count
             frequency_weight = 1.0 - (index / count * 0.1) + 0.05
@@ -66,8 +51,3 @@ class AppResult(Result):
             (self.description, 0.7 * frequency_weight),
             *[(k, 0.6 * frequency_weight) for k in self.keywords],
         ]
-
-    def bump_starts(self) -> None:
-        starts = app_starts.get(self.app_id, 0)
-        app_starts[self.app_id] = starts + 1
-        app_starts.save()

--- a/ulauncher/modes/apps/app_starts.py
+++ b/ulauncher/modes/apps/app_starts.py
@@ -1,0 +1,23 @@
+from __future__ import annotations
+
+from ulauncher import paths
+from ulauncher.utils.json_conf import JsonKeyValueConf
+
+app_starts_path = f"{paths.STATE}/app_starts.json"
+
+
+class AppStarts(JsonKeyValueConf[str, int]):
+    _top_ids: list[str] | None = None
+
+    def get_top_app_ids(self) -> list[str]:
+        if self._top_ids is None:
+            self._top_ids = sorted(self, key=lambda k: self.get(k, 0), reverse=True)
+        return self._top_ids
+
+    def bump(self, app_id: str) -> None:
+        self._top_ids = None
+        self[app_id] = self.get(app_id, 0) + 1
+        self.save()
+
+
+app_starts = AppStarts.load(app_starts_path)

--- a/ulauncher/modes/apps/app_starts.py
+++ b/ulauncher/modes/apps/app_starts.py
@@ -7,15 +7,10 @@ app_starts_path = f"{paths.STATE}/app_starts.json"
 
 
 class AppStarts(JsonKeyValueConf[str, int]):
-    _top_ids: list[str] | None = None
-
     def get_top_app_ids(self) -> list[str]:
-        if self._top_ids is None:
-            self._top_ids = sorted(self, key=lambda k: self.get(k, 0), reverse=True)
-        return self._top_ids
+        return sorted(self, key=lambda k: self.get(k, 0), reverse=True)
 
     def bump(self, app_id: str) -> None:
-        self._top_ids = None
         self[app_id] = self.get(app_id, 0) + 1
         self.save()
 


### PR DESCRIPTION
Previously this was owned by app_result, which is the wrong place. Moved into isolated module and moved related methods from AppResult to the new class

This enabled fixing [potential performance issue](https://github.com/Ulauncher/Ulauncher/pull/1674#discussion_r3071650676) since we can cache and invalidate from AppMode.get_triggers()