### PR TITLE
fix(data): apply defaults on clear

### DIFF
--- a/ulauncher/data/base_data_class.py
+++ b/ulauncher/data/base_data_class.py
@@ -3,17 +3,24 @@ from __future__ import annotations
 from copy import deepcopy
 from typing import Any
 
+from ulauncher.utils.lru_cache import lru_cache
+
+
+@lru_cache(maxsize=None)
+def _class_defaults(cls: type) -> dict[str, Any]:
+    result: dict[str, Any] = {}
+    for base_cls in reversed(cls.__mro__):
+        if base_cls in BaseDataClass.__mro__:
+            continue
+        result.update(
+            {k: v for k, v in vars(base_cls).items() if not k.startswith("__") and not callable(getattr(base_cls, k))}
+        )
+    return result
+
 
 def _apply_class_defaults(instance: BaseDataClass) -> None:
-    for cls in reversed(instance.__class__.__mro__):
-        if cls in BaseDataClass.__mro__:
-            continue
-        defaults = {
-            k: deepcopy(v)  # deep copy to handle https://stackoverflow.com/q/1132941/633921
-            for k, v in vars(cls).items()
-            if (not k.startswith("__") and not callable(getattr(cls, k)))
-        }
-        instance.update(defaults)
+    # deep copy to handle https://stackoverflow.com/q/1132941/633921
+    instance.update(deepcopy(_class_defaults(type(instance))))
 
 
 class BaseDataClass(dict):  # type: ignore [type-arg]

--- a/ulauncher/data/base_data_class.py
+++ b/ulauncher/data/base_data_class.py
@@ -4,6 +4,18 @@ from copy import deepcopy
 from typing import Any
 
 
+def _apply_class_defaults(instance: BaseDataClass) -> None:
+    for cls in reversed(instance.__class__.__mro__):
+        if cls in BaseDataClass.__mro__:
+            continue
+        defaults = {
+            k: deepcopy(v)  # deep copy to handle https://stackoverflow.com/q/1132941/633921
+            for k, v in vars(cls).items()
+            if (not k.startswith("__") and not callable(getattr(cls, k)))
+        }
+        instance.update(defaults)
+
+
 class BaseDataClass(dict):  # type: ignore [type-arg]
     """
     BaseDataClass
@@ -31,20 +43,17 @@ class BaseDataClass(dict):  # type: ignore [type-arg]
 
     def __init__(self, *args: Any, **kwargs: Any) -> None:
         super().__init__()
-        # loop through class inheritance chain and add class props (defaults) as to the instance
-        # this is the same as the python dataclass decorators does
-        for cls in reversed(self.__class__.__mro__):
-            if cls in BaseDataClass.__mro__:
-                continue
-            defaults = {
-                k: deepcopy(v)  # deep copy to handle https://stackoverflow.com/q/1132941/633921
-                for k, v in vars(cls).items()
-                if (not k.startswith("__") and not callable(getattr(cls, k)))
-            }
-            self.update(defaults)
-
-        # set values
+        _apply_class_defaults(self)
         self.update(*args, **kwargs)
+
+    def clear(self) -> None:
+        """Reset to class defaults, removing any runtime-added keys.
+
+        Overrides dict.clear so that declared fields are always present after a clear,
+        preserving the type contract of subclasses that declare non-optional fields.
+        """
+        super().clear()
+        _apply_class_defaults(self)
 
     def __hash__(self) -> int:  # type: ignore [override]
         """


### PR DESCRIPTION
`dict.clear` removes all data, which is a type contract with `BaseDataClass` subclasses.

I never called it, before but we have a bug because we load data without calling it, so I think we need this change.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make `BaseDataClass.clear()` restore class defaults instead of leaving the instance empty. This prevents missing required fields after a clear and keeps subclass type contracts intact.

- **Bug Fixes**
  - Override `clear()` to reapply class defaults, so declared fields remain after resets.

- **Refactors**
  - Extract and cache class default resolution with `_class_defaults` (via `lru_cache`), and apply through `_apply_class_defaults` with a single deepcopy per apply.

<sup>Written for commit eec494e60e931d43de1dd48bc2f7aea6504dbc8a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

