### PR TITLE
feat: rename `daemonless` to (not) `keep_alive` and make it apply only for non systemd users

### DIFF
--- a/ulauncher/ui/app.py
+++ b/ulauncher/ui/app.py
@@ -92,7 +92,12 @@ class UlauncherApp(Gtk.Application):
     def setup(self) -> None:
         settings = Settings.load()
         cli_args = cli.get_args()
-        if settings.keep_alive or cli_args.daemon:
+        # On systemd systems, the unit's enabled state is the source of truth for "should this
+        # run as a service" - keep_alive only applies as a fallback for users without systemd.
+        from ulauncher.utils.systemd_controller import SystemdController
+
+        is_persistent = cli_args.daemon or (settings.keep_alive and not SystemdController("ulauncher").supported)
+        if is_persistent:
             # Keep the app running even without a window
             self.hold()
 

--- a/ulauncher/ui/app.py
+++ b/ulauncher/ui/app.py
@@ -92,7 +92,7 @@ class UlauncherApp(Gtk.Application):
     def setup(self) -> None:
         settings = Settings.load()
         cli_args = cli.get_args()
-        if not settings.daemonless or cli_args.daemon:
+        if settings.keep_alive or cli_args.daemon:
             # Keep the app running even without a window
             self.hold()
 

--- a/ulauncher/ui/preferences/views/preferences.py
+++ b/ulauncher/ui/preferences/views/preferences.py
@@ -106,6 +106,7 @@ class PreferencesView(BaseView):
                 wrap=True,
                 max_width_chars=70,
                 margin_top=2,
+                use_markup=True,
             ),
             "preferences-setting-description",
         )
@@ -134,23 +135,19 @@ class PreferencesView(BaseView):
     def _add_general_section(self, parent: Gtk.Box) -> None:
         """Add general settings section"""
         general_box = self._create_section_container(parent, "General")
+        background_recommendation = "\n<b>Recommended:</b> Enabling this will make Ulauncher open noticeably faster."
 
-        # Launch at login
+        # Launch at login / Keep running in background
         if self.autostart_pref.can_start():
             autostart_switch = Gtk.Switch(active=self.autostart_pref.is_enabled())
             autostart_switch.connect("notify::active", self._on_autostart_toggled)
-
-            desc = "Start Ulauncher automatically whenever your desktop session begins."
-            if not self.settings.keep_alive:
-                desc += " Enabling this will turn off Daemonless mode."
+            desc = f"Start Ulauncher in the background when your desktop session starts. {background_recommendation}"
             self._add_setting_row(general_box, "Launch at login", autostart_switch, desc)
         else:
-            warning_text = (
-                "Automatic startup via systemd is not available on your system. "
-                "To start Ulauncher at login, add it to your desktop environment's autostart settings."
-            )
-            unavailable_label = Gtk.Label(label="Not available", sensitive=False)
-            self._add_setting_row(general_box, "Launch at login", unavailable_label, warning_text, is_warning=True)
+            keep_alive_switch = Gtk.Switch(active=self.settings.keep_alive)
+            keep_alive_switch.connect("notify::active", self._on_keep_alive_toggled)
+            desc = f"Keep Ulauncher running in the background. {background_recommendation}"
+            self._add_setting_row(general_box, "Keep running in background", keep_alive_switch, desc)
 
         # Hotkey
         if HotkeyController.is_supported():
@@ -269,15 +266,6 @@ class PreferencesView(BaseView):
         )
         self._add_setting_row(advanced_box, "Enable Layer Shell", layer_switch, desc)
 
-        # Daemonless mode
-        daemonless_switch = Gtk.Switch(active=not self.settings.keep_alive)
-        daemonless_switch.connect("notify::active", self._on_daemonless_toggled)
-        desc = (
-            "Only run Ulauncher on demand without a background daemon. Startup may be slower and quick launch "
-            "features like auto-start are disabled."
-        )
-        self._add_setting_row(advanced_box, "Daemonless mode", daemonless_switch, desc)
-
         # Jump keys
         jump_entry = Gtk.Entry(text=self.settings.jump_keys, width_chars=50)
         jump_entry.connect("changed", self._on_jump_keys_changed)
@@ -297,8 +285,6 @@ class PreferencesView(BaseView):
         is_enabled = switch.get_active()
         try:
             self.autostart_pref.toggle(is_enabled)
-            if is_enabled and not self.settings.keep_alive:
-                self.settings.save({"keep_alive": True})
         except OSError:
             logger.exception("Failed to toggle autostart")
             switch.set_active(not is_enabled)
@@ -356,12 +342,10 @@ class PreferencesView(BaseView):
     def _on_filters_toggled(self, switch: Gtk.Switch, _: Any) -> None:
         self.settings.save({"disable_desktop_filters": switch.get_active()})
 
-    def _on_daemonless_toggled(self, switch: Gtk.Switch, _: Any) -> None:
+    def _on_keep_alive_toggled(self, switch: Gtk.Switch, _: Any) -> None:
         is_enabled = switch.get_active()
-        self.settings.save({"keep_alive": not is_enabled})
-        events.emit("app:toggle_hold", not is_enabled)
-        if is_enabled:
-            SystemdController("ulauncher").stop()
+        self.settings.save({"keep_alive": is_enabled})
+        events.emit("app:toggle_hold", is_enabled)
 
     def _on_jump_keys_changed(self, entry: Gtk.Entry) -> None:
         self.settings.save({"jump_keys": entry.get_text()})

