### PR TITLE
perf: cache app ranking

### DIFF
--- a/tests/modes/apps/test_app_history.py
+++ b/tests/modes/apps/test_app_history.py
@@ -11,7 +11,7 @@ class AppHistory(_AppHistory):
 class TestAppHistory:
     def test_get_top_app_ids_sorted_by_count(self) -> None:
         app_history = AppHistory({"app1.desktop": 3000, "app2.desktop": 765})
-        ids = app_history.get_top_app_ids()
+        ids = app_history.get_app_ranking()
         assert ids[0] == "app1.desktop"
         assert ids[1] == "app2.desktop"
 
@@ -23,4 +23,4 @@ class TestAppHistory:
     def test_bump_updates_top_app_ids(self) -> None:
         app_history = AppHistory({"app1.desktop": 1, "app2.desktop": 1})
         app_history.bump("app2.desktop")
-        assert app_history.get_top_app_ids() == ["app2.desktop", "app1.desktop"]
+        assert app_history.get_app_ranking() == ["app2.desktop", "app1.desktop"]

--- a/ulauncher/modes/apps/app_history.py
+++ b/ulauncher/modes/apps/app_history.py
@@ -7,7 +7,8 @@ _app_history_path = f"{paths.STATE}/app_starts.json"
 
 
 class _AppHistory(JsonKeyValueConf[str, int]):
-    def get_top_app_ids(self) -> list[str]:
+    def get_app_ranking(self) -> list[str]:
+        """Get list of app IDs sorted by launch count"""
         return sorted(self, key=lambda k: self.get(k, 0), reverse=True)
 
     def bump(self, app_id: str) -> None:

--- a/ulauncher/modes/apps/app_history.py
+++ b/ulauncher/modes/apps/app_history.py
@@ -7,12 +7,20 @@ _app_history_path = f"{paths.STATE}/app_starts.json"
 
 
 class _AppHistory(JsonKeyValueConf[str, int]):
+    _ranking_cache: list[str] | None = None
+
     def get_app_ranking(self) -> list[str]:
         """Get list of app IDs sorted by launch count"""
-        return sorted(self, key=lambda k: self.get(k, 0), reverse=True)
+        if self._ranking_cache is None:
+            self._ranking_cache = sorted(self, key=lambda k: self.get(k, 0), reverse=True)
+        return self._ranking_cache
+
+    def clear_ranking_cache(self) -> None:
+        self._ranking_cache = None
 
     def bump(self, app_id: str) -> None:
         self[app_id] = self.get(app_id, 0) + 1
+        self.clear_ranking_cache()
         self.save()
 
 

--- a/ulauncher/modes/apps/app_mode.py
+++ b/ulauncher/modes/apps/app_mode.py
@@ -48,7 +48,7 @@ class AppMode(Mode):
     def get_home_results(self, limit: int) -> list[AppResult]:
         """Get the top {N} apps (based on number of launches) to show when the query is empty"""
         # TODO: filter out old apps
-        return list(filter(None, map(AppResult.from_id, app_history.get_top_app_ids())))[:limit]
+        return list(filter(None, map(AppResult.from_id, app_history.get_app_ranking())))[:limit]
 
     def activate_result(
         self,

--- a/ulauncher/modes/apps/app_mode.py
+++ b/ulauncher/modes/apps/app_mode.py
@@ -23,6 +23,7 @@ class AppMode(Mode):
         callback([])
 
     def get_triggers(self) -> Iterator[AppResult]:
+        app_history.clear_ranking_cache()
         settings = Settings.load()
 
         if not settings.enable_application_mode:

--- a/ulauncher/modes/apps/app_result.py
+++ b/ulauncher/modes/apps/app_result.py
@@ -40,7 +40,7 @@ class AppResult(Result):
 
     def get_searchable_fields(self) -> list[tuple[str, float]]:
         frequency_weight = 1.0
-        sorted_app_ids = app_history.get_top_app_ids()
+        sorted_app_ids = app_history.get_app_ranking()
         if count := len(sorted_app_ids):
             index = sorted_app_ids.index(self.app_id) if self.app_id in sorted_app_ids else count
             frequency_weight = 1.0 - (index / count * 0.1) + 0.05


### PR DESCRIPTION
Renames `get_top_app_ids` -> `get_app_ranking` and caches `get_app_ranking` since it's used on every keypress.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Cache app ranking and rename the history API to cut sorting work while typing. Cached ranking is reused across result builders and invalidated per query and on launches.

- **Refactors**
  - Renamed `get_top_app_ids` to `get_app_ranking`; updated call sites and tests.
  - Added in-memory cache in `AppHistory`; invalidated via `clear_ranking_cache()` at `get_triggers()` start and on `bump()` so `get_home_results` and `AppResult.get_searchable_fields` share a consistent ranking.

<sup>Written for commit b505bbb4037f8700ccd2a1278a9712ecf6594acc. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

