### PR TITLE
ci: mark unstable version as prerelease in draft release action

### DIFF
--- a/.github/workflows/draft-release.yml
+++ b/.github/workflows/draft-release.yml
@@ -26,6 +26,7 @@ jobs:
         uses: softprops/action-gh-release@v1
         with:
           draft: true
+          prerelease: ${{ contains(github.ref_name, '-') }}
           files: |
             dist/*.tar.gz
             dist/*.deb


### PR DESCRIPTION
Sets the default value when drafting a release

Makes the same assumptions that the publish-release action does later (`if [[ "$VERSION" == *-* ]];`).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Mark draft releases as prereleases when the tag contains a hyphen (e.g., 1.2.3-beta). This aligns the draft-release workflow with the publish-release logic and prevents unstable tags from appearing as stable.

<sup>Written for commit 2ec476b5eed8be17c07860e12dd2918865271a39. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

