### PR TITLE
refactor(log): consistently use logging.getLogger(__name__)

### DIFF
--- a/ulauncher/api/client/Client.py
+++ b/ulauncher/api/client/Client.py
@@ -9,7 +9,7 @@ from ulauncher.api.shared.event import EventType
 from ulauncher.gi import GLib
 from ulauncher.utils.socket_msg_controller import SocketMsgController
 
-logger = logging.getLogger()
+logger = logging.getLogger(__name__)
 
 
 class Client:

--- a/ulauncher/core.py
+++ b/ulauncher/core.py
@@ -16,7 +16,7 @@ from ulauncher.utils.settings import Settings
 from ulauncher.utils.timer import TimerContext, timer
 
 _events = EventBus()
-logger = logging.getLogger()
+logger = logging.getLogger(__name__)
 
 PLACEHOLDER_DELAY = 0.3  # delay in sec before Loading... is rendered
 

--- a/ulauncher/data/_file_cache.py
+++ b/ulauncher/data/_file_cache.py
@@ -6,7 +6,7 @@ from typing import Any, TypeVar, cast
 from ulauncher.utils.json_utils import json_load, json_save
 from ulauncher.utils.lru_cache import lru_cache
 
-logger = logging.getLogger()
+logger = logging.getLogger(__name__)
 FileInstanceT = TypeVar("FileInstanceT")
 _instance_paths: dict[int, str] = {}
 

--- a/ulauncher/internals/effect_utils.py
+++ b/ulauncher/internals/effect_utils.py
@@ -18,7 +18,7 @@ if TYPE_CHECKING:
 
 _VALID_EFFECT_TYPES: Final = frozenset(getattr(EffectType, key) for key in EffectType.__annotations__)
 _events = EventBus()
-_logger = logging.getLogger()
+_logger = logging.getLogger(__name__)
 
 
 def is_valid(effect_msg: Any) -> bool:

--- a/ulauncher/main.py
+++ b/ulauncher/main.py
@@ -54,7 +54,7 @@ def main() -> None:  # noqa: PLR0915
     init_helpers.configure_logging(verbose=cli_args.verbose, use_app_logging=True)
 
     # Logger for actual use in this file
-    logger = logging.getLogger()
+    logger = logging.getLogger(__name__)
 
     # log uncaught exceptions
     def except_hook(exctype: type[BaseException], exception: BaseException, traceback: TracebackType | None) -> None:

--- a/ulauncher/modes/apps/app_mode.py
+++ b/ulauncher/modes/apps/app_mode.py
@@ -14,7 +14,7 @@ from ulauncher.modes.apps.launch_app import launch_app
 from ulauncher.modes.mode import Mode
 from ulauncher.utils.settings import Settings
 
-logger = logging.getLogger()
+logger = logging.getLogger(__name__)
 
 
 class AppMode(Mode):

--- a/ulauncher/modes/apps/app_result.py
+++ b/ulauncher/modes/apps/app_result.py
@@ -8,7 +8,7 @@ from ulauncher.gi import GioUnix
 from ulauncher.internals.result import Result
 from ulauncher.modes.apps.app_rankings import AppRankings
 
-logger = logging.getLogger()
+logger = logging.getLogger(__name__)
 
 
 class AppResult(Result):

--- a/ulauncher/modes/apps/launch_app.py
+++ b/ulauncher/modes/apps/launch_app.py
@@ -10,7 +10,7 @@ from ulauncher.modes.apps.try_raise_app import try_raise_app
 from ulauncher.utils.launch_detached import launch_detached
 from ulauncher.utils.settings import Settings
 
-logger = logging.getLogger()
+logger = logging.getLogger(__name__)
 
 
 def launch_app(desktop_entry_name: str) -> bool:

--- a/ulauncher/modes/apps/try_raise_app.py
+++ b/ulauncher/modes/apps/try_raise_app.py
@@ -4,7 +4,7 @@ import logging
 
 from ulauncher.utils.environment import IS_X11
 
-logger = logging.getLogger()
+logger = logging.getLogger(__name__)
 
 
 def try_raise_app(app_id: str) -> bool:

