### PR TITLE
fix: various cli fixes

### DIFF
--- a/ulauncher/cli.py
+++ b/ulauncher/cli.py
@@ -30,9 +30,8 @@ def get_cli_args() -> CLIArguments:
     # Python's argparse is very similar to Gtk.Application.add_main_option_entries,
     # but GTK adds in their own options we don't want like --help-gtk --help-gapplication --help-all
     parser = argparse.ArgumentParser(
-        None,
-        "%(prog)s OPTIONS or ARGUMENT",
-        "Ulauncher is a GTK application launcher with support for extensions, shortcuts (scripts), calculator, file browser and custom themes.",  # noqa: E501
+        usage="%(prog)s OPTIONS or ARGUMENT",
+        description="Ulauncher is a GTK application launcher with support for extensions, shortcuts (scripts), calculator, file browser and custom themes.",  # noqa: E501
         add_help=False,
     )
     parser.add_argument("-h", "--help", action="help", help="Show this help message and exit")

--- a/ulauncher/modes/extensions/extension_cli_handlers.py
+++ b/ulauncher/modes/extensions/extension_cli_handlers.py
@@ -132,14 +132,15 @@ def upgrade_extensions(_: ArgumentParser, args: Namespace) -> bool:
         # Upgrade specific extension
         if controller := get_ext_controller(args.input):
             try:
-                asyncio.run(controller.update())
+                updated = asyncio.run(controller.update())
             except ext_exceptions.UrlError:
                 _warn_url_error(controller.id, controller.state.url)
                 return False
             except (ext_exceptions.NetworkError, ext_exceptions.RemoteError):
                 logger.warning("Network error: Could not upgrade %s", args.input)
                 return False
-            dbus_trigger_event("extensions:reload", [controller.id])
+            if updated:
+                dbus_trigger_event("extensions:reload", [controller.id])
             return True
         logger.error("Error: Argument '%s' does not match any installed extension", args.input)
         return False

--- a/ulauncher/modes/extensions/extension_cli_handlers.py
+++ b/ulauncher/modes/extensions/extension_cli_handlers.py
@@ -236,13 +236,13 @@ def preview_extension(_: ArgumentParser, args: Namespace) -> bool:  # noqa: PLR0
             .decode()
             .strip()
         )
-
-        if git_url:
-            url_to_parse = git_url
-            logger.debug("Found git remote URL: %s", git_url)
     except (subprocess.CalledProcessError, FileNotFoundError):
         # Not a git repository or git not available, use path as is
         logger.debug("No git remote found, using path as URL input")
+    else:
+        if git_url:
+            url_to_parse = git_url
+            logger.debug("Found git remote URL: %s", git_url)
 
     # Parse the URL/path to get extension ID
     try:

--- a/ulauncher/modes/extensions/extension_cli_handlers.py
+++ b/ulauncher/modes/extensions/extension_cli_handlers.py
@@ -74,7 +74,7 @@ def install_extension(parser: ArgumentParser, args: Namespace) -> bool:
         dbus_trigger_event("extensions:reload", [controller.id])
     except (ValueError, ext_exceptions.UrlError):  # error already logged
         return False
-    except ext_exceptions.RemoteError:
+    except (ext_exceptions.NetworkError, ext_exceptions.RemoteError):
         logger.warning("Network error: Could not install %s", args.input)
         return False
     return True
@@ -121,7 +121,7 @@ async def _upgrade_all_extensions() -> list[str]:
                 updated_extensions.append(controller.id)
         except ext_exceptions.UrlError:
             _warn_url_error(controller.id, controller.state.url)
-        except ext_exceptions.RemoteError:
+        except (ext_exceptions.NetworkError, ext_exceptions.RemoteError):
             logger.warning("Network error: Could not upgrade %s", controller.id)
 
     return updated_extensions
@@ -136,7 +136,7 @@ def upgrade_extensions(_: ArgumentParser, args: Namespace) -> bool:
             except ext_exceptions.UrlError:
                 _warn_url_error(controller.id, controller.state.url)
                 return False
-            except ext_exceptions.RemoteError:
+            except (ext_exceptions.NetworkError, ext_exceptions.RemoteError):
                 logger.warning("Network error: Could not upgrade %s", args.input)
                 return False
             dbus_trigger_event("extensions:reload", [controller.id])


### PR DESCRIPTION
This addresses most of the complaints from #1713 (the bots keep complaining about pre-existing issues when moving code).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes CLI help and improves extension commands. Handles network errors correctly and skips unnecessary reloads after upgrades.

- **Bug Fixes**
  - Set argparse `usage` and `description` via keywords for correct help output.
  - Catch `NetworkError` alongside `RemoteError` in install/upgrade and log a clear warning.
  - In preview, only use the git remote URL when found; otherwise keep the provided path.

- **Performance**
  - Trigger `extensions:reload` only if an extension actually updated.

<sup>Written for commit a783bc918dbcfbd5830d534d781b07c6031bce75. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

