### PR TITLE
refactor: replace Gtk app cli handling with a custom start() helper

### DIFF
--- a/ulauncher/main.py
+++ b/ulauncher/main.py
@@ -108,4 +108,4 @@ def main() -> None:  # noqa: PLR0915
     app = UlauncherApp()
 
     with contextlib.suppress(KeyboardInterrupt):
-        app.run(sys.argv)
+        app.start(activate=not cli_args.daemon)

--- a/ulauncher/ui/app.py
+++ b/ulauncher/ui/app.py
@@ -29,6 +29,8 @@ class UlauncherApp(Gtk.Application):
     # new instances sends the signals to the registered one
     # So all methods except __init__ runs on the main app
     query = ""
+    # One-shot: set to True to make the next activation a no-op (e.g. for --daemon startup).
+    skip_next_activate: bool = False
     # pyrefly: ignore[bad-assignment] https://github.com/facebook/pyrefly/issues/2227
     windows: WeakValueDictionary[Literal["main", "preferences"], Gtk.ApplicationWindow] = WeakValueDictionary()
     _tray_icon: ulauncher.ui.helpers.tray_icon.TrayIcon | None = None  # pyrefly: ignore[implicit-import]
@@ -42,7 +44,7 @@ class UlauncherApp(Gtk.Application):
         return gi.version_info  # type: ignore[attr-defined]
 
     def __init__(self, *args: Any, **kwargs: Any) -> None:
-        kwargs.update(application_id=app_id, flags=Gio.ApplicationFlags.HANDLES_COMMAND_LINE)
+        kwargs.update(application_id=app_id)
         super().__init__(*args, **kwargs)
         events.set_self(self)
         self.connect("startup", lambda *_: self.setup())  # runs only once on the main instance
@@ -74,18 +76,19 @@ class UlauncherApp(Gtk.Application):
         return False
 
     def do_activate(self, *_args: Any, **_kwargs: Any) -> None:
+        if self.skip_next_activate:
+            self.skip_next_activate = False
+            return
         logger.debug("Activated via gapplication")
         self.show_launcher()
 
-    def do_command_line(self, command_line: Gio.ApplicationCommandLine, *_args: Any, **_kwargs: Any) -> int:
-        # command_line is the cli arguments from the process that activated the app
-        # This is unlike get_cli_args(), which is the arguments from the initial call that started ulauncher
-        args = command_line.get_arguments()
-        # --no-window was a temporary name in the v6 beta (never released stable)
-        if "--daemon" not in args and "--no-window" not in args:
-            self.activate()
-
-        return 0
+    def start(self, *, activate: bool = True) -> int:
+        self.register()
+        if self.get_is_remote() and not activate:
+            # Daemon already running in another process; this invocation has nothing to do.
+            return 0
+        self.skip_next_activate = not activate
+        return self.run([])
 
     def setup(self) -> None:
         settings = Settings.load()


### PR DESCRIPTION
Previously we passed the whole CLI just to check the --daemon flag It was confusing and ugly because the CLI had to be handled/parsed twice and the app only cared about thids specfic flag.

Replaced it with a new UlauncherApp.start() method which:

  - Calls register() to determine whether this process is the primary or a remote invocation talking to an already-running primary.
  - Short-circuits when the caller asked for no activation (--daemon) and a primary is already running - the secondary process has nothing to do and exits.
  - Otherwise sets a one-shot skip_next_activate flag and calls run([]), leaving Gtk's default activate-signal forwarding to handle the rest.

do_activate honors the flag and resets it, so the primary suppresses exactly one activation (the one triggered by its own startup) without affecting later activations from remote invocations or D-Bus actions.

With this in place HANDLES_COMMAND_LINE and do_command_line are no longer needed and are removed, and main.py no longer leaks sys.argv into the app layer.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaced the Gtk CLI path with a new `UlauncherApp.start()` to handle `--daemon` and activation cleanly. This removes duplicate argument parsing and stops leaking `sys.argv` into the app layer.

- **Refactors**
  - Added `UlauncherApp.start(activate=True)`: registers the app, exits early for remote + `--daemon`, and uses a one-shot `skip_next_activate` before calling `run([])`.
  - Removed `Gio.ApplicationFlags.HANDLES_COMMAND_LINE` and `do_command_line`; activation now goes through `do_activate`.
  - Updated `main.py` to call `app.start(activate=not cli_args.daemon)`.

<sup>Written for commit 20df759a03525b78d0223935729e69b11fc03f4e. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