--- a/ulauncher/modes/calc/calc_mode.py
+++ b/ulauncher/modes/calc/calc_mode.py
@@ -54,7 +54,7 @@ functions: dict[str, Callable[..., float | Decimal]] = {
 }
 
 constants = {"pi": Decimal(math.pi), "e": Decimal(math.e)}
-logger = logging.getLogger()
+logger = logging.getLogger(__name__)
 
 
 # Show a friendlier output for incomplete queries, instead of "Invalid"

--- a/ulauncher/modes/extensions/extension_controller.py
+++ b/ulauncher/modes/extensions/extension_controller.py
@@ -58,7 +58,7 @@ class ExtensionState(JsonConf):
         super().__setitem__(key, value)
 
 
-logger = logging.getLogger()
+logger = logging.getLogger(__name__)
 extension_runtimes: dict[str, ExtensionRuntime] = {}
 stopped_listeners: dict[str, list[Callable[[], None]]] = defaultdict(list)
 

--- a/ulauncher/modes/extensions/extension_dependencies.py
+++ b/ulauncher/modes/extensions/extension_dependencies.py
@@ -7,7 +7,7 @@ from os.path import isdir, isfile
 
 from ulauncher.modes.extensions import ext_exceptions
 
-logger = logging.getLogger()
+logger = logging.getLogger(__name__)
 
 
 class ExtensionDependencies:

--- a/ulauncher/modes/extensions/extension_manifest.py
+++ b/ulauncher/modes/extensions/extension_manifest.py
@@ -8,7 +8,7 @@ from ulauncher.data import BaseDataClass, JsonConf
 from ulauncher.modes.extensions import ext_exceptions
 from ulauncher.utils.version import satisfies
 
-logger = logging.getLogger()
+logger = logging.getLogger(__name__)
 
 
 class ExtensionManifestPreference(BaseDataClass):

--- a/ulauncher/modes/extensions/extension_mode.py
+++ b/ulauncher/modes/extensions/extension_mode.py
@@ -17,7 +17,7 @@ from ulauncher.modes.extensions.extension_controller import ExtensionController
 from ulauncher.modes.mode import Mode
 from ulauncher.utils.eventbus import EventBus
 
-logger = logging.getLogger()
+logger = logging.getLogger(__name__)
 events = EventBus("extensions")
 
 

--- a/ulauncher/modes/extensions/extension_registry.py
+++ b/ulauncher/modes/extensions/extension_registry.py
@@ -9,7 +9,7 @@ from ulauncher.utils.eventbus import EventBus
 
 events = EventBus("extension_lifecycle")
 
-logger = logging.getLogger()
+logger = logging.getLogger(__name__)
 _ext_controllers: dict[str, ExtensionController] = {}
 
 

--- a/ulauncher/modes/extensions/extension_remote.py
+++ b/ulauncher/modes/extensions/extension_remote.py
@@ -21,7 +21,7 @@ from ulauncher.modes.extensions.extension_manifest import ExtensionManifest
 from ulauncher.utils.untar import untar
 from ulauncher.utils.version import satisfies
 
-logger = logging.getLogger()
+logger = logging.getLogger(__name__)
 
 
 class UrlParseResult(BaseDataClass):

--- a/ulauncher/modes/extensions/extension_runtime.py
+++ b/ulauncher/modes/extensions/extension_runtime.py
@@ -17,7 +17,7 @@ ExtensionExitCause = Literal[
     "Stopped", "Terminated", "Exited", "MissingModule", "MissingInternals", "Incompatible", "Invalid"
 ]
 ExitHandlerCallback = Callable[[ExtensionExitCause, str], None]
-logger = logging.getLogger()
+logger = logging.getLogger(__name__)
 events = EventBus()
 
 

--- a/ulauncher/modes/file_browser/file_browser_mode.py
+++ b/ulauncher/modes/file_browser/file_browser_mode.py
@@ -15,7 +15,7 @@ from ulauncher.utils.eventbus import EventBus
 from ulauncher.utils.fold_user_path import fold_user_path
 
 _events = EventBus()
