### PR TITLE
ci: generate git cliff release notes

### DIFF
--- a/.github/workflows/draft-release.yml
+++ b/.github/workflows/draft-release.yml
@@ -11,6 +11,12 @@ jobs:
     container: ulauncher/build-image:6.6
     steps:
       - uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+      - name: Set up virtual environment
+        run: make venv
+      - name: Generate release notes
+        run: .venv/bin/git-cliff --current > RELEASE_NOTES.md
       - name: Check
         run: make check
       - name: Build release
@@ -27,6 +33,7 @@ jobs:
         with:
           draft: true
           prerelease: ${{ contains(github.ref_name, '-') }}
+          body_path: RELEASE_NOTES.md
           files: |
             dist/*.tar.gz
             dist/*.deb

--- a/cliff.toml
+++ b/cliff.toml
@@ -1,0 +1,35 @@
+[changelog]
+body = """
+{% if commits | length != 0 %}
+## What's Changed{% for group, commits in commits | filter(attribute="merge_commit", value=false) | group_by(attribute="group") %}
+
+### {{ group | striptags | trim }}
+{% for commit in commits %}* {% if commit.scope %}**{{ commit.scope }}:** {% endif %}{{ commit.message | replace_regex(from="( +\\(#\\d+\\))+$", to="") | upper_first }}{% if commit.links | length > 0 %} ({% for link in commit.links %}[{{ link.text }}]({{ link.href }}){% if not loop.last %}, {% endif %}{% endfor %}){% else %} ([{{ commit.id | truncate(length=7, end="") }}](https://github.com/Ulauncher/Ulauncher/commit/{{ commit.id }})){% endif %}
+{% endfor %}{% endfor %}
+{% else %}
+## What's Changed
+
+* No user-facing changes were captured for this release.
+{% endif %}
+"""
+trim = true
+
+[git]
+conventional_commits = true
+filter_unconventional = true
+filter_commits = true
+sort_commits = "oldest"
+tag_pattern = "v[0-9].*"
+link_parsers = [
+    { pattern = "#(\\d+)", href = "https://github.com/Ulauncher/Ulauncher/pull/$1" },
+]
+# Group names carry <!-- N --> prefixes so git-cliff sorts them correctly;
+# striptags in the template strips these before rendering.
+commit_parsers = [
+    { breaking = true, group = "<!-- -1 -->💥 Breaking Changes" },
+    { message = "^feat(\\(.+\\))?!?:", group = "<!-- 0 -->✨ New Features" },
+    { message = "^fix(\\(.+\\))?!?:", group = "<!-- 1 -->🐛 Bug Fixes" },
+    { message = "^perf(\\(.+\\))?!?:", group = "<!-- 2 -->⚡ Performance" },
+    { message = "^(build|chore|ci|docs|refactor|style|test)(\\(.+\\))?!?:", skip = true },
+    { message = "^revert(\\(.+\\))?!?:", skip = true },
+]

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,6 +4,7 @@
 # NOTE: pygobject-stubs needs PYGOBJECT_STUB_CONFIG=Gtk3,Gdk3,Soup2
 
 build
+git-cliff >= 2.7, < 3
 lefthook == 2.*
 pygobject-stubs==2.12.0
 pyrefly >= 0.63.0, < 0.64.0


### PR DESCRIPTION
Generate release notes for the draft releases, because the github release notes only includes merged PRs, bot commits pushed directly to main or if there are more than one fix/feat per pr.

Can be tested locally too, with `.venv/bin/git-cliff --latest` or a version range like `v1.2.3..v1.2.4` instead of `--latest`

https://github.com/Ulauncher/Ulauncher/releases/tag/v6.0.0-beta31 was made with this tool + template (but manually).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Generate release notes for draft releases using `git-cliff`, so notes include commit-level changes that GitHub’s auto-notes miss (e.g., bot commits and multiple feat/fix entries). This adds a release notes template and wires it into the CI draft release.

- **New Features**
  - Generate `RELEASE_NOTES.md` in the draft-release workflow with `.venv/bin/git-cliff --current` and attach via `body_path`.
  - Checkout full history (`fetch-depth: 0`) so tags and commits are available to `git-cliff`.
  - Add `cliff.toml` with conventional commit grouping (breaking, feat, fix, perf) and PR link parsing.

- **Dependencies**
  - Add `git-cliff >= 2.7, < 3` to `requirements.txt`.

<sup>Written for commit 61c7e873f81680f67a3746a5158a1b4d077ada85. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

