### PR TITLE
refactor: move signal handling to the app

### DIFF
--- a/ulauncher/main.py
+++ b/ulauncher/main.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import contextlib
 import logging
-import signal
 import sys
 from types import TracebackType
 
@@ -25,7 +24,6 @@ def main() -> None:  # noqa: PLR0915
 
     init_helpers.init_x11_threads()
 
-    from ulauncher.gi import GLib
     from ulauncher.ui.app import UlauncherApp  # noqa: TID251
     from ulauncher.utils.environment import DESKTOP_ID, DESKTOP_NAME, DISTRO, IS_X11_COMPATIBLE, XDG_SESSION_TYPE
     from ulauncher.utils.migrate import v5_to_v6
@@ -108,12 +106,6 @@ def main() -> None:  # noqa: PLR0915
     v5_to_v6()
 
     app = UlauncherApp()
-
-    def handler() -> bool:
-        app.quit()
-        return False
-
-    GLib.unix_signal_add(priority=GLib.PRIORITY_DEFAULT, signum=signal.SIGTERM, handler=handler)
 
     with contextlib.suppress(KeyboardInterrupt):
         app.run(sys.argv)

--- a/ulauncher/ui/app.py
+++ b/ulauncher/ui/app.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import json
 import logging
+import signal
 from typing import Any, Iterable, Literal, cast
 from weakref import WeakValueDictionary
 
@@ -11,7 +12,7 @@ from gi.repository import Gdk, Gtk
 import ulauncher
 from ulauncher import app_id, first_run
 from ulauncher.cli import get_cli_args
-from ulauncher.gi import Gio
+from ulauncher.gi import Gio, GLib
 from ulauncher.internals.result import Result
 from ulauncher.ui.preferences.preferences_window import PreferencesWindow
 from ulauncher.ui.ulauncher_window import UlauncherWindow
@@ -66,6 +67,11 @@ class UlauncherApp(Gtk.Application):
                 ("trigger-event", lambda *args: self.delegate_custom_message(args[1].get_string()), "s"),
             ],
         )
+        GLib.unix_signal_add(GLib.PRIORITY_DEFAULT, signal.SIGTERM, self._on_sigterm)
+
+    def _on_sigterm(self) -> bool:
+        self.quit()
+        return False
 
     def do_activate(self, *_args: Any, **_kwargs: Any) -> None:
         logger.debug("Activated via gapplication")


### PR DESCRIPTION
This signal handler should only apply to to the primary Gtk app instance (not the remote). do_startup only runs on the primary instance, so this is where the SIGTERM handler belongs



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Move SIGTERM handling into the app so only the primary instance handles termination and remote instances are unaffected. Register the handler in `UlauncherApp.do_startup` via `GLib.unix_signal_add` and remove the old hook from `main.py`.

<sup>Written for commit d1016e220f05d36fd6ae0591c96e35e2e5e081b0. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