--- a/ulauncher/ui/preferences/views/preferences.py
+++ b/ulauncher/ui/preferences/views/preferences.py
@@ -141,7 +141,7 @@ class PreferencesView(BaseView):
             autostart_switch.connect("notify::active", self._on_autostart_toggled)
 
             desc = "Start Ulauncher automatically whenever your desktop session begins."
-            if self.settings.daemonless:
+            if not self.settings.keep_alive:
                 desc += " Enabling this will turn off Daemonless mode."
             self._add_setting_row(general_box, "Launch at login", autostart_switch, desc)
         else:
@@ -270,7 +270,7 @@ class PreferencesView(BaseView):
         self._add_setting_row(advanced_box, "Enable Layer Shell", layer_switch, desc)
 
         # Daemonless mode
-        daemonless_switch = Gtk.Switch(active=self.settings.daemonless)
+        daemonless_switch = Gtk.Switch(active=not self.settings.keep_alive)
         daemonless_switch.connect("notify::active", self._on_daemonless_toggled)
         desc = (
             "Only run Ulauncher on demand without a background daemon. Startup may be slower and quick launch "
@@ -297,8 +297,8 @@ class PreferencesView(BaseView):
         is_enabled = switch.get_active()
         try:
             self.autostart_pref.toggle(is_enabled)
-            if is_enabled and self.settings.daemonless:
-                self.settings.save({"daemonless": False})
+            if is_enabled and not self.settings.keep_alive:
+                self.settings.save({"keep_alive": True})
         except OSError:
             logger.exception("Failed to toggle autostart")
             switch.set_active(not is_enabled)
@@ -358,7 +358,7 @@ class PreferencesView(BaseView):
 
     def _on_daemonless_toggled(self, switch: Gtk.Switch, _: Any) -> None:
         is_enabled = switch.get_active()
-        self.settings.save({"daemonless": is_enabled})
+        self.settings.save({"keep_alive": not is_enabled})
         events.emit("app:toggle_hold", not is_enabled)
         if is_enabled:
             SystemdController("ulauncher").stop()

--- a/ulauncher/utils/settings.py
+++ b/ulauncher/utils/settings.py
@@ -13,12 +13,12 @@ class Settings(JsonConf):
     base_width = 750
     clear_previous_query = True
     close_on_focus_out = True
-    daemonless = False
     disable_desktop_filters = False
     enable_application_mode = True
     grab_mouse_pointer = False
     hotkey_show_app = ""  # Note that this is no longer used, other than for migrating to the DE wrapper
     jump_keys = "1234567890abcdefghijklmnopqrstuvwxyz"
+    keep_alive = True
     layer_shell = True
     max_recent_apps = 0
     raise_if_started = False
@@ -31,9 +31,13 @@ class Settings(JsonConf):
 
     # Convert dash to underscore
     def __setitem__(self, key: str, value: Any) -> None:  # type: ignore[override]
-        if key.replace("-", "_") == "show_indicator_icon":
-            key = "show_tray_icon"
-        super().__setitem__(key.replace("-", "_"), value)
+        normalized = key.replace("-", "_")
+        if normalized == "show_indicator_icon":
+            normalized = "show_tray_icon"
+        elif normalized == "daemonless":
+            normalized = "keep_alive"
+            value = not value
+        super().__setitem__(normalized, value)
 
     def get_jump_keys(self) -> list[str]:
         # convert to list and filter out duplicates


### PR DESCRIPTION
`daemonless` has been a bit of an experiment, which we still don't want to recommend, but it's probably more controversial to always run as a service and never offer an alternative.

This setting was previously a separate, but mutually exclusive setting for the autostart setting.

This PR changes the setting work in the opposite way `keep_alive`, but only if systemd is not available.

If systemd is available, systemd becomes the single source of truth for this setting. If you enabled it, then it runs via systemd.

If systemd is not available, the new `keep_alive` setting determines if we should keep the app running. Then the first run would "become" the daemon.

In both cases, disabling this setting runs it "daemonless". I made the recommendation to not disable (this will show on both):

<img width="1482" height="278" alt="image" src="https://github.com/user-attachments/assets/270e92de-47a4-4358-83e7-7f2edb544714" />


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Renamed the `daemonless` setting to `keep_alive` and made it apply only when systemd isn’t available. On systemd systems, the systemd unit’s enabled state now solely controls background behavior.

- New Features
  - On systemd, autostart via systemd is the source of truth; `keep_alive` is ignored.
  - On non-systemd, `keep_alive` (default true) controls whether Ulauncher stays running; the first run becomes the background process.
  - Preferences: show “Launch at login” when systemd is available; otherwise show “Keep running in background.” Removed the “Daemonless mode” toggle. Added a short note explaining the faster startup benefit.
  - Startup: the app holds only when `--daemon` is passed or `keep_alive` is true and systemd is unavailable.

- Migration
  - Existing `daemonless` is auto-migrated to `keep_alive` with inverted semantics. No action needed.

<sup>Written for commit 1770ebf9c5908d9f8f041563991c8cc7574d3d56. Summary will update on new commits. <a href="https://cubic.dev/pr/Ulauncher/Ulauncher/pull/1721?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

