### PR TITLE
fix(cli): prevent crash if upgrade fails due to local repo url/path error

### DIFF
--- a/ulauncher/modes/extensions/extension_cli_handlers.py
+++ b/ulauncher/modes/extensions/extension_cli_handlers.py
@@ -95,6 +95,17 @@ def uninstall_extension(parser: ArgumentParser, args: Namespace) -> bool:
     return False
 
 
+def _warn_url_error(ext_id: str, url: str) -> None:
+    if url.startswith(("/", "file://")):
+        logger.warning(
+            "Could not upgrade %s: local path '%s' no longer exists. Reinstall with: ulauncher install <new-path>",
+            ext_id,
+            url,
+        )
+    else:
+        logger.warning("Could not upgrade %s: invalid URL '%s'", ext_id, url)
+
+
 def upgrade_extensions(_: ArgumentParser, args: Namespace) -> bool:
     from ulauncher.modes.extensions import extension_registry
 
@@ -103,6 +114,9 @@ def upgrade_extensions(_: ArgumentParser, args: Namespace) -> bool:
         if controller := get_ext_controller(args.input):
             try:
                 asyncio.run(controller.update())
+            except ext_exceptions.UrlError:
+                _warn_url_error(args.input, controller.state.url)
+                return False
             except ext_exceptions.RemoteError:
                 logger.warning("Network error: Could not upgrade %s", args.input)
             dbus_trigger_event("extensions:reload", [controller.id])
@@ -120,6 +134,8 @@ def upgrade_extensions(_: ArgumentParser, args: Namespace) -> bool:
             updated = asyncio.run(controller.update())
             if updated:
                 updated_extensions.append(controller.id)
+        except ext_exceptions.UrlError:
+            _warn_url_error(controller.id, controller.state.url)
         except ext_exceptions.RemoteError:
             logger.warning("Network error: Could not upgrade %s", controller.id)
 

--- a/ulauncher/modes/extensions/extension_cli_handlers.py
+++ b/ulauncher/modes/extensions/extension_cli_handlers.py
@@ -115,7 +115,7 @@ def upgrade_extensions(_: ArgumentParser, args: Namespace) -> bool:
             try:
                 asyncio.run(controller.update())
             except ext_exceptions.UrlError:
-                _warn_url_error(args.input, controller.state.url)
+                _warn_url_error(controller.id, controller.state.url)
                 return False
             except ext_exceptions.RemoteError:
                 logger.warning("Network error: Could not upgrade %s", args.input)


### PR DESCRIPTION
I managed to reproduce this by moving my local dir for an extension I installed from as the git remote.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevent CLI crash when upgrading extensions with an invalid remote URL or a missing local path. Now we show a clear warning, use the normalized extension ID, and suggest reinstalling if the local path moved.

- **Bug Fixes**
  - Catch `UrlError` during single and bulk upgrades to avoid crashing.
  - Added `_warn_url_error` to differentiate missing local paths vs invalid URLs and show a reinstall hint.
  - Warnings now use the normalized extension ID for clarity.
  - Continue with other upgrades when one fails; network errors still log as before.

<sup>Written for commit 4a2bf8addabb7abd1cc459cc54785d85b6a0348b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

