### PR TITLE
refactor: decouple extension icon resolution from GTK

### DIFF
--- a/ulauncher/modes/extensions/extension_controller.py
+++ b/ulauncher/modes/extensions/extension_controller.py
@@ -7,6 +7,7 @@ import sys
 import tempfile
 from collections import defaultdict
 from datetime import datetime
+from os.path import isfile, join
 from pathlib import Path
 from shutil import copytree, rmtree
 from typing import Any, Callable
@@ -165,13 +166,12 @@ class ExtensionController:
         user_prefs_json = _load_preferences(self.id)
         user_prefs_json.save(data)
 
-    def get_normalized_icon_path(self, icon: str | None = None) -> str | None:
-        # get_icon_path uses Gtk, but this function is only used in the UI layer
-        # so lazy loading avoid loading it in the extension or cli runtime
-        # TODO: move functionality to UI layer (having it here is still a perf footgun)
-        from ulauncher.ui.get_icon_path import get_icon_path  # noqa: TID251
-
-        return get_icon_path(icon or self.manifest.icon, base_path=self.path)
+    def get_icon_value(self, icon: str | None = None) -> str:
+        icon_value = icon or self.manifest.icon
+        expanded_path = join(self.path, icon_value)
+        if isfile(expanded_path):
+            return expanded_path
+        return icon_value
 
     async def remove(self) -> None:
         if not self.is_manageable:

--- a/ulauncher/modes/extensions/extension_mode.py
+++ b/ulauncher/modes/extensions/extension_mode.py
@@ -108,7 +108,7 @@ class ExtensionMode(Mode):
             for trigger_id, trigger in ext.triggers.items():
                 name = html.escape(trigger.name)
                 description = html.escape(trigger.description)
-                icon = ext.get_normalized_icon_path(trigger.icon)
+                icon = ext.get_icon_value(trigger.icon)
 
                 if trigger.keyword:
                     self._trigger_cache[trigger.keyword] = (trigger_id, ext.id)
@@ -120,7 +120,7 @@ class ExtensionMode(Mode):
 
     def get_placeholder_icon(self) -> str | None:
         if self.active_ext:
-            return self.active_ext.get_normalized_icon_path()
+            return self.active_ext.get_icon_value()
         return None
 
     def activate_result(
@@ -294,7 +294,7 @@ class ExtensionMode(Mode):
             effect_msg = []
             for result_dict in raw_effect_msg:
                 result = Result(**result_dict)
-                result.icon = self.active_ext.get_normalized_icon_path(result_dict.get("icon")) or ""
+                result.icon = self.active_ext.get_icon_value(result_dict.get("icon"))
 
                 # Convert legacy actions to the new actions dictionary format
                 if not result.actions:

--- a/ulauncher/ui/get_icon_path.py
+++ b/ulauncher/ui/get_icon_path.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import logging
-from os.path import expanduser, isfile, join
+from os.path import expanduser
 
 from gi.repository import Gtk
 
@@ -11,21 +11,17 @@ icon_theme = Gtk.IconTheme.get_default()
 logger = logging.getLogger()
 
 
-def get_icon_path(icon: str, size: int = 32, base_path: str = "") -> str | None:
+def get_icon_path(icon: str, size: int = 32) -> str | None:
     try:
         if icon and isinstance(icon, str):
             icon = expanduser(icon)
             if icon.startswith("/"):
                 return icon
 
-            expanded_path = join(base_path, icon)
-            if isfile(expanded_path):
-                return expanded_path
-
             if themed_icon := icon_theme.lookup_icon(icon, size, Gtk.IconLookupFlags.FORCE_SIZE):
                 return themed_icon.get_filename()
 
-    except (OSError, GLib.Error) as err:
+    except GLib.Error as err:
         logger.warning("Error '%s' occurred when trying to load icon path '%s'.", err, icon)
         logger.info("If this happens often, please see https://github.com/Ulauncher/Ulauncher/discussions/1346")
 

--- a/ulauncher/ui/preferences/views/extensions.py
+++ b/ulauncher/ui/preferences/views/extensions.py
@@ -81,7 +81,7 @@ class ExtensionsView(BaseView):
                 extension_cache[ext.id] = (
                     ext.manifest.name,
                     ext_utils.get_status_str(ext),
-                    ext.get_normalized_icon_path(),
+                    ext.get_icon_value(),
                 )
 
         if extension_cache == self.extension_cache:
@@ -202,7 +202,7 @@ class ExtensionsView(BaseView):
         left_box = Gtk.Box(orientation=Gtk.Orientation.HORIZONTAL, spacing=20)
 
         # Large icon
-        icon_path = ext.get_normalized_icon_path()
+        icon_path = ext.get_icon_value()
         icon_surface = load_icon_surface(icon_path or "", views.ICON_SIZE_L, self.get_scale_factor())
         icon_image = Gtk.Image.new_from_surface(icon_surface)
         left_box.pack_start(icon_image, False, False, 0)


### PR DESCRIPTION
This fixes a TODO from #1704

It turned out to be easier than I thought since we already call `get_icon_path` from load_icon_surface, so we just needed to check if the path is relative to the extension dir and return the absolute path then and otherwise `get_icon_path` will handle it later.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Decoupled extension icon resolution from GTK by resolving relative icon files in the extension and delegating theme lookup to the UI. This removes GTK imports from extension/CLI runtimes and makes icon handling clearer.

- **Refactors**
  - Added `ExtensionController.get_icon_value()` to return an absolute path if the file exists, else the icon name.
  - Replaced `get_normalized_icon_path()` usages with `get_icon_value()` in extension mode and preferences UI.
  - Simplified `get_icon_path()` to only handle absolute paths and theme lookup; removed the `base_path` argument and file checks.
  - Avoids lazy GTK imports outside the UI layer.

<sup>Written for commit d236c8499d4ea9ae3ee83c8a576a833bc6645003. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

