### PR TITLE
fix: respect keep alive setting

### DIFF
--- a/ulauncher/ui/app.py
+++ b/ulauncher/ui/app.py
@@ -240,7 +240,8 @@ class UlauncherApp(Gtk.Application):
             from ulauncher.ui.helpers.tray_icon import TrayIcon
 
             self._tray_icon = TrayIcon()
-        self._tray_icon.switch(enable)
+        # A tray icon is only meaningful while the app keeps running in the background.
+        self._tray_icon.switch(enable and self._persistent)
 
     @events.on
     def toggle_hold(self, value: bool) -> None:
@@ -248,6 +249,7 @@ class UlauncherApp(Gtk.Application):
         if value != self._persistent:
             self._persistent = value
             self.hold() if value else self.release()
+            self.toggle_tray_icon(Settings.load().show_tray_icon)
 
     @events.on
     def quit(self) -> None:  # pyrefly: ignore[bad-override]

--- a/ulauncher/ui/app.py
+++ b/ulauncher/ui/app.py
@@ -96,10 +96,14 @@ class UlauncherApp(Gtk.Application):
         from ulauncher.utils.systemd_controller import SystemdController
 
         settings = Settings.load()
+        # Always hold on app start (conditionally release after closing window)
         self.hold()
         # On systemd the unit's enabled state wins; keep_alive is the non-systemd fallback.
         controller = SystemdController("ulauncher")
         self._persistent = controller.is_enabled() or (settings.keep_alive and not controller.supported)
+        if self._persistent:
+            # Sync additional hold with user settings
+            self.hold()
 
         if settings.show_tray_icon and self._persistent:
             self.toggle_tray_icon(True)

--- a/ulauncher/ui/app.py
+++ b/ulauncher/ui/app.py
@@ -10,7 +10,7 @@ import gi
 from gi.repository import Gdk, Gtk
 
 import ulauncher
-from ulauncher import app_id, cli, first_run
+from ulauncher import app_id, first_run
 from ulauncher.gi import Gio, GLib
 from ulauncher.internals.result import Result
 from ulauncher.ui.preferences.preferences_window import PreferencesWindow
@@ -30,6 +30,9 @@ class UlauncherApp(Gtk.Application):
     query = ""
     # One-shot: set to True to make the next activation a no-op (e.g. for --daemon startup).
     skip_next_activate: bool = False
+    # Whether the app should keep running with no windows open. Set in setup() from the
+    # systemd unit state (or keep_alive fallback) and kept in sync by toggle_hold().
+    _persistent: bool = False
     # pyrefly: ignore[bad-assignment] https://github.com/facebook/pyrefly/issues/2227
     windows: WeakValueDictionary[Literal["main", "preferences"], Gtk.ApplicationWindow] = WeakValueDictionary()
     _tray_icon: ulauncher.ui.helpers.tray_icon.TrayIcon | None = None  # pyrefly: ignore[implicit-import]
@@ -90,19 +93,16 @@ class UlauncherApp(Gtk.Application):
         self.run([])
 
     def setup(self) -> None:
-        settings = Settings.load()
-        cli_args = cli.get_args()
-        # On systemd systems, the unit's enabled state is the source of truth for "should this
-        # run as a service" - keep_alive only applies as a fallback for users without systemd.
         from ulauncher.utils.systemd_controller import SystemdController
 
-        is_persistent = cli_args.daemon or (settings.keep_alive and not SystemdController("ulauncher").supported)
-        if is_persistent:
-            # Keep the app running even without a window
-            self.hold()
+        settings = Settings.load()
+        self.hold()
+        # On systemd the unit's enabled state wins; keep_alive is the non-systemd fallback.
+        controller = SystemdController("ulauncher")
+        self._persistent = controller.is_enabled() or (settings.keep_alive and not controller.supported)
 
-            if settings.show_tray_icon:
-                self.toggle_tray_icon(True)
+        if settings.show_tray_icon and self._persistent:
+            self.toggle_tray_icon(True)
 
         if first_run or settings.hotkey_show_app:
             from ulauncher.ui.helpers.hotkey_controller import HotkeyController
@@ -160,16 +160,17 @@ class UlauncherApp(Gtk.Application):
 
     def _on_window_destroyed(self, _window: Gtk.Window, key: Literal["main", "preferences"]) -> None:
         self.windows.pop(key, None)
-        if not self.windows:
+        if not self.windows and not self._persistent:
             # Clipboard contents only live as long as the owning app, and clipboard managers
             # (klipper, gpaste, wl-clip-persist, ...) need time to snapshot them after we set
             # ownership. X11/Wayland have no "snapshot done" event, and managers react on their
             # own schedule with non-trivial wakeup latency. GTK4's Gdk.Clipboard.store_async
-            # closes this gap properly, but we're using GTK3. So hold the app for 1s on the
+            # closes this gap properly, but we're using GTK3. So delay the quit by 1s on the
             # chance the user's last action was a clipboard copy. 0.25s wasn't enough; 1s seems
             # to work, but maybe not on all systems.