-logger = logging.getLogger()
+logger = logging.getLogger(__name__)
 
 
 class FileBrowserMode(Mode):

--- a/ulauncher/modes/shortcuts/run_script.py
+++ b/ulauncher/modes/shortcuts/run_script.py
@@ -6,7 +6,7 @@ import tempfile
 
 from ulauncher.utils.decorator.run_async import run_async
 
-logger = logging.getLogger()
+logger = logging.getLogger(__name__)
 
 
 @run_async  # must be async because the script may be launching blocking processes like pkexec (issue 1299)

--- a/ulauncher/modes/shortcuts/shortcut_mode.py
+++ b/ulauncher/modes/shortcuts/shortcut_mode.py
@@ -11,7 +11,7 @@ from ulauncher.modes.shortcuts import results
 from ulauncher.modes.shortcuts.run_shortcut import run_shortcut
 from ulauncher.modes.shortcuts.shortcuts import Shortcut, Shortcuts
 
-logger = logging.getLogger()
+logger = logging.getLogger(__name__)
 
 
 def get_description(shortcut: Shortcut, query: Query | None = None) -> str:

--- a/ulauncher/ui/app.py
+++ b/ulauncher/ui/app.py
@@ -19,7 +19,7 @@ from ulauncher.utils.eventbus import EventBus
 from ulauncher.utils.settings import Settings
 from ulauncher.utils.timer import timer
 
-logger = logging.getLogger()
+logger = logging.getLogger(__name__)
 events = EventBus("app")
 
 

--- a/ulauncher/ui/get_icon_path.py
+++ b/ulauncher/ui/get_icon_path.py
@@ -8,7 +8,7 @@ from gi.repository import Gtk
 from ulauncher.gi import GLib
 
 icon_theme = Gtk.IconTheme.get_default()
-logger = logging.getLogger()
+logger = logging.getLogger(__name__)
 
 
 def get_icon_path(icon: str, size: int = 32) -> str | None:

--- a/ulauncher/ui/helpers/hotkey_controller.py
+++ b/ulauncher/ui/helpers/hotkey_controller.py
@@ -11,7 +11,7 @@ from ulauncher.utils.environment import DESKTOP_ID, DESKTOP_NAME
 from ulauncher.utils.launch_detached import launch_detached
 from ulauncher.utils.systemd_controller import SystemdController
 
-logger = logging.getLogger()
+logger = logging.getLogger(__name__)
 launch_command = f"gapplication launch {app_id}"
 
 

--- a/ulauncher/ui/helpers/monitor.py
+++ b/ulauncher/ui/helpers/monitor.py
@@ -6,7 +6,7 @@ from gi.repository import Gdk, GdkX11  # pyrefly: ignore[missing-module-attribut
 
 from ulauncher.gi import Gio
 
-logger = logging.getLogger()
+logger = logging.getLogger(__name__)
 
 
 def get_monitor(use_mouse_position: bool = False) -> Gdk.Monitor | None:

--- a/ulauncher/ui/helpers/theme.py
+++ b/ulauncher/ui/helpers/theme.py
@@ -8,7 +8,7 @@ from pathlib import Path
 from ulauncher import paths
 from ulauncher.data import JsonConf
 
