### PR TITLE
perf(cli): replace busy-wait with sigwait in preview

### DIFF
--- a/ulauncher/cli/commands/preview.py
+++ b/ulauncher/cli/commands/preview.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 import logging
 import signal
 import subprocess
-import time
 from pathlib import Path
 from typing import TYPE_CHECKING
 
@@ -117,17 +116,12 @@ def run(args: CLIArguments) -> int:  # noqa: PLR0911, PLR0912, PLR0915 - intenti
         )
 
     preview_ext_id = f"{ext_id}.preview"
-    interrupted = False
 
-    def signal_handler(_sig: int, _frame: object) -> None:
-        nonlocal interrupted
-        interrupted = True
-
-    signal.signal(signal.SIGINT, signal_handler)
-
+    # Block SIGINT so sigwait() can accept it atomically without the default
+    # KeyboardInterrupt or a pause()-style missed-signal race.
+    signal.pthread_sigmask(signal.SIG_BLOCK, [signal.SIGINT])
     logger.info("Press Ctrl+C to stop previewing extension '%s'...", ext_id)
-    while not interrupted:
-        time.sleep(0.1)
+    signal.sigwait([signal.SIGINT])
 
     logger.info("Stopping '%s'...", ext_id)
     dbus_trigger_event("extensions:stop_preview", {"preview_ext_id": preview_ext_id, "original_ext_id": ext_id})

--- a/ulauncher/cli/commands/preview.py
+++ b/ulauncher/cli/commands/preview.py
@@ -117,8 +117,8 @@ def run(args: CLIArguments) -> int:  # noqa: PLR0911, PLR0912, PLR0915 - intenti
 
     preview_ext_id = f"{ext_id}.preview"
 
-    # Block SIGINT so sigwait() can accept it atomically without the default
-    # KeyboardInterrupt or a pause()-style missed-signal race.
+    # Block SIGINT so sigwait() can dequeue it atomically without racing
+    # with Python's default KeyboardInterrupt handler.
     signal.pthread_sigmask(signal.SIG_BLOCK, [signal.SIGINT])
     logger.info("Press Ctrl+C to stop previewing extension '%s'...", ext_id)
     signal.sigwait([signal.SIGINT])


### PR DESCRIPTION
Replaces a 100ms polling loop that watched a nonlocal interrupted flag with pthread_sigmask + sigwait. SIGINT is blocked before the wait so it cannot be lost; sigwait then atomically dequeues the pending signal (or sleeps until one arrives).

No Python-level SIGINT handler is needed: the signal never reaches Python's default handler while blocked, so KeyboardInterrupt cannot fire. This is the textbook race-free idiom — strictly better than the busy-wait (no 100ms wakeups, no CPU/power cost) and avoids missed-signal window between handler registration and the wait that would happen with signal.pause() (which was the first implementation).

This PR was fully AI driven. Starting with a [code review bot comment](https://github.com/Ulauncher/Ulauncher/pull/1713#discussion_r3230440433). The commit and comment above are fully AI generated and not tested by me. I do think this is working and an improvement, but it's not top prio and I'm not in a hurry to get it merged, but I keep forgetting how to debug after every time I re-learn it for testing so I'll just put this on hold until then unless @gornostal wants to test it.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replace the 100ms busy-wait in the CLI preview command with `signal.pthread_sigmask` + `signal.sigwait` for atomic Ctrl+C handling. Blocks `SIGINT` to avoid `KeyboardInterrupt`, removes periodic wakeups, lowers CPU/power, exits cleanly; also cleans up comments to remove references to the prior `signal.pause()` attempt.

<sup>Written for commit 74e23972a09272a6e9901ac9f09c9a9d813c3d66. Summary will update on new commits. <a href="https://cubic.dev/pr/Ulauncher/Ulauncher/pull/1720?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->