-            self.toggle_hold(True)
-            timer(1, lambda: self.toggle_hold(False))
+            #
+            # re-check windows in case the user re-opened it during the delay
+            timer(1, lambda: self.quit() if not self.windows else None)
 
     @events.on
     def show_results(self, results: Iterable[Result]) -> None:
@@ -184,8 +185,8 @@ class UlauncherApp(Gtk.Application):
 
     @events.on
     def show_preferences(self, page: str | None = None) -> None:
-        # Register prefs in self.windows before closing main, so the destroy handler sees a
-        # remaining window during the transition.
+        # Register prefs in self.windows before closing main, so the main destroy handler
+        # sees a remaining window and doesn't quit the app on non-persistent setups.
         preferences = cast("PreferencesWindow | None", self.windows.get("preferences"))
         if preferences and preferences.get_window() is None:
             logger.warning("Ignoring stale Preferences window reference (suspecting a memory leak)")
@@ -239,7 +240,10 @@ class UlauncherApp(Gtk.Application):
 
     @events.on
     def toggle_hold(self, value: bool) -> None:
-        self.hold() if value else self.release()
+        # Idempotent: gio's release() logs a critical warning on underflow.
+        if value != self._persistent:
+            self._persistent = value
+            self.hold() if value else self.release()
 
     @events.on
     def quit(self) -> None:  # pyrefly: ignore[bad-override]

--- a/ulauncher/ui/preferences/views/preferences.py
+++ b/ulauncher/ui/preferences/views/preferences.py
@@ -135,19 +135,19 @@ class PreferencesView(BaseView):
     def _add_general_section(self, parent: Gtk.Box) -> None:
         """Add general settings section"""
         general_box = self._create_section_container(parent, "General")
-        background_recommendation = "\n<b>Recommended:</b> Enabling this will make Ulauncher open noticeably faster."
+        run_in_bg_footer = "\n<b>Recommended:</b> Enabling this will make Ulauncher open noticeably faster."
 
-        # Launch at login / Keep running in background
+        # Run in background (via systemd autostart, or keep-alive fallback)
         if self.autostart_pref.can_start():
             autostart_switch = Gtk.Switch(active=self.autostart_pref.is_enabled())
             autostart_switch.connect("notify::active", self._on_autostart_toggled)
-            desc = f"Start Ulauncher in the background when your desktop session starts. {background_recommendation}"
-            self._add_setting_row(general_box, "Launch at login", autostart_switch, desc)
+            desc = "Start Ulauncher automatically with your desktop session so it's ready when you need it."
+            self._add_setting_row(general_box, "Run in background", autostart_switch, f"{desc}{run_in_bg_footer}")
         else:
             keep_alive_switch = Gtk.Switch(active=self.settings.keep_alive)
             keep_alive_switch.connect("notify::active", self._on_keep_alive_toggled)
-            desc = f"Keep Ulauncher running in the background. {background_recommendation}"
-            self._add_setting_row(general_box, "Keep running in background", keep_alive_switch, desc)
+            desc = "Keep Ulauncher running in the background after first use so it stays ready"
+            self._add_setting_row(general_box, "Run in background", keep_alive_switch, f"{desc}{run_in_bg_footer}")
 
         # Hotkey
         if HotkeyController.is_supported():
@@ -291,6 +291,8 @@ class PreferencesView(BaseView):
         except OSError:
             logger.exception("Failed to toggle autostart")
             switch.set_active(not is_enabled)
+            return
+        events.emit("app:toggle_hold", is_enabled)
 
     def _on_hotkey_clicked(self, _: Gtk.Button) -> None:
         HotkeyController.show_dialog()

--- a/ulauncher/ui/preferences/views/preferences.py
+++ b/ulauncher/ui/preferences/views/preferences.py
@@ -149,6 +149,8 @@ class PreferencesView(BaseView):
             desc = "Keep Ulauncher running in the background after first use so it stays ready"
             self._add_setting_row(general_box, "Run in background", keep_alive_switch, f"{desc}{run_in_bg_footer}")
 
+        self._add_tray_icon_row(general_box)
+
         # Hotkey
         if HotkeyController.is_supported():
             hotkey_button = Gtk.Button.new_with_label("Set hotkey")
@@ -235,12 +237,6 @@ class PreferencesView(BaseView):
         """Add advanced settings section"""
         advanced_box = self._create_section_container(parent, "Advanced")
 
-        # Show tray icon
-        tray_switch = Gtk.Switch(active=self.settings.show_tray_icon)
-        tray_switch.connect("notify::active", self._on_tray_toggled)
-        desc = "Display a tray icon for quick actions. Requires AppIndicator3 or XApp on X11."
-        self._add_setting_row(advanced_box, "Show tray icon", tray_switch, desc)
-
         # Desktop filters
         filters_switch = Gtk.Switch(active=self.settings.disable_desktop_filters)
         filters_switch.connect("notify::active", self._on_filters_toggled)
@@ -280,6 +276,22 @@ class PreferencesView(BaseView):
         )
         self._add_setting_row(advanced_box, "Terminal command", terminal_entry, desc, full_width=True)
 
