### PR TITLE
feat(JsonConf): add explicit reload method

### DIFF
--- a/tests/data/test_json_conf.py
+++ b/tests/data/test_json_conf.py
@@ -148,32 +148,39 @@ class TestJsonConf:
         assert hasattr(c2a, "unique_cache_key")
         assert hasattr(c2b, "unique_cache_key")
 
-    def test_load_always_reads_file(self, tmp_path: Path) -> None:
-        """Test that load() always reads from file and updates cached instance"""
+    def test_load_is_lazy(self, tmp_path: Path) -> None:
+        """Test that load() returns the cached instance without re-reading the file"""
         json_file = str(tmp_path / "jsonconf.json")
 
         class C1(JsonConf):
             pass
 
-        # Create initial file with data
         json_save({"a": 1}, json_file)
-
-        # Load and verify
         c1 = C1.load(json_file)
         assert c1.a == 1
 
-        # Write a different value directly to the file
         json_save({"a": 2}, json_file)
-
-        # Load again - should read the new value and update the cached instance
         c1_again = C1.load(json_file)
-        assert c1_again.a == 2
-        # Since it's the same cached instance, the original reference should also be updated
-        assert c1.a == 2
+        assert c1_again.a == 1  # not re-read
         assert id(c1) == id(c1_again)
 
-    def test_load_removes_deleted_keys(self, tmp_path: Path) -> None:
-        """Test that reloading removes keys absent from the file, while preserving class defaults"""
+    def test_reload_reads_file(self, tmp_path: Path) -> None:
+        """Test that reload() re-reads from disk and updates the instance"""
+        json_file = str(tmp_path / "jsonconf.json")
+
+        class C1(JsonConf):
+            pass
+
+        json_save({"a": 1}, json_file)
+        c1 = C1.load(json_file)
+        assert c1.a == 1
+
+        json_save({"a": 2}, json_file)
+        c1.reload()
+        assert c1.a == 2
+
+    def test_reload_removes_deleted_keys(self, tmp_path: Path) -> None:
+        """Test that reload() removes keys absent from the file, while preserving class defaults"""
         json_file = str(tmp_path / "jsonconf.json")
 
         class C1(JsonConf):
@@ -186,8 +193,7 @@ class TestJsonConf:
         assert c1.default_key == "default"
 
         json_save({"a": 3}, json_file)
-        c1_again = C1.load(json_file)
-        assert c1_again.a == 3
-        assert "b" not in c1_again
-        assert c1_again.default_key == "default"
-        assert id(c1) == id(c1_again)
+        c1.reload()
+        assert c1.a == 3
+        assert "b" not in c1
+        assert c1.default_key == "default"

--- a/tests/data/test_json_key_value_conf.py
+++ b/tests/data/test_json_key_value_conf.py
@@ -117,23 +117,34 @@ class TestJsonKeyValueConf:
         assert "unique_cache_key" in c2a
         assert "unique_cache_key" in c2b
 
-    def test_load_always_reads_file(self, tmp_path: Path) -> None:
+    def test_load_is_lazy(self, tmp_path: Path) -> None:
         json_file = str(tmp_path / "jsonkvconf.json")
 
         class Store(JsonKeyValueConf[str, int]):
             pass
 
         json_save({"a": 1}, json_file)
-
         store = Store.load(json_file)
         assert store["a"] == 1
 
         json_save({"a": 2}, json_file)
-
         store_again = Store.load(json_file)
-        assert store_again["a"] == 2
-        assert store["a"] == 2
+        assert store_again["a"] == 1  # not re-read
         assert id(store) == id(store_again)
+
+    def test_reload_reads_file(self, tmp_path: Path) -> None:
+        json_file = str(tmp_path / "jsonkvconf.json")
+
+        class Store(JsonKeyValueConf[str, int]):
+            pass
+
+        json_save({"a": 1}, json_file)
+        store = Store.load(json_file)
+        assert store["a"] == 1
+
+        json_save({"a": 2}, json_file)
+        store.reload()
+        assert store["a"] == 2
 
     def test_raises_on_invalid_type_arguments(self) -> None:
         with pytest.raises(TypeError, match="key type must be str"):
@@ -216,20 +227,16 @@ class TestJsonKeyValueConf:
         sub["key"] = "/tmp/test"  # type: ignore[assignment]
         assert isinstance(sub["key"], Path)
 
-    def test_load_removes_deleted_keys(self, tmp_path: Path) -> None:
+    def test_reload_removes_deleted_keys(self, tmp_path: Path) -> None:
         json_file = str(tmp_path / "jsonkvconf.json")
 
         class Store(JsonKeyValueConf[str, int]):
             pass
 
         json_save({"a": 1, "b": 2}, json_file)
-
         store = Store.load(json_file)
         assert dict(store.items()) == {"a": 1, "b": 2}
 
         json_save({"a": 3}, json_file)
-
-        store_again = Store.load(json_file)
-        assert dict(store_again.items()) == {"a": 3}
+        store.reload()
         assert dict(store.items()) == {"a": 3}
-        assert id(store) == id(store_again)

--- a/ulauncher/data/_file_cache.py
+++ b/ulauncher/data/_file_cache.py
@@ -1,35 +1,41 @@
 from __future__ import annotations
 
 import logging
