### PR TITLE
refactor: default sorting to false for json utils

### DIFF
--- a/tests/data/test_json_conf.py
+++ b/tests/data/test_json_conf.py
@@ -40,8 +40,8 @@ class TestJsonConf:
         assert jc2.a == 1
 
     def test_stringify(self) -> None:
-        assert json_stringify(JsonConf(a=1, c=3, b=2)) == '{"a": 1, "b": 2, "c": 3}'
-        assert json_stringify(JsonConf(a=1, c=3, b=2), sort_keys=False) == '{"a": 1, "c": 3, "b": 2}'
+        assert json_stringify(JsonConf(a=1, c=3, b=2)) == '{"a": 1, "c": 3, "b": 2}'
+        assert json_stringify(JsonConf(a=1, c=3, b=2), sort_keys=True) == '{"a": 1, "b": 2, "c": 3}'
         assert json_stringify(JsonConf(a=1, b=2), indent=4) == '{\n    "a": 1,\n    "b": 2\n}'
         conf = JsonConf(a=None, b=[], c={}, d=1)
         assert json_stringify(conf) == '{"d": 1}'
@@ -105,7 +105,7 @@ class TestJsonConf:
         assert ClassWDefault(a=9).sum() == 10
         inst = ClassWDefault()
         assert inst.sum() == 3
-        assert json_stringify(SubclassWDefault()) == '{"a": 2, "b": 1, "c": 3}'
+        assert json_stringify(SubclassWDefault(), sort_keys=True) == '{"a": 2, "b": 1, "c": 3}'
 
         # Test file operations with real files
         json_ko_file = tmp_path / "jsonconf-key-order.json"
@@ -131,7 +131,7 @@ class TestJsonConf:
         data.update({"two": 2})
         data.three = 3
         data["four"] = 4
-        assert json_stringify(data, sort_keys=False) == '{"_one": 1, "_two": 2, "_three": 3, "_four": 4}'
+        assert json_stringify(data) == '{"_one": 1, "_two": 2, "_three": 3, "_four": 4}'
 
     def test_file_cache(self, tmp_path: Path) -> None:
         """Test that different JsonConf subclasses maintain separate file caches"""

--- a/ulauncher/data/_file_cache.py
+++ b/ulauncher/data/_file_cache.py
@@ -24,7 +24,7 @@ def _load_cached_file_instance(cls: type[FileInstanceT], path: str | Path) -> tu
     return instance, data
 
 
-def _save_cached_file_instance(instance: object, data: Any, *, sort_keys: bool = True) -> bool:
+def _save_cached_file_instance(instance: object, data: Any, *, sort_keys: bool = False) -> bool:
     file_path = _instance_paths.get(id(instance))
     if file_path is None:
         logger.error("Could not resolve file path for instance %s", instance.__class__.__name__)

--- a/ulauncher/data/json_conf.py
+++ b/ulauncher/data/json_conf.py
@@ -29,4 +29,4 @@ class JsonConf(BaseDataClass):
 
     def save(self, *args: Any, **kwargs: Any) -> bool:
         self.update(*args, **kwargs)
-        return _save_cached_file_instance(self, self)
+        return _save_cached_file_instance(self, self, sort_keys=True)

--- a/ulauncher/data/json_key_value_conf.py
+++ b/ulauncher/data/json_key_value_conf.py
@@ -109,4 +109,4 @@ class JsonKeyValueConf(MutableMapping[str, V], Generic[K, V]):
 
     def save(self, *args: Any, **kwargs: Any) -> bool:
         self.update(*args, **kwargs)
-        return _save_cached_file_instance(self, dict(self.items()), sort_keys=False)
+        return _save_cached_file_instance(self, dict(self.items()))

--- a/ulauncher/utils/json_utils.py
+++ b/ulauncher/utils/json_utils.py
@@ -39,7 +39,7 @@ def json_load(path: str | Path) -> Any:
 
 
 def json_stringify(
-    data: Any, indent: int | str | None = None, sort_keys: bool = True, value_blacklist: list[Any] | None = None
+    data: Any, indent: int | str | None = None, sort_keys: bool = False, value_blacklist: list[Any] | None = None
 ) -> str:
     # When serializing to JSON, filter out common empty default values like None, empty list or dict
     # These are default values when initializing the objects, but they are not actual data
@@ -53,7 +53,7 @@ def json_save(
     data: Any,
     path: str | Path,
     indent: int | str | None = 2,
-    sort_keys: bool = True,
+    sort_keys: bool = False,
     value_blacklist: list[Any] | None = None,
 ) -> bool:
     """Save self to file path"""


### PR DESCRIPTION
Default json stringification sorting to `false` in utils/helpers and only override in JsonConf

This aligns with the json.dumps defaults and it makes more sense since key sorting should be explicit. You don't want to sort arbitrary key/value dict data on every save.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Default JSON utils no longer sort keys by default. Sorting is now explicit, with `JsonConf.save()` opting in for deterministic output.

- **Refactors**
  - Set `sort_keys=False` by default in `json_stringify` and `json_save`.
  - Set `sort_keys=False` in `_save_cached_file_instance` default; `JsonConf.save()` now calls it with `sort_keys=True`.
  - `JsonKeyValueConf.save()` relies on the new default (no sorting).
  - Updated tests to reflect unsorted defaults and explicit sorting where needed.

<sup>Written for commit 36b8ebed92bfe9156037bab0ef796e8877bfa5df. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

