### PR TITLE
refactor(cli): simplify CLIArguments public interface

### DIFF
--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,65 @@
+import pytest
+from pytest_mock import MockerFixture
+
+from ulauncher import cli
+
+
+class TestCLI:
+    def test_parse_empty_args_defaults(self, capsys: pytest.CaptureFixture[str]) -> None:
+        args = cli.parse([])
+
+        assert args.daemon is False
+        assert args.verbose is False
+        assert args.command is None
+        assert capsys.readouterr().out == ""
+
+    def test_parse_no_window_maps_to_daemon(self, capsys: pytest.CaptureFixture[str]) -> None:
+        args = cli.parse(["--no-window"])
+
+        assert args.daemon is True
+        assert not hasattr(args, "no_window")
+        assert "use --daemon" in capsys.readouterr().err
+
+    def test_parse_dev_maps_to_verbose(self, capsys: pytest.CaptureFixture[str]) -> None:
+        args = cli.parse(["--dev"])
+
+        assert args.verbose is True
+        assert not hasattr(args, "dev")
+        assert "use --verbose" in capsys.readouterr().err
+
+    def test_parse_hide_window_exits(self, capsys: pytest.CaptureFixture[str]) -> None:
+        with pytest.raises(SystemExit) as exc_info:
+            cli.parse(["--hide-window"])
+        assert exc_info.value.code == 2
+        assert "use --daemon" in capsys.readouterr().err
+
+    def test_parse_no_extensions_exits(self, capsys: pytest.CaptureFixture[str]) -> None:
+        with pytest.raises(SystemExit) as exc_info:
+            cli.parse(["--no-extensions"])
+        assert exc_info.value.code == 2
+        assert "use --help to list available commands" in capsys.readouterr().err
+
+    def test_parse_no_window_shadow_exits(self) -> None:
+        with pytest.raises(SystemExit) as exc_info:
+            cli.parse(["--no-window-shadow"])
+        assert exc_info.value.code == 2
+
+    def test_parse_upgrade_normalizes_alias(self, capsys: pytest.CaptureFixture[str]) -> None:
+        args = cli.parse(["up"])
+
+        assert args.command == "upgrade"
+        assert capsys.readouterr().out == ""
+
+    def test_run_command_dispatches_default_app_handler(self, mocker: MockerFixture) -> None:
+        ensure_runtime_dirs = mocker.patch("ulauncher.cli.ensure_runtime_dirs")
+        mocker.patch("ulauncher.cli.configure_logging")
+        handler = mocker.Mock(return_value=True)
+        load_handler = mocker.patch("ulauncher.cli._load_handler", return_value=handler)
+
+        args = cli.parse([])
+
+        assert cli.run_command(args) is True
+
+        ensure_runtime_dirs.assert_called_once_with()
+        load_handler.assert_called_once_with("ulauncher.cli.commands.app:run")
+        handler.assert_called_once_with(args)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -37,7 +37,7 @@ class TestCLI:
         with pytest.raises(SystemExit) as exc_info:
             cli.parse(["--no-extensions"])
         assert exc_info.value.code == 2
-        assert "use --help to list available commands" in capsys.readouterr().err
+        assert "see --help for available commands" in capsys.readouterr().err
 
     def test_parse_no_window_shadow_exits(self) -> None:
         with pytest.raises(SystemExit) as exc_info:

--- a/ulauncher/cli/__init__.py
+++ b/ulauncher/cli/__init__.py
@@ -13,18 +13,13 @@ from ulauncher.utils.lru_cache import lru_cache
 CommandName = Literal["extensions", "install", "uninstall", "upgrade", "preview"]
 
 
-class CLIArguments(argparse.Namespace):
-    daemon: bool
-    dev: bool  # deprecated
-    verbose: bool
-    hide_window: bool  # deprecated
-    no_extensions: bool  # deprecated
-    no_window: bool  # deprecated unreleased alias for hide_window (made more sense semantically)
-    no_window_shadow: bool  # deprecated
-    input: str
-    path: str
-    with_debugger: bool
-    command: CommandName | None
+class CLIArguments(BaseDataClass):
+    daemon = False
+    verbose = False
+    input = ""
+    path = ""
+    with_debugger = False
+    command: CommandName | None = None
 
 
 CLICommandHandler = Callable[[CLIArguments], int]
@@ -132,9 +127,6 @@ def _get_parser() -> argparse.ArgumentParser:
     parser.add_argument("--no-window", action="store_true", help=argparse.SUPPRESS)
     parser.add_argument("--no-window-shadow", action="store_true", help=argparse.SUPPRESS)
 
