### PR TITLE
feat: frequency ranking

### DIFF
--- a/tests/modes/apps/test_app_history.py
+++ b/tests/modes/apps/test_app_history.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from ulauncher.modes.apps.app_history import _AppHistory
+from ulauncher.modes.apps.app_history import _AppHistory, _AppHistoryData
 
 
 class AppHistory(_AppHistory):
@@ -16,9 +16,9 @@ class TestAppHistory:
         assert ids[1] == "app2.desktop"
 
     def test_bump_increments_count(self) -> None:
-        app_history = AppHistory({"app.desktop": 100})
+        app_history = AppHistory({"app.desktop": _AppHistoryData(count=100)})
         app_history.bump("app.desktop")
-        assert app_history.get("app.desktop") == 101
+        assert app_history["app.desktop"].count == 101
 
     def test_bump_updates_top_app_ids(self) -> None:
         app_history = AppHistory({"app1.desktop": 1, "app2.desktop": 1})

--- a/ulauncher/modes/apps/app_history.py
+++ b/ulauncher/modes/apps/app_history.py
@@ -2,26 +2,43 @@ from __future__ import annotations
 
 import operator
 import time
-from typing import Any, TypedDict
+from typing import Any
 
 from ulauncher import paths
+from ulauncher.utils.base_data_class import BaseDataClass
 from ulauncher.utils.json_conf import JsonKeyValueConf
 
 _APP_HISTORY_PATH = f"{paths.STATE}/app_starts.json"
 
 
-class _AppHistoryData(TypedDict):
-    count: int
-    last_launches: list[float]
+class _AppHistoryData(BaseDataClass):
+    count = 0
+    last_launches: list[float] = []
 
 
 class _AppHistory(JsonKeyValueConf[str, _AppHistoryData]):
     _ranking_cache: list[str] | None = None
 
     def _coerce_value(self, value: Any) -> _AppHistoryData:
+        if isinstance(value, _AppHistoryData):
+            return value
+        valid_count = 0
+        valid_launches: list[float] = []
+
         if isinstance(value, int):
-            return {"count": value, "last_launches": []}
-        return {"count": value.get("count", 0), "last_launches": value.get("last_launches", [])}
+            valid_count = value
+        elif isinstance(value, dict):
+            raw_count = value.get("count")
+            if isinstance(raw_count, int):
+                valid_count = raw_count
+            elif isinstance(raw_count, str) and raw_count.isdigit():
+                valid_count = int(raw_count)
+
+            raw_launches = value.get("last_launches")
+            if isinstance(raw_launches, (list, tuple)):
+                valid_launches = [float(x) for x in raw_launches if isinstance(x, (int, float))][-10:]
+
+        return _AppHistoryData(count=valid_count, last_launches=valid_launches)
 
     def get_app_ranking(self) -> list[str]:
         if self._ranking_cache is None:
@@ -36,8 +53,8 @@ class _AppHistory(JsonKeyValueConf[str, _AppHistoryData]):
     @staticmethod
     def _calculate_score(data: _AppHistoryData) -> float:
         now = time.time()
-        score = data["count"] * 0.1
-        for launch_time in data["last_launches"]:
+        score = data.count * 0.1
+        for launch_time in data.last_launches:
             diff = now - launch_time
             if diff < 86400:
                 score += 100
@@ -54,12 +71,16 @@ class _AppHistory(JsonKeyValueConf[str, _AppHistoryData]):
         return score
 
     def bump(self, app_id: str) -> None:
-        data = self.get(app_id, {"count": 0, "last_launches": []})
-        data["count"] += 1
-        data["last_launches"].append(time.time())
-        if len(data["last_launches"]) > 10:
-            data["last_launches"].pop(0)
-        self[app_id] = data
+        data = self.get(app_id)
+        if not data:
+            data = _AppHistoryData()
+            self[app_id] = data
+
+        data.count += 1
+        data.last_launches.append(time.time())
+        if len(data.last_launches) > 10:
+            data.last_launches.pop(0)
+
         self.clear_ranking_cache()
         self.save()
 

