### PR TITLE
fix(cli): upgrade_extensions returned true on RemoteError

### DIFF
--- a/ulauncher/modes/extensions/extension_cli_handlers.py
+++ b/ulauncher/modes/extensions/extension_cli_handlers.py
@@ -119,6 +119,7 @@ def upgrade_extensions(_: ArgumentParser, args: Namespace) -> bool:
                 return False
             except ext_exceptions.RemoteError:
                 logger.warning("Network error: Could not upgrade %s", args.input)
+                return False
             dbus_trigger_event("extensions:reload", [controller.id])
             return True
         logger.error("Error: Argument '%s' does not match any installed extension", args.input)


### PR DESCRIPTION
^

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the CLI `upgrade_extensions` handler to return False when a network `RemoteError` occurs. This prevents reporting success and skips triggering a reload after a failed upgrade.

<sup>Written for commit 4e02d4f0e2ede8e378b8674cf5bb360d4694e82c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

