### PR TITLE
refactor(json-config): remove validation

### DIFF
--- a/tests/data/test_json_conf.py
+++ b/tests/data/test_json_conf.py
@@ -124,8 +124,8 @@ class TestJsonConf:
 
     def test_setitem_always_used(self) -> None:
         class UnderscorePrefix(JsonConf):
-            def __setitem__(self, key: str, value: Any, validate_type: bool = True) -> None:
-                super().__setitem__("_" + key, value, validate_type)
+            def __setitem__(self, key: str, value: Any) -> None:
+                super().__setitem__("_" + key, value)
 
         data = UnderscorePrefix({"one": 1})
         data.update({"two": 2})

--- a/ulauncher/data/json_conf.py
+++ b/ulauncher/data/json_conf.py
@@ -21,17 +21,6 @@ class JsonConf(BaseDataClass):
     File paths are stored in an external reference object, which is not part of the data.
     """
 
-    def __setitem__(self, key: str, value: dict[str, Any], validate_type: bool = True) -> None:
-        if hasattr(self.__class__, key):
-            class_val = getattr(self.__class__, key)
-            # WARNING: this logic does not work with union types or nullable types,
-            # since it derives the type from the initial class value
-            if validate_type and not isinstance(value, type(class_val)):
-                msg = f'"{key}" must be of type {type(class_val).__name__}, {type(value).__name__} given.'
-                raise KeyError(msg)
-
-        super().__setitem__(key, value)
-
     @classmethod
     def load(cls: type[T], path: str | Path) -> T:
         instance, data = _load_cached_file_instance(cls, path)

--- a/ulauncher/modes/extensions/extension_manifest.py
+++ b/ulauncher/modes/extensions/extension_manifest.py
@@ -21,10 +21,6 @@ class ExtensionManifestPreference(JsonConf):
     max: int | None = None
     min: int | None = None
 
-    def __setitem__(self, key: str, value: Any) -> None:  # type: ignore[override]
-        validate_type = key in ["name", "type", "description", "options"]
-        super().__setitem__(key, value, validate_type)
-
 
 class ExtensionManifestTrigger(JsonConf):
     name = ""


### PR DESCRIPTION
When I created it, it felt like a good idea to avoid needing to declare the type and validation separately. But since it doesn't actually check the type, but the class values, it will use the default type for union types, which is a major footgun.

I made a local working branch where it actually used type introspection so that it got the real types. This only worked for explicitly declared types so I still had to keep the current way of using the class value as the fallback if there were no explicit types declared. That made it much more complex.

The utility for it is very minimal. The ExtensionManifest is the most complex case and we have manual validation for that. The themes also has manual validation (but a bit lacking). Most other config files are more like data cache, and not meant to be edited by the user.

Settings is probably the only valid case left, but I think the utility there is low as well.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed implicit type validation from `JsonConf.__setitem__` to avoid misleading checks based on class defaults, especially for union/nullable types. This simplifies config handling; manual validation remains where needed (e.g., ExtensionManifest, themes).

- **Refactors**
  - Removed `validate_type` logic from `JsonConf.__setitem__`.
  - Dropped custom validation in `ExtensionManifestPreference.__setitem__`.
  - Updated tests to use the new `__setitem__` signature.

- **Migration**
  - If you relied on `KeyError` from `JsonConf.__setitem__`, add explicit validation in your code.
  - Remove any `validate_type` argument in overrides or calls.

<sup>Written for commit dd644c9060106295633d33e61826881871f562b8. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

