### PR TITLE
feat(JsonKVConf): optimize for primitive types and parameterized lists

### DIFF
--- a/tests/utils/test_json_conf.py
+++ b/tests/utils/test_json_conf.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from pathlib import Path
-from typing import Any
+from typing import Any, Dict, List, Tuple
 
 import pytest
 
@@ -305,14 +305,70 @@ class TestJsonKeyValueConf:
             class NoGenerics(JsonKeyValueConf):  # type: ignore[type-arg]
                 pass
 
-    def test_subclass_of_subclass_inherits_value_type(self) -> None:
-        class Store(JsonKeyValueConf[str, int]):
+        with pytest.raises(TypeError, match="unparameterized"):
+
+            class UnparamList(JsonKeyValueConf[str, list]):  # type: ignore[type-arg]
+                pass
+
+        with pytest.raises(TypeError, match="unparameterized"):
+
+            class UnparamDict(JsonKeyValueConf[str, dict]):  # type: ignore[type-arg]
+                pass
+
+        with pytest.raises(TypeError, match="unsupported parameterized"):
+
+            class TupleValue(JsonKeyValueConf[str, Tuple[str, int]]):  # type: ignore[type-arg]
+                pass
+
+    def test_primitive_value_types_accepted(self) -> None:
+        class StrStore(JsonKeyValueConf[str, str]):
+            pass
+
+        class IntStore(JsonKeyValueConf[str, int]):
+            pass
+
+        s = StrStore()
+        s["key"] = "hello"
+        assert s["key"] == "hello"
+
+        i = IntStore()
+        i["key"] = 42
+        assert i["key"] == 42
+
+    def test_parameterized_list_and_dict_accepted(self) -> None:
+        class ListStore(JsonKeyValueConf[str, List[int]]):
+            pass
+
+        class DictStore(JsonKeyValueConf[str, Dict[str, int]]):
+            pass
+
+        ls = ListStore()
+        ls["nums"] = [1, 2, 3]
+        assert ls["nums"] == [1, 2, 3]
+
+        ds = DictStore()
+        ds["mapping"] = {"a": 1}
+        assert ds["mapping"] == {"a": 1}
+
+    def test_coerce_value_skips_if_already_correct_type(self) -> None:
+        class PathStore(JsonKeyValueConf[str, Path]):
+            pass
+
+        store = PathStore()
+        existing = Path("/tmp/test")
+        store["key"] = existing
+        assert store["key"] is existing
+
+    def test_subclass_of_subclass_coerces_values(self) -> None:
+        class Store(JsonKeyValueConf[str, Path]):
             pass
 
         class SubStore(Store):
             pass
 
-        assert SubStore._value_type is int
+        sub = SubStore()
+        sub["key"] = "/tmp/test"  # type: ignore[assignment]
+        assert isinstance(sub["key"], Path)
 
     def test_load_removes_deleted_keys(self, tmp_path: Path) -> None:
         json_file = tmp_path / "jsonkvconf.json"

--- a/ulauncher/utils/json_conf.py
+++ b/ulauncher/utils/json_conf.py
@@ -91,15 +91,33 @@ class JsonKeyValueConf(MutableMapping[str, V], Generic[K, V]):
                 if len(args) != 2:  # noqa: PLR2004
                     msg = f"{cls.__name__}: JsonKeyValueConf requires exactly 2 type args, got {len(args)}"
                     raise TypeError(msg)
+                key_type, value_type = args
                 # `is str` is intentional: we're checking type identity, not equality.
                 # The builtin `str` type object is a singleton, so `is` is correct here.
-                if args[0] is not str:
-                    msg = f"{cls.__name__}: key type must be str, got {args[0]!r}"
+                if key_type is not str:
+                    msg = f"{cls.__name__}: key type must be str, got {key_type!r}"
                     raise TypeError(msg)
-                if not isinstance(args[1], type):
-                    msg = f"{cls.__name__}: value type must be a concrete type, got {args[1]!r}"
+                if value_type in (str, int, float, bool):
+                    return  # no coercion needed
+                if value_type in (list, dict):
+                    msg = (
+                        f"{cls.__name__}: unparameterized {value_type} not supported. "
+                        f"Use list[...] for lists and BaseDataClass subclasses or dict[K, V] for dicts"
+                    )
                     raise TypeError(msg)
-                cls._value_type = args[1]
+                if origin := get_origin(value_type):
+                    if origin in (list, dict):
+                        return  # no coercion needed
+                    msg = (
+                        f"{cls.__name__}: unsupported parameterized value type. "
+                        f"Only list and dict supported, got {value_type!r}"
+                    )
+                    raise TypeError(msg)
+                if isinstance(value_type, type):
+                    cls._value_type = value_type
+                else:
+                    msg = f"{cls.__name__}: value type must be a concrete type, got {value_type!r}"
+                    raise TypeError(msg)
                 return
 
         if cls._value_type is None:


### PR DESCRIPTION
  This commit extends JsonKeyValueConf to support two new value type categories:
  1. Primitive types (str, int, float, bool) — skip coercion since JSON already delivers the
  right native type
  2. Parameterized generics (list[X], dict[K, V]) — skip coercion since JSON delivers these
  natively too

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Optimize JsonKeyValueConf to skip coercion for primitive values and parameterized lists/dicts, and to validate unsupported generics. This speeds up config reads/writes and improves type safety.

- **New Features**
  - Accept str/int/float/bool and list[T]/dict[K, V] without coercion.
  - Reject unparameterized list/dict and unsupported generics (e.g., Tuple[str, int]) with clear errors.
  - Added tests for acceptance paths, error cases, and coercion fallback for concrete types.

<sup>Written for commit 010f539022c36d498ec23a034ca2565e0a85e14b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