--- a/ulauncher/modes/apps/app_history.py
+++ b/ulauncher/modes/apps/app_history.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-import operator
+import math
 import time
 from typing import Any
 
@@ -10,6 +10,8 @@ from ulauncher.utils.json_conf import JsonKeyValueConf
 
 _APP_HISTORY_PATH = f"{paths.STATE}/app_starts.json"
 _MAX_APP_HISTORY = 10
+_SEARCH_SCORE_HALF_TIME = 5 * 24 * 60 * 60  # 5 days
+_SCORE_DECAY = math.log(2) / _SEARCH_SCORE_HALF_TIME
 
 
 class _AppHistoryData(BaseDataClass):
@@ -44,8 +46,7 @@ class _AppHistory(JsonKeyValueConf[str, _AppHistoryData]):
     def get_app_ranking(self) -> list[str]:
         if self._ranking_cache is None:
             scores = {app_id: _AppHistory._calculate_score(data) for app_id, data in self.items()}
-            sorted_ids = sorted(scores.items(), key=operator.itemgetter(1), reverse=True)
-            self._ranking_cache = [app_id for app_id, score in sorted_ids]
+            self._ranking_cache = sorted(scores, key=scores.get, reverse=True)  # type: ignore[arg-type]
         return self._ranking_cache
 
     def clear_ranking_cache(self) -> None:
@@ -55,20 +56,9 @@ class _AppHistory(JsonKeyValueConf[str, _AppHistoryData]):
     def _calculate_score(data: _AppHistoryData) -> float:
         now = time.time()
         score = data.count * 0.1
+        # Exponential decay: score halves every SEARCH_SCORE_HALF_TIME, approaches 0 for old launches
         for launch_time in data.last_launches:
-            diff = now - launch_time
-            if diff < 86400:
-                score += 100
-            elif diff < 259200:
-                score += 80
-            elif diff < 604800:
-                score += 60
-            elif diff < 1209600:
-                score += 40
-            elif diff < 2592000:
-                score += 20
-            else:
-                score += 10
+            score += 100 * math.exp(-_SCORE_DECAY * (now - launch_time))
         return score
 
     def bump(self, app_id: str) -> None:

--- a/ulauncher/modes/apps/app_history.py
+++ b/ulauncher/modes/apps/app_history.py
@@ -9,6 +9,7 @@ from ulauncher.utils.base_data_class import BaseDataClass
 from ulauncher.utils.json_conf import JsonKeyValueConf
 
 _APP_HISTORY_PATH = f"{paths.STATE}/app_starts.json"
+_MAX_APP_HISTORY = 10
 
 
 class _AppHistoryData(BaseDataClass):
@@ -36,7 +37,7 @@ class _AppHistory(JsonKeyValueConf[str, _AppHistoryData]):
 
             raw_launches = value.get("last_launches")
             if isinstance(raw_launches, (list, tuple)):
-                valid_launches = [float(x) for x in raw_launches if isinstance(x, (int, float))][-10:]
+                valid_launches = [float(x) for x in raw_launches if isinstance(x, (int, float))][-_MAX_APP_HISTORY:]
 
         return _AppHistoryData(count=valid_count, last_launches=valid_launches)
 
@@ -78,7 +79,7 @@ class _AppHistory(JsonKeyValueConf[str, _AppHistoryData]):
 
         data.count += 1
         data.last_launches.append(time.time())
-        if len(data.last_launches) > 10:
+        if len(data.last_launches) > _MAX_APP_HISTORY:
             data.last_launches.pop(0)
 
         self.clear_ranking_cache()

--- a/ulauncher/modes/apps/app_history.py
+++ b/ulauncher/modes/apps/app_history.py
@@ -1,25 +1,65 @@
 from __future__ import annotations
 
