### PR TITLE
refactor(app): destroy flow

### DIFF
--- a/ulauncher/ui/app.py
+++ b/ulauncher/ui/app.py
@@ -183,21 +183,26 @@ class UlauncherApp(Gtk.Application):
 
     @events.on
     def show_preferences(self, page: str | None = None) -> None:
-        if main_window := self.windows.get("main"):
-            cast("UlauncherWindow", main_window).close(save_query=True)
-
-        if preferences := self.windows.get("preferences"):
-            if preferences.get_window() is None:
-                logger.warning("Ignoring stale Preferences window reference (suspecting a memory leak)")
-                del self.windows["preferences"]
-                self.show_preferences(page)
-                return
-            cast("PreferencesWindow", preferences).present(page)
-        else:
+        # Register prefs in self.windows before closing main, so the destroy handler sees a
+        # remaining window during the transition.
+        preferences = cast("PreferencesWindow | None", self.windows.get("preferences"))
+        if preferences and preferences.get_window() is None:
+            logger.warning("Ignoring stale Preferences window reference (suspecting a memory leak)")
+            del self.windows["preferences"]
+            preferences = None
+        is_new = preferences is None
+        if preferences is None:
             preferences = PreferencesWindow(application=self)
             preferences.connect("destroy", self._on_window_destroyed, "preferences")
             self.windows["preferences"] = preferences
+
+        if main_window := self.windows.get("main"):
+            cast("UlauncherWindow", main_window).close(save_query=True)
+
+        if is_new:
             preferences.show(page)
+        else:
+            preferences.present(page)
 
     def activate_query(self, query_str: str) -> None:
         self.activate()

--- a/ulauncher/ui/app.py
+++ b/ulauncher/ui/app.py
@@ -164,9 +164,11 @@ class UlauncherApp(Gtk.Application):
 
         if "main" not in self.windows:
             main_window = UlauncherWindow(application=self)
-            # Drop the reference on destroy to prevent stale window references
-            main_window.connect("destroy", lambda *_: self.windows.pop("main", None))
+            main_window.connect("destroy", self._on_window_destroyed, "main")
             self.windows["main"] = main_window
+
+    def _on_window_destroyed(self, _window: Gtk.Window, key: Literal["main", "preferences"]) -> None:
+        self.windows.pop(key, None)
 
     @events.on
     def show_results(self, results: Iterable[Result]) -> None:
@@ -193,8 +195,7 @@ class UlauncherApp(Gtk.Application):
             cast("PreferencesWindow", preferences).present(page)
         else:
             preferences = PreferencesWindow(application=self)
-            # Drop the weakref entry on destroy so we don't keep a stale window around.
-            preferences.connect("destroy", lambda *_: self.windows.pop("preferences", None))
+            preferences.connect("destroy", self._on_window_destroyed, "preferences")
             self.windows["preferences"] = preferences
             preferences.show(page)
 

--- a/ulauncher/ui/app.py
+++ b/ulauncher/ui/app.py
@@ -145,16 +145,7 @@ class UlauncherApp(Gtk.Application):
     @events.on
     def copy_and_close(self, data: str) -> None:
         self.clipboard_store(data)
-        self.toggle_hold(True)
         self.close_launcher()
-        # Clipboard contents only live as long as the owning app does, so we need to give clipboard
-        # managers (klipper, gpaste, wl-clip-persist, ...) time to snapshot them after we set
-        # ownership. X11/Wayland have no "snapshot done" event, and managers react on their own
-        # schedule with non-trivial wakeup latency
-        # GTK4's Gdk.Clipboard.store_async closes this gap properly, but we're using GTK3.
-        # The timeout is set to one second to give clipboard managers enough time to snapshot.
-        # I tried 0.25s but it wasn't enough. 1s seems to be, but maybe not on all systems?
-        timer(1, lambda: self.toggle_hold(False))
 
     @events.on
     def show_launcher(self) -> None:
@@ -169,6 +160,16 @@ class UlauncherApp(Gtk.Application):
 
     def _on_window_destroyed(self, _window: Gtk.Window, key: Literal["main", "preferences"]) -> None:
         self.windows.pop(key, None)
+        if not self.windows:
+            # Clipboard contents only live as long as the owning app, and clipboard managers
+            # (klipper, gpaste, wl-clip-persist, ...) need time to snapshot them after we set
+            # ownership. X11/Wayland have no "snapshot done" event, and managers react on their
+            # own schedule with non-trivial wakeup latency. GTK4's Gdk.Clipboard.store_async
+            # closes this gap properly, but we're using GTK3. So hold the app for 1s on the
+            # chance the user's last action was a clipboard copy. 0.25s wasn't enough; 1s seems
+            # to work, but maybe not on all systems.
+            self.toggle_hold(True)
+            timer(1, lambda: self.toggle_hold(False))
 
     @events.on
     def show_results(self, results: Iterable[Result]) -> None:


### PR DESCRIPTION
Three commits refactor/ simplify app destroy flow. These shouldn't do anything in themselves, but will enable a fix coming after this.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Refactored the app destroy flow by centralizing window cleanup and clipboard grace handling in `_on_window_destroyed`. This simplifies logic and makes last-window-close behavior consistent with a brief 1s hold for clipboard managers.

- **Refactors**
  - Replaced inline destroy lambdas with `_on_window_destroyed` that removes window entries and, when no windows remain, uses `toggle_hold` + 1s timer to allow clipboard snapshot.
  - Moved clipboard grace from `copy_and_close` into the destroy handler to cover all dismiss paths.
  - Reordered `show_preferences` to register the preferences window before closing the main window; connects its destroy handler, cleans up stale references, and uses `show` for new vs `present` for existing windows.

<sup>Written for commit 4ae0baa938ff97313157c5ebc9a2d787b588fd7f. Summary will update on new commits. <a href="https://cubic.dev/pr/Ulauncher/Ulauncher/pull/1723?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