-from pathlib import Path
-from typing import Any, MutableMapping, TypeVar, cast
+from typing import Any, TypeVar, cast
 
 from ulauncher.utils.json_utils import json_load, json_save
 from ulauncher.utils.lru_cache import lru_cache
 
 logger = logging.getLogger()
 FileInstanceT = TypeVar("FileInstanceT")
-_MappingT = TypeVar("_MappingT", bound="MutableMapping[str, Any]")
-_instance_paths: dict[int, Path] = {}
+_instance_paths: dict[int, str] = {}
 
 
-@lru_cache(maxsize=None)
-def _get_or_create_instance(cls: type[FileInstanceT], file_path: Path) -> FileInstanceT:
-    instance = cls()
-    _instance_paths[id(instance)] = file_path
-    return cast("FileInstanceT", instance)
-
-
-def _load_cached_file_instance(cls: type[_MappingT], path: str) -> _MappingT:
-    file_path = Path(path).resolve()
+def _populate_from_file(instance: Any, file_path: str) -> None:
     data = json_load(file_path)
-    instance = _get_or_create_instance(cls, file_path)
     if isinstance(data, dict):
         instance.clear()
         instance.update(data)
-    elif data is not None:
+    elif data is None:
+        logger.warning("File not found or unreadable: %s — keeping cached data", file_path)
+    else:
         logger.warning("Expected a JSON object in %s, got %s — file ignored", file_path, type(data).__name__)
-    return instance
+
+
+@lru_cache(maxsize=None)
+def _get_or_create_instance(cls: type[FileInstanceT], file_path: str) -> FileInstanceT:
+    instance = cls()
+    _instance_paths[id(instance)] = file_path
+    _populate_from_file(instance, file_path)
+    return cast("FileInstanceT", instance)
+
+
+def _reload_file_instance(instance: Any) -> None:
+    file_path = _instance_paths.get(id(instance))
+    if file_path is None:
+        logger.error("%s.reload() called on instance not created via load()", instance.__class__.__name__)
+        return
+    _populate_from_file(instance, file_path)
 
 
 def _save_cached_file_instance(instance: object, data: Any, *, sort_keys: bool = False) -> bool:

--- a/ulauncher/data/json_conf.py
+++ b/ulauncher/data/json_conf.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from typing import Any, TypeVar
 
-from ulauncher.data._file_cache import _load_cached_file_instance, _save_cached_file_instance
+from ulauncher.data._file_cache import _get_or_create_instance, _reload_file_instance, _save_cached_file_instance
 from ulauncher.data.base_data_class import BaseDataClass
 
 T = TypeVar("T", bound="JsonConf")
@@ -22,7 +22,10 @@ class JsonConf(BaseDataClass):
 
     @classmethod
     def load(cls: type[T], path: str) -> T:
-        return _load_cached_file_instance(cls, path)
+        return _get_or_create_instance(cls, path)
+
+    def reload(self) -> None:
+        _reload_file_instance(self)
 
     def save(self, *args: Any, **kwargs: Any) -> bool:
         self.update(*args, **kwargs)

--- a/ulauncher/data/json_key_value_conf.py
+++ b/ulauncher/data/json_key_value_conf.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 # MutableMapping from typing (not collections.abc) supports subscript syntax on Python 3.8 for class bases.
 from typing import Any, Callable, Generic, Iterator, MutableMapping, TypeVar, cast, get_args, get_origin
 
-from ulauncher.data._file_cache import _load_cached_file_instance, _save_cached_file_instance
+from ulauncher.data._file_cache import _get_or_create_instance, _reload_file_instance, _save_cached_file_instance
 
 V = TypeVar("V")
 K = TypeVar("K", bound=str)
@@ -95,7 +95,10 @@ class JsonKeyValueConf(MutableMapping[str, V], Generic[K, V]):
 
     @classmethod
     def load(cls: type[KVC], path: str) -> KVC:
-        return _load_cached_file_instance(cls, path)
+        return _get_or_create_instance(cls, path)
+
+    def reload(self) -> None:
+        _reload_file_instance(self)
 
     def save(self, *args: Any, **kwargs: Any) -> bool:
         self.update(*args, **kwargs)

--- a/ulauncher/ui/windows/ulauncher_window.py
+++ b/ulauncher/ui/windows/ulauncher_window.py
@@ -198,6 +198,7 @@ class UlauncherWindow(Gtk.ApplicationWindow):
         self.set_opacity(1)
 
     def deferred_init(self) -> None:
+        self.settings.reload()
         if self.query_str:
             # select all text in the input field.
             # used when user turns off "start with blank query" setting


### PR DESCRIPTION
Avoid needlessly reloading config files from disk.
Add an explicit reload method instead.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make config loading lazy and add a reload() API to avoid unnecessary disk reads. The window reloads settings on show to pick up changes immediately.

- **New Features**
  - Added reload() to JsonConf and JsonKeyValueConf.
  - load(path) now returns the cached instance without re-reading the file.
  - Updated internal file cache to track paths and support reload().
  - Window calls settings.reload() in deferred_init().

- **Migration**
  - If you used load() to refresh from disk, call reload() on the instance instead.
  - reload() works only on instances created via load().

<sup>Written for commit 1c3e196c72ecefbca9219b31c173d9a8c07252ed. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