-    # Ensure subcommand-specific attrs are always present on the namespace
-    parser.set_defaults(input="", path="", with_debugger=False)
-
     subparsers = parser.add_subparsers(
         title="commands",
         description="Available commands",
@@ -179,4 +171,28 @@ def parse(input_args: list[str]) -> CLIArguments:
     # Python's argparse is very similar to Gtk.Application.add_main_option_entries,
     # but GTK adds in their own options we don't want like --help-gtk --help-gapplication --help-all
     parser = _get_parser()
-    return parser.parse_args(args=input_args, namespace=CLIArguments())
+
+    args = parser.parse_args(args=input_args)
+    namespace = vars(args)
+
+    legacy_args: dict[str, tuple[str | None, str | None]] = {
+        "dev": ("verbose", "--verbose"),
+        "no_window": ("daemon", "--daemon"),
+        # intentionally break hide_window to prevent legacy XDG autostart entries from starting
+        "hide_window": (None, "--daemon"),
+        "no_extensions": (None, "--help to list available commands"),
+        "no_window_shadow": (None, "the Window shadow size setting"),
+    }
+
+    for legacy_arg, (shim, subst) in legacy_args.items():
+        if namespace.pop(legacy_arg, False):
+            msg = f"The --{legacy_arg.replace('_', '-')} argument has been removed"
+            if subst:
+                msg += f" (use {subst})"
+            sys.stderr.write(f"\033[33m{msg}\033[0m\n")
+            if shim:
+                namespace[shim] = True
+            else:
+                sys.exit(2)
+
+    return CLIArguments(**namespace)

--- a/ulauncher/cli/__init__.py
+++ b/ulauncher/cli/__init__.py
@@ -187,7 +187,9 @@ def parse(input_args: list[str]) -> CLIArguments:
     for legacy_arg, (shim, hint) in legacy_args.items():
         if namespace.pop(legacy_arg, False):
             msg = f"The --{legacy_arg.replace('_', '-')} argument has been removed ({hint})"
-            sys.stderr.write(f"\033[33m{msg}\033[0m\n")
+            if sys.stderr.isatty():
+                msg = f"\033[33m{msg}\033[0m"
+            sys.stderr.write(f"{msg}\n")
             if shim:
                 namespace[shim] = True
             else:

--- a/ulauncher/cli/__init__.py
+++ b/ulauncher/cli/__init__.py
@@ -175,20 +175,18 @@ def parse(input_args: list[str]) -> CLIArguments:
     args = parser.parse_args(args=input_args)
     namespace = vars(args)
 
-    legacy_args: dict[str, tuple[str | None, str | None]] = {
-        "dev": ("verbose", "--verbose"),
-        "no_window": ("daemon", "--daemon"),
+    legacy_args: dict[str, tuple[str | None, str]] = {
+        "dev": ("verbose", "use --verbose"),
+        "no_window": ("daemon", "use --daemon"),
         # intentionally break hide_window to prevent legacy XDG autostart entries from starting
-        "hide_window": (None, "--daemon"),
-        "no_extensions": (None, "--help to list available commands"),
-        "no_window_shadow": (None, "the Window shadow size setting"),
+        "hide_window": (None, "use --daemon"),
+        "no_extensions": (None, "see --help for available commands"),
+        "no_window_shadow": (None, "configure via the Window shadow size setting in preferences"),
     }
 
-    for legacy_arg, (shim, subst) in legacy_args.items():
+    for legacy_arg, (shim, hint) in legacy_args.items():
         if namespace.pop(legacy_arg, False):
-            msg = f"The --{legacy_arg.replace('_', '-')} argument has been removed"
-            if subst:
-                msg += f" (use {subst})"
+            msg = f"The --{legacy_arg.replace('_', '-')} argument has been removed ({hint})"
             sys.stderr.write(f"\033[33m{msg}\033[0m\n")
             if shim:
                 namespace[shim] = True

--- a/ulauncher/cli/__init__.py
+++ b/ulauncher/cli/__init__.py
@@ -10,6 +10,15 @@ from ulauncher.data import BaseDataClass
 from ulauncher.init_helpers import configure_logging, ensure_runtime_dirs
 from ulauncher.utils.lru_cache import lru_cache
 
+_LEGACY_ARGS: dict[str, tuple[str | None, str]] = {
+    "dev": ("verbose", "use --verbose"),
+    "no_window": ("daemon", "use --daemon"),
+    # intentionally break hide_window to prevent legacy XDG autostart entries from starting
+    "hide_window": (None, "use --daemon"),
+    "no_extensions": (None, "see --help for available commands"),
+    "no_window_shadow": (None, "configure via the Window shadow size setting in preferences"),
+}
+
 CommandName = Literal["extensions", "install", "uninstall", "upgrade", "preview"]
 
 
@@ -175,16 +184,7 @@ def parse(input_args: list[str]) -> CLIArguments:
     args = parser.parse_args(args=input_args)
     namespace = vars(args)
 
-    legacy_args: dict[str, tuple[str | None, str]] = {
-        "dev": ("verbose", "use --verbose"),
-        "no_window": ("daemon", "use --daemon"),
-        # intentionally break hide_window to prevent legacy XDG autostart entries from starting
-        "hide_window": (None, "use --daemon"),
-        "no_extensions": (None, "see --help for available commands"),
-        "no_window_shadow": (None, "configure via the Window shadow size setting in preferences"),
-    }
-
-    for legacy_arg, (shim, hint) in legacy_args.items():
+    for legacy_arg, (shim, hint) in _LEGACY_ARGS.items():
         if namespace.pop(legacy_arg, False):
             msg = f"The --{legacy_arg.replace('_', '-')} argument has been removed ({hint})"
             if sys.stderr.isatty():

--- a/ulauncher/cli/commands/app.py
+++ b/ulauncher/cli/commands/app.py
@@ -26,21 +26,6 @@ def run(cli_args: CLIArguments) -> int:
         print("Ulauncher requires GTK+ version 3.22 or newer. Please upgrade your GTK version.")  # noqa: T201
         return 1
 
-    if cli_args.hide_window:
-        # Ulauncher's "Launch at Login" is now implemented with systemd, but originally
-        # it was implemented using XDG autostart. To prevent files created the old way
-        # from starting a second Ulauncher background process we have to make sure the
-        # --daemon flag prevents the app from starting.
-        print("The --hide-window argument has been renamed to --daemon")  # noqa: T201
-        return 2
-    if cli_args.no_window:
-        # --hide-window was renamed to --no-window for a while in v6 beta (never released)
-        print("The --no-window argument has been renamed to --daemon")  # noqa: T201
-        return 2
-    if cli_args.dev:
-        print("The --dev argument has been removed (use --verbose instead)")  # noqa: T201
-        return 2
-
     logger = logging.getLogger(__name__)
 
     def except_hook(exctype: type[BaseException], exception: BaseException, traceback: TracebackType | None) -> None:
@@ -64,10 +49,6 @@ def run(cli_args: CLIArguments) -> int:
     logger.info("Extension API version %s", api_version)
     logger.info("GTK+ %s.%s.%s", *gtk_version)
     logger.info("PyGObject+ %i.%i.%i", *UlauncherApp.get_pygobject_version())
-    if cli_args.no_extensions:
-        logger.warning("The --no-extensions argument has been removed in Ulauncher v6")
-    if cli_args.no_window_shadow:
-        logger.warning("The --no-window-shadow argument has been removed in Ulauncher v6")
 
     if XDG_SESSION_TYPE != "X11":
         from ulauncher.ui.helpers import layer_shell  # noqa: TID251


### PR DESCRIPTION
CLIArguments used to be a representation of the exact input arguments given. This meant that legacy flags couldn't be normalized, so for example if you wanted to check `--daemon` you also had to check the legacy flag `--no-window`.

This changes CLIArguments from an argparse.Namespace, to a BaseDataClass, so that we can normalize the public interface, removing the legacy flags.

Additionally, this also takes ownership of the legacy flag warnings and adds a more declarative way to define these to show better help messages.

The behavior for what is a fatal vs non-fatal error for legacy flags now depends on what we can shim. If a deprecated argument maps 1:1 to a new argument we activate that instead, while also showing a warning.

For flags we cannot support, we add a clear error message and exit instead of silently ignoring.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Simplifies the CLI by converting `CLIArguments` to a dataclass and centralizing legacy flag handling in `parse()`. Deprecations print clear hints (TTY-colored when appropriate), and command aliases are normalized.

- **Refactors**
  - Replaced `argparse.Namespace` with `CLIArguments` dataclass and defaults.
  - Centralized legacy flags in a table with shims and full hints; warnings go to stderr and use color only if stderr is a TTY.
  - Normalized in `parse()`:
    - `--dev` → `--verbose` (warn)
    - `--no-window` → `--daemon` (warn)
    - `--hide-window`, `--no-extensions`, `--no-window-shadow` exit 2 with guidance.
  - Normalized alias `up` → `upgrade`; removed legacy checks from the `app` handler; added tests for defaults, mappings, alias, errors, and command dispatch.

<sup>Written for commit dd66db3a5e0c480519ae35ae1fe2b2eb36897140. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