+import operator
+import time
+from typing import Any, TypedDict
+
 from ulauncher import paths
 from ulauncher.utils.json_conf import JsonKeyValueConf
 
 _APP_HISTORY_PATH = f"{paths.STATE}/app_starts.json"
 
 
-class _AppHistory(JsonKeyValueConf[str, int]):
+class _AppHistoryData(TypedDict):
+    count: int
+    last_launches: list[float]
+
+
+class _AppHistory(JsonKeyValueConf[str, _AppHistoryData]):
     _ranking_cache: list[str] | None = None
 
+    def _coerce_value(self, value: Any) -> _AppHistoryData:
+        if isinstance(value, int):
+            return {"count": value, "last_launches": []}
+        return {"count": value.get("count", 0), "last_launches": value.get("last_launches", [])}
+
     def get_app_ranking(self) -> list[str]:
-        """Get list of app IDs sorted by launch count"""
         if self._ranking_cache is None:
-            self._ranking_cache = sorted(self, key=lambda k: self.get(k, 0), reverse=True)
+            scores = {app_id: _AppHistory._calculate_score(data) for app_id, data in self.items()}
+            sorted_ids = sorted(scores.items(), key=operator.itemgetter(1), reverse=True)
+            self._ranking_cache = [app_id for app_id, score in sorted_ids]
         return self._ranking_cache
 
     def clear_ranking_cache(self) -> None:
         self._ranking_cache = None
 
+    @staticmethod
+    def _calculate_score(data: _AppHistoryData) -> float:
+        now = time.time()
+        score = data["count"] * 0.1
+        for launch_time in data["last_launches"]:
+            diff = now - launch_time
+            if diff < 86400:
+                score += 100
+            elif diff < 259200:
+                score += 80
+            elif diff < 604800:
+                score += 60
+            elif diff < 1209600:
+                score += 40
+            elif diff < 2592000:
+                score += 20
+            else:
+                score += 10
+        return score
+
     def bump(self, app_id: str) -> None:
-        self[app_id] = self.get(app_id, 0) + 1
+        data = self.get(app_id, {"count": 0, "last_launches": []})
+        data["count"] += 1
+        data["last_launches"].append(time.time())
+        if len(data["last_launches"]) > 10:
+            data["last_launches"].pop(0)
+        self[app_id] = data
         self.clear_ranking_cache()
         self.save()
 


### PR DESCRIPTION
Rework of #1674

The original PR exposed a lot of things that needed improvements in main first, so I reworked the structure and semantics a lot for the sake of this feature. I tried to push that to the original branch but the author disabled that.

The main difference from this branch and #1674 is that all the logic involving this data was moved into a dedicated module (#1688), renamed to `app_history.py` (f30248ec0) and implemented with a new JsonKeyValueConf helper class #1684 to support typed data for this JSON configs in this shape.

I also added cache for app ranking (aa9117a46) to address one of the copilot complaints.and the `get_top_app_ids` method was renamed to get_app_ranking.

All these changes are already merged and the old branch is rebased on top of them, which heavily changes the code implementation.

I also fixed linting issues and rewrote the decay algorithm 5633301b1 (in the branch).

I still have some opinions/thoughts about this solution, but I figured this is a better base to start the discussion.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add frequency-based app ranking with exponential decay using recent launch times, replacing simple count sorting. Adds a small ranking cache and a typed history format to improve accuracy and performance.

- **New Features**
  - Ranks apps by score: count weight + decayed recent launches (half-life 5 days), keeping up to 10 timestamps per app.
  - Caches the computed ranking and invalidates on bump.
  - Stores typed history entries (count + last_launches) with value coercion and validation.

- **Migration**
  - Replace get_top_app_ids() calls with get_app_ranking().
  - Existing app_starts.json with integer counts is auto-coerced; no manual steps required.

<sup>Written for commit 5633301b176116abe5b6f5d9b0bae582ed5e6051. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

