### PR TITLE
refactor(jsonconf): replace _file_instances cache with lru_cache

### DIFF
--- a/ulauncher/data/_file_cache.py
+++ b/ulauncher/data/_file_cache.py
@@ -4,24 +4,19 @@ import logging
 from pathlib import Path
 from typing import Any, TypeVar, cast
 
-from ulauncher.utils.json_utils import json_load, json_save
+from ulauncher.utils.json_utils import json_save
+from ulauncher.utils.lru_cache import lru_cache
 
 logger = logging.getLogger()
 FileInstanceT = TypeVar("FileInstanceT")
-_file_instances: dict[tuple[Path, type[object]], object] = {}
 _instance_paths: dict[int, Path] = {}
 
 
-def _load_cached_file_instance(cls: type[FileInstanceT], path: str | Path) -> tuple[FileInstanceT, Any]:
-    file_path = Path(path).resolve()
-    key = (file_path, cls)
-    data = json_load(file_path)
-    instance = cast("FileInstanceT", _file_instances.get(key))
-    if instance is None:
-        instance = cls()
-        _file_instances[key] = instance
-        _instance_paths[id(instance)] = file_path
-    return instance, data
+@lru_cache(maxsize=None)
+def _get_or_create_instance(cls: type[FileInstanceT], file_path: Path) -> FileInstanceT:
+    instance = cls()
+    _instance_paths[id(instance)] = file_path
+    return cast("FileInstanceT", instance)
 
 
 def _save_cached_file_instance(instance: object, data: Any, *, sort_keys: bool = False) -> bool:

--- a/ulauncher/data/json_conf.py
+++ b/ulauncher/data/json_conf.py
@@ -3,8 +3,9 @@ from __future__ import annotations
 from pathlib import Path
 from typing import Any, TypeVar
 
-from ulauncher.data._file_cache import _load_cached_file_instance, _save_cached_file_instance
+from ulauncher.data._file_cache import _get_or_create_instance, _save_cached_file_instance
 from ulauncher.data.base_data_class import BaseDataClass
+from ulauncher.utils.json_utils import json_load
 
 T = TypeVar("T", bound="JsonConf")
 
@@ -23,7 +24,9 @@ class JsonConf(BaseDataClass):
 
     @classmethod
     def load(cls: type[T], path: str | Path) -> T:
-        instance, data = _load_cached_file_instance(cls, path)
+        file_path = Path(path).resolve()
+        data = json_load(file_path)
+        instance = _get_or_create_instance(cls, file_path)
         instance.update(data)
         return instance
 

--- a/ulauncher/data/json_key_value_conf.py
+++ b/ulauncher/data/json_key_value_conf.py
@@ -6,7 +6,8 @@ from pathlib import Path
 # MutableMapping from typing (not collections.abc) supports subscript syntax on Python 3.8 for class bases.
 from typing import Any, Callable, Generic, Iterator, MutableMapping, TypeVar, cast, get_args, get_origin
 
-from ulauncher.data._file_cache import _load_cached_file_instance, _save_cached_file_instance
+from ulauncher.data._file_cache import _get_or_create_instance, _save_cached_file_instance
+from ulauncher.utils.json_utils import json_load
 
 logger = logging.getLogger()
 V = TypeVar("V")
@@ -99,7 +100,9 @@ class JsonKeyValueConf(MutableMapping[str, V], Generic[K, V]):
 
     @classmethod
     def load(cls: type[KVC], path: str | Path) -> KVC:
-        instance, data = _load_cached_file_instance(cls, path)
+        file_path = Path(path).resolve()
+        data = json_load(file_path)
+        instance = _get_or_create_instance(cls, file_path)
         if isinstance(data, dict):
             instance.clear()
             instance.update(data)


### PR DESCRIPTION
Replace _load_cached_file_instance with _get_or_create_instance which only handles the caching, and move the (re)load logic to the load methods instead.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Refactored config instance caching by replacing the internal `_file_instances` dict with an `lru_cache` and moving JSON reloads into each class’s `load` method. This simplifies caching and keeps reload behavior explicit.

- **Refactors**
  - Added `_get_or_create_instance(cls, file_path)` using `lru_cache` to cache instances per class and path.
  - Removed `_load_cached_file_instance`; `JsonConf.load` and `JsonKeyValueConf.load` now call `json_load(file_path)` and update the cached instance.

<sup>Written for commit ca6725a46d377e08386e3d1e244e2581332c3150. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

