### PR TITLE
feat(JsonConf): add explicit reload flag

### DIFF
--- a/tests/data/test_json_conf.py
+++ b/tests/data/test_json_conf.py
@@ -148,32 +148,39 @@ class TestJsonConf:
         assert hasattr(c2a, "unique_cache_key")
         assert hasattr(c2b, "unique_cache_key")
 
-    def test_load_always_reads_file(self, tmp_path: Path) -> None:
-        """Test that load() always reads from file and updates cached instance"""
+    def test_load_is_lazy(self, tmp_path: Path) -> None:
+        """Test that load() returns the cached instance without re-reading the file"""
         json_file = str(tmp_path / "jsonconf.json")
 
         class C1(JsonConf):
             pass
 
-        # Create initial file with data
         json_save({"a": 1}, json_file)
-
-        # Load and verify
         c1 = C1.load(json_file)
         assert c1.a == 1
 
-        # Write a different value directly to the file
         json_save({"a": 2}, json_file)
-
-        # Load again - should read the new value and update the cached instance
         c1_again = C1.load(json_file)
-        assert c1_again.a == 2
-        # Since it's the same cached instance, the original reference should also be updated
-        assert c1.a == 2
+        assert c1_again.a == 1  # not re-read
         assert id(c1) == id(c1_again)
 
-    def test_load_removes_deleted_keys(self, tmp_path: Path) -> None:
-        """Test that reloading removes keys absent from the file, while preserving class defaults"""
+    def test_load_force_reads_file(self, tmp_path: Path) -> None:
+        """Test that load(force=True) re-reads from disk and updates the instance"""
+        json_file = str(tmp_path / "jsonconf.json")
+
+        class C1(JsonConf):
+            pass
+
+        json_save({"a": 1}, json_file)
+        c1 = C1.load(json_file)
+        assert c1.a == 1
+
+        json_save({"a": 2}, json_file)
+        C1.load(json_file, force=True)
+        assert c1.a == 2
+
+    def test_load_force_removes_deleted_keys(self, tmp_path: Path) -> None:
+        """Test that load(force=True) removes keys absent from the file, while preserving class defaults"""
         json_file = str(tmp_path / "jsonconf.json")
 
         class C1(JsonConf):
@@ -186,8 +193,7 @@ class TestJsonConf:
         assert c1.default_key == "default"
 
         json_save({"a": 3}, json_file)
-        c1_again = C1.load(json_file)
-        assert c1_again.a == 3
-        assert "b" not in c1_again
-        assert c1_again.default_key == "default"
-        assert id(c1) == id(c1_again)
+        C1.load(json_file, force=True)
+        assert c1.a == 3
+        assert "b" not in c1
+        assert c1.default_key == "default"

--- a/tests/data/test_json_key_value_conf.py
+++ b/tests/data/test_json_key_value_conf.py
@@ -117,23 +117,34 @@ class TestJsonKeyValueConf:
         assert "unique_cache_key" in c2a
         assert "unique_cache_key" in c2b
 
-    def test_load_always_reads_file(self, tmp_path: Path) -> None:
+    def test_load_is_lazy(self, tmp_path: Path) -> None:
         json_file = str(tmp_path / "jsonkvconf.json")
 
         class Store(JsonKeyValueConf[str, int]):
             pass
 
         json_save({"a": 1}, json_file)
-
         store = Store.load(json_file)
         assert store["a"] == 1
 
         json_save({"a": 2}, json_file)
-
         store_again = Store.load(json_file)
-        assert store_again["a"] == 2
-        assert store["a"] == 2
+        assert store_again["a"] == 1  # not re-read
         assert id(store) == id(store_again)
+
+    def test_load_force_reads_file(self, tmp_path: Path) -> None:
+        json_file = str(tmp_path / "jsonkvconf.json")
+
+        class Store(JsonKeyValueConf[str, int]):
+            pass
+
+        json_save({"a": 1}, json_file)
+        store = Store.load(json_file)
+        assert store["a"] == 1
+
+        json_save({"a": 2}, json_file)
+        Store.load(json_file, force=True)
+        assert store["a"] == 2
 
     def test_raises_on_invalid_type_arguments(self) -> None:
         with pytest.raises(TypeError, match="key type must be str"):
@@ -216,20 +227,16 @@ class TestJsonKeyValueConf:
         sub["key"] = "/tmp/test"  # type: ignore[assignment]
         assert isinstance(sub["key"], Path)
 
-    def test_load_removes_deleted_keys(self, tmp_path: Path) -> None:
+    def test_load_force_removes_deleted_keys(self, tmp_path: Path) -> None:
         json_file = str(tmp_path / "jsonkvconf.json")
 
         class Store(JsonKeyValueConf[str, int]):
             pass
 
         json_save({"a": 1, "b": 2}, json_file)
-
         store = Store.load(json_file)
         assert dict(store.items()) == {"a": 1, "b": 2}
 
         json_save({"a": 3}, json_file)
-
-        store_again = Store.load(json_file)
-        assert dict(store_again.items()) == {"a": 3}
+        Store.load(json_file, force=True)
         assert dict(store.items()) == {"a": 3}
-        assert id(store) == id(store_again)

--- a/ulauncher/data/_file_cache.py
+++ b/ulauncher/data/_file_cache.py
@@ -1,34 +1,39 @@
 from __future__ import annotations
 
 import logging