-logger = logging.getLogger()
+logger = logging.getLogger(__name__)
 DEFAULT_THEME = "light"
 CSS_RESET = """
 * {

--- a/ulauncher/ui/helpers/tray_icon.py
+++ b/ulauncher/ui/helpers/tray_icon.py
@@ -17,7 +17,7 @@ from ulauncher.utils.eventbus import EventBus
 from ulauncher.utils.settings import Settings
 
 tray_icon_lib: Literal["AyatanaIndicator", "XApp"] | None = None
-logger = logging.getLogger()
+logger = logging.getLogger(__name__)
 events = EventBus()
 icon_asset_path = f"{paths.ASSETS}/icons/system/status"
 default_icon_name = Settings.tray_icon_name  # intentionally using the class, not the instance, to get the default

--- a/ulauncher/ui/hotkey_dialog.py
+++ b/ulauncher/ui/hotkey_dialog.py
@@ -6,7 +6,7 @@ from typing import Any
 
 from gi.repository import Gdk, Gtk
 
-logger = logging.getLogger()
+logger = logging.getLogger(__name__)
 footer_notice = "Be aware that keyboard shortcuts may be reserved by, or conflict with your system."
 
 RESPONSES = SimpleNamespace(OK=-5, CLOSE=-7)

--- a/ulauncher/ui/load_icon_surface.py
+++ b/ulauncher/ui/load_icon_surface.py
@@ -10,7 +10,7 @@ if TYPE_CHECKING:
     from cairo import ImageSurface  # pyrefly: ignore - this fails in our docker image for some reason
 
 
-logger = logging.getLogger()
+logger = logging.getLogger(__name__)
 
 DEFAULT_EXE_ICON = f"{paths.ASSETS}/icons/executable.png"
 

--- a/ulauncher/ui/preferences/utils/ext_handlers.py
+++ b/ulauncher/ui/preferences/utils/ext_handlers.py
@@ -13,7 +13,7 @@ from ulauncher.modes.extensions import ext_exceptions
 from ulauncher.modes.extensions.extension_controller import ExtensionController
 from ulauncher.ui.preferences.views import DialogLauncher, get_window_for_widget, styled
 
-logger = logging.getLogger()
+logger = logging.getLogger(__name__)
 
 
 class ExtensionHandlers:

--- a/ulauncher/ui/preferences/views/extensions.py
+++ b/ulauncher/ui/preferences/views/extensions.py
@@ -25,7 +25,7 @@ from ulauncher.ui.preferences.views import (
 )
 from ulauncher.utils.launch_detached import open_detached
 
-logger = logging.getLogger()
+logger = logging.getLogger(__name__)
 REFRESH_INTERVAL = 250
 
 

--- a/ulauncher/ui/preferences/views/preferences.py
+++ b/ulauncher/ui/preferences/views/preferences.py
@@ -13,7 +13,7 @@ from ulauncher.utils.eventbus import EventBus
 from ulauncher.utils.settings import Settings
 from ulauncher.utils.systemd_controller import SystemdController
 
-logger = logging.getLogger()
+logger = logging.getLogger(__name__)
 events = EventBus()
 
 

--- a/ulauncher/ui/result_widget.py
+++ b/ulauncher/ui/result_widget.py
@@ -14,7 +14,7 @@ from ulauncher.utils.settings import Settings
 
 ELLIPSIZE_MIN_LENGTH = 6
 ELLIPSIZE_FORCE_AT_LENGTH = 20
-logger = logging.getLogger()
+logger = logging.getLogger(__name__)
 
 
 class ResultWidget(Gtk.EventBox):

--- a/ulauncher/ui/ulauncher_window.py
+++ b/ulauncher/ui/ulauncher_window.py
@@ -18,7 +18,7 @@ from ulauncher.utils.environment import DESKTOP_ID, IS_X11_COMPATIBLE
 from ulauncher.utils.eventbus import EventBus
 from ulauncher.utils.settings import Settings
 
-logger = logging.getLogger()
+logger = logging.getLogger(__name__)
 events = EventBus()
 
 

--- a/ulauncher/utils/environment.py
+++ b/ulauncher/utils/environment.py
@@ -13,7 +13,7 @@ import os
 import pathlib
 from typing import Literal
 
-logger = logging.getLogger()
+logger = logging.getLogger(__name__)
 
 GDK_BACKEND = os.environ.get("GDK_BACKEND", "").upper()
 XDG_SESSION_TYPE = os.environ.get("XDG_SESSION_TYPE", "").upper()

--- a/ulauncher/utils/fuzzy_search.py
+++ b/ulauncher/utils/fuzzy_search.py
@@ -6,7 +6,7 @@ from difflib import Match, SequenceMatcher
 
 from ulauncher.utils.lru_cache import lru_cache
 
-logger = logging.getLogger()
+logger = logging.getLogger(__name__)
 
 
 def _get_matching_blocks_native(query_str: str, text: str) -> list[Match]:

--- a/ulauncher/utils/json_utils.py
+++ b/ulauncher/utils/json_utils.py
@@ -7,7 +7,7 @@ from datetime import datetime
 from pathlib import Path
 from typing import Any
 
-logger = logging.getLogger()
+logger = logging.getLogger(__name__)
 
 
 # remove json nulls

--- a/ulauncher/utils/launch_detached.py
+++ b/ulauncher/utils/launch_detached.py
@@ -7,7 +7,7 @@ import sys
 from ulauncher.gi import GLib
 from ulauncher.utils.systemd_controller import SystemdController
 
-logger = logging.getLogger()
+logger = logging.getLogger(__name__)
 
 
 def detach_child() -> None:

--- a/ulauncher/utils/logging_color_formatter.py
+++ b/ulauncher/utils/logging_color_formatter.py
@@ -27,7 +27,8 @@ class ColoredFormatter(logging.Formatter):
             # Ensure the same name gets the same color every time
             random.seed(record.name)
             name_color = random.randint(32, 37)
-            prefix += f"{mkcolor(name_color, True)} {record.name}{mkcolor(0)}:"
-        suffix = f"{mkcolor(2)}{record.module}.{record.funcName}:{record.lineno}{mkcolor(0)}"  # 2 means faded
+            name = record.name[len("ulauncher.") :] if record.name.startswith("ulauncher.") else record.name
+            prefix += f"{mkcolor(name_color, True)} {name}{mkcolor(0)}:"
+        suffix = f"{mkcolor(2)}{record.funcName}:{record.lineno}{mkcolor(0)}"  # 2 means faded
         formatter = logging.Formatter(f"%(asctime)s {prefix} %(message)s {suffix}")
         return formatter.format(record)

--- a/ulauncher/utils/migrate.py
+++ b/ulauncher/utils/migrate.py
@@ -9,7 +9,7 @@ from typing import Any, Callable
 
 from ulauncher import first_v6_run, paths
 
-_logger = logging.getLogger()
+_logger = logging.getLogger(__name__)
 CACHE_PATH = os.path.join(os.environ.get("XDG_CACHE_HOME", f"{paths.HOME}/.cache"), "ulauncher_cache")  # See issue#40
 
 

--- a/ulauncher/utils/socket_msg_controller.py
+++ b/ulauncher/utils/socket_msg_controller.py
@@ -7,7 +7,7 @@ from typing import Any, Callable
 
 from ulauncher.gi import Gio, GioUnix, GLib
 
-logger = logging.getLogger()
+logger = logging.getLogger(__name__)
 
 
 class SocketMsgController:

--- a/ulauncher/utils/systemd_controller.py
+++ b/ulauncher/utils/systemd_controller.py
@@ -2,7 +2,7 @@ import logging
 import subprocess
 from shutil import which
 
-logger = logging.getLogger()
+logger = logging.getLogger(__name__)
 
 
 def systemctl_run(*args: str) -> str:

--- a/ulauncher/utils/v5_killer.py
+++ b/ulauncher/utils/v5_killer.py
@@ -4,7 +4,7 @@ import signal
 
 from ulauncher import first_v6_run
 
-logger = logging.getLogger()
+logger = logging.getLogger(__name__)
 v5_service_name = "net.launchpad.ulauncher"
 
 


### PR DESCRIPTION
Our old way worked fine, but `logger = logging.getLogger(__name__)` is more standard and it allows filtering by module (`logging.getLogger("ulauncher.modes.extensions").setLevel(logging.DEBUG)`).

And aligning with standards means less noise from review bots

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Standardize logging by using `logging.getLogger(__name__)` everywhere and simplify log output to reduce noise. This enables per‑module log filtering and keeps logs easier to read.

- **Refactors**
  - Replace `logging.getLogger()` with `logging.getLogger(__name__)` across all modules.
  - Update `logging_color_formatter` to strip the `ulauncher.` prefix from logger names and show only `funcName:lineno` in the suffix.
  - Supports per-module filtering, e.g. `logging.getLogger("ulauncher.modes.extensions").setLevel(logging.DEBUG)`.

<sup>Written for commit 5f7588a33cc0e9c166e1263991d4cb3a9e1c5207. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

