### PR TITLE
perf(cli): reuse event loop for bulk upgrades

### DIFF
--- a/ulauncher/modes/extensions/extension_cli_handlers.py
+++ b/ulauncher/modes/extensions/extension_cli_handlers.py
@@ -106,9 +106,28 @@ def _warn_url_error(ext_id: str, url: str) -> None:
         logger.warning("Could not upgrade %s: invalid URL '%s'", ext_id, url)
 
 
-def upgrade_extensions(_: ArgumentParser, args: Namespace) -> bool:
+async def _upgrade_all_extensions() -> list[str]:
     from ulauncher.modes.extensions import extension_registry
 
+    updated_extensions: list[str] = []
+
+    for controller in extension_registry.load_all():
+        if not controller.is_manageable or not controller.state.url:
+            continue
+
+        try:
+            updated = await controller.update()
+            if updated:
+                updated_extensions.append(controller.id)
+        except ext_exceptions.UrlError:
+            _warn_url_error(controller.id, controller.state.url)
+        except ext_exceptions.RemoteError:
+            logger.warning("Network error: Could not upgrade %s", controller.id)
+
+    return updated_extensions
+
+
+def upgrade_extensions(_: ArgumentParser, args: Namespace) -> bool:
     if "input" in args and args.input:
         # Upgrade specific extension
         if controller := get_ext_controller(args.input):
@@ -125,21 +144,7 @@ def upgrade_extensions(_: ArgumentParser, args: Namespace) -> bool:
         logger.error("Error: Argument '%s' does not match any installed extension", args.input)
         return False
 
-    updated_extensions: list[str] = []
-
-    for controller in extension_registry.load_all():
-        if not controller.is_manageable or not controller.state.url:
-            continue
-
-        try:
-            updated = asyncio.run(controller.update())
-            if updated:
-                updated_extensions.append(controller.id)
-        except ext_exceptions.UrlError:
-            _warn_url_error(controller.id, controller.state.url)
-        except ext_exceptions.RemoteError:
-            logger.warning("Network error: Could not upgrade %s", controller.id)
-
+    updated_extensions = asyncio.run(_upgrade_all_extensions())
     if updated_extensions:
         dbus_trigger_event("extensions:reload", updated_extensions)
 


### PR DESCRIPTION
I was getting several code review comments about this. I think it's not a big deal, but this change should make it better and the ai bots will complain less.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reuse a single asyncio event loop for bulk CLI extension upgrades to reduce overhead and speed up upgrades. No behavior change; errors still log and we trigger reloads when extensions update.

- **Refactors**
  - Added `_upgrade_all_extensions()` to run all upgrades in one loop.
  - Replaced per-extension `asyncio.run(controller.update())` with a single `asyncio.run(_upgrade_all_extensions())`.

<sup>Written for commit b048ada48015817314d83da22936a566d5873192. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