-from pathlib import Path
-from typing import Any, MutableMapping, TypeVar, cast
+from typing import Any, TypeVar, cast
 
 from ulauncher.utils.json_utils import json_load, json_save
 from ulauncher.utils.lru_cache import lru_cache
 
 logger = logging.getLogger()
 FileInstanceT = TypeVar("FileInstanceT")
-_MappingT = TypeVar("_MappingT", bound="MutableMapping[str, Any]")
-_instance_paths: dict[int, Path] = {}
+_instance_paths: dict[int, str] = {}
 
 
-@lru_cache(maxsize=None)
-def _get_or_create_instance(cls: type[FileInstanceT], file_path: Path) -> FileInstanceT:
-    instance = cls()
-    _instance_paths[id(instance)] = file_path
-    return cast("FileInstanceT", instance)
-
-
-def _load_cached_file_instance(cls: type[_MappingT], path: str) -> _MappingT:
-    file_path = Path(path).resolve()
+def _populate_from_file(instance: Any, file_path: str) -> None:
     data = json_load(file_path)
-    instance = _get_or_create_instance(cls, file_path)
     if isinstance(data, dict):
         instance.clear()
         instance.update(data)
-    elif data is not None:
+    elif data is None:
+        logger.warning("File not found or unreadable: %s — keeping cached data", file_path)
+    else:
         logger.warning("Expected a JSON object in %s, got %s — file ignored", file_path, type(data).__name__)
+
+
+@lru_cache(maxsize=None)
+def _get_or_create_instance(cls: type[FileInstanceT], file_path: str) -> FileInstanceT:
+    instance = cls()
+    _instance_paths[id(instance)] = file_path
+    _populate_from_file(instance, file_path)
+    return cast("FileInstanceT", instance)
+
+
+def _load_cached_file_instance(cls: type[FileInstanceT], path: str, *, force: bool = False) -> FileInstanceT:
+    instance = _get_or_create_instance(cls, path)
+    if force:
+        _populate_from_file(instance, path)
     return instance
 
 

--- a/ulauncher/data/json_conf.py
+++ b/ulauncher/data/json_conf.py
@@ -21,8 +21,8 @@ class JsonConf(BaseDataClass):
     """
 
     @classmethod
-    def load(cls: type[T], path: str) -> T:
-        return _load_cached_file_instance(cls, path)
+    def load(cls: type[T], path: str, *, force: bool = False) -> T:
+        return _load_cached_file_instance(cls, path, force=force)
 
     def save(self, *args: Any, **kwargs: Any) -> bool:
         self.update(*args, **kwargs)

--- a/ulauncher/data/json_key_value_conf.py
+++ b/ulauncher/data/json_key_value_conf.py
@@ -94,8 +94,8 @@ class JsonKeyValueConf(MutableMapping[str, V], Generic[K, V]):
         return repr(self._data)
 
     @classmethod
-    def load(cls: type[KVC], path: str) -> KVC:
-        return _load_cached_file_instance(cls, path)
+    def load(cls: type[KVC], path: str, *, force: bool = False) -> KVC:
+        return _load_cached_file_instance(cls, path, force=force)
 
     def save(self, *args: Any, **kwargs: Any) -> bool:
         self.update(*args, **kwargs)

--- a/ulauncher/modes/extensions/extension_manifest.py
+++ b/ulauncher/modes/extensions/extension_manifest.py
@@ -161,7 +161,7 @@ class ExtensionManifest(JsonConf):
                 raise ext_exceptions.CompatibilityError(msg)
 
     @classmethod
-    def load(cls, path: str) -> ExtensionManifest:
+    def load(cls, path: str, *, force: bool = False) -> ExtensionManifest:
         if not path.endswith("/manifest.json"):
             path = f"{path}/manifest.json"
-        return super().load(path)
+        return super().load(path, force=force)

--- a/ulauncher/ui/windows/ulauncher_window.py
+++ b/ulauncher/ui/windows/ulauncher_window.py
@@ -36,7 +36,7 @@ class UlauncherWindow(Gtk.ApplicationWindow):
 
     def __init__(self, **kwargs: Any) -> None:  # noqa: PLR0915
         logger.info("Opening Ulauncher window")
-        self.settings = Settings.load()
+        self.settings = Settings.load(force=True)
         self.core = UlauncherCore()
         width_request = int(self.settings.base_width)
         height_request = -1

--- a/ulauncher/utils/settings.py
+++ b/ulauncher/utils/settings.py
@@ -40,5 +40,5 @@ class Settings(JsonConf):
         return list(dict.fromkeys(list(self.jump_keys)))
 
     @classmethod
-    def load(cls) -> Settings:  # type: ignore[override]
-        return super().load(_settings_file)
+    def load(cls, *, force: bool = False) -> Settings:  # type: ignore[override]
+        return super().load(_settings_file, force=force)


### PR DESCRIPTION
Avoid needlessly reloading config files from disk.
Add an explicit flag to force reload instead.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make JSON config loading lazy to avoid unnecessary disk reads. Add a `force` flag to reload from disk when needed, and use it when opening the window so settings reflect on-disk changes.

- **New Features**
  - Cache JSON-backed configs; `load()` returns the cached instance by default.
  - Add `force` to `JsonConf.load`, `JsonKeyValueConf.load`, `Settings.load`, and `ExtensionManifest.load`.
  - Use `Settings.load(force=True)` when showing the Ulauncher window.

- **Migration**
  - If you relied on `load()` always re-reading from disk, call `load(..., force=True)` instead. Existing calls without `force` continue to work.

<sup>Written for commit 250b1ed562c3e6d5d3767a461586cedd4d4f264e. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