+    def _add_tray_icon_row(self, parent: Gtk.Box) -> None:
+        # Placed next to "Run in background" because the tray icon is only effective while persistent.
+        self._tray_switch = Gtk.Switch(active=self.settings.show_tray_icon, sensitive=self._is_persistent())
+        self._tray_switch.connect("notify::active", self._on_tray_toggled)
+        desc = (
+            "Display a tray icon for quick actions. Only available while Ulauncher is set to "
+            "run in the background. Also requires AppIndicator3 or XApp on X11."
+        )
+        self._add_setting_row(parent, "Show tray icon", self._tray_switch, desc)
+
+    def _is_persistent(self) -> bool:
+        # Mirrors UlauncherApp.setup(): systemd autostart wins where supported, else keep_alive.
+        if self.autostart_pref.can_start():
+            return self.autostart_pref.is_enabled()
+        return self.settings.keep_alive
+
     # Event handlers
     def _on_autostart_toggled(self, switch: Gtk.Switch, _: Any) -> None:
         is_enabled = switch.get_active()
@@ -292,6 +304,7 @@ class PreferencesView(BaseView):
             logger.exception("Failed to toggle autostart")
             switch.set_active(not is_enabled)
             return
+        self._tray_switch.set_sensitive(is_enabled)
         events.emit("app:toggle_hold", is_enabled)
 
     def _on_hotkey_clicked(self, _: Gtk.Button) -> None:
@@ -350,6 +363,7 @@ class PreferencesView(BaseView):
     def _on_keep_alive_toggled(self, switch: Gtk.Switch, _: Any) -> None:
         is_enabled = switch.get_active()
         self.settings.save({"keep_alive": is_enabled})
+        self._tray_switch.set_sensitive(is_enabled)
         events.emit("app:toggle_hold", is_enabled)
 
     def _on_jump_keys_changed(self, entry: Gtk.Entry) -> None:


### PR DESCRIPTION
## Summary

#1721 made `keep_alive` (or systemd's enabled state) the single source of truth for whether Ulauncher persists in the background, but several call sites still read the old startup-time signals. The result was that the new setting didn't fully live up to its intent: toggling it in preferences didn't take effect until the next restart, D-Bus-activated invocations bypassed it on systemd, and the tray icon could outlive the background process it depends on.

This PR aligns the runtime behavior.

## Fixes / Improvements

- **Clarify preferences wording** (450ef22) — Rephrased labels so that autostart and `keep_alive` read as two routes to the same outcome (keeping the session alive).
- **Keep tray icon in sync with persistence state** (ef03bae) — The tray icon is only meaningful while the app keeps running in the background. `toggle_tray_icon` now enforces that, and `toggle_hold` refreshes tray visibility.
- **Gate "Show tray icon" on persistence in preferences** (0da1e6b) — Moved the toggle out of "Advanced" to sit next to "Run in background" in General. The switch is disabled when persistence is off, with a description that points to the option that needs to be enabled first; sensitivity and description update live.
- **Respect `keep_alive` / systemd state at window-close time** (450ef22) — Persistence was decided once at startup from `cli_args.daemon` and a narrow `keep_alive and not systemd.supported` check. Now the app holds unconditionally at setup, caches the user's intent in `_persistent` (derived from the systemd unit state or `keep_alive` fallback), and the destroy handler quits after a 1s grace only when not persistent. D-Bus activations are covered too. Re-checks `self.windows` before quitting to handle a quick re-activation race.
- **Apply persistence changes immediately** (450ef22) — Toggling either persistence setting in preferences now emits `app:toggle_hold`, keeping `_persistent` and the gio hold reference in sync without a restart.
- **Sync pre-launcher `_persistent` with hold count** (0b69c83) — Prevented a latent footgun where flipping persistence with no setting initially could close the preferences window via the hold count rather than the explicit listener.

## Follow-up

A coming PR will rename `ulauncher --daemon` to `ulauncher start`, to avoid implying that it stays running.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes app persistence: `ulauncher` now respects systemd unit state or the `keep_alive` fallback at runtime, applies changes immediately, and only quits after a 1s grace when not persistent. The tray icon follows persistence and its toggle is placed next to “Run in background”.

- **Bug Fixes**
  - Persistence is derived from systemd enabled state or `keep_alive`; runtime flips apply immediately and won’t close windows; D‑Bus activations respected.
  - On last window close, quit after a 1s delay only if not persistent; re-check windows to avoid races.
  - Tray icon visibility follows persistence; “Show tray icon” moved to General next to “Run in background” and disabled when not persistent.

- **Refactors**
  - Hold on setup; track desired state in `_persistent`; `toggle_hold` is idempotent and refreshes the tray.
  - Preferences wording: “Run in background” clarifies systemd autostart vs `keep_alive` fallback.

<sup>Written for commit 0da1e6bb4fa0d38de6c33d02280f3811e38022bd. Summary will update on new commits. <a href="https://cubic.dev/pr/Ulauncher/Ulauncher/pull/1722?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

