### PR TITLE
chore: fix release notes not catching breaking changes

### DIFF
--- a/cliff.toml
+++ b/cliff.toml
@@ -4,7 +4,8 @@ body = """
 ## What's Changed{% for group, commits in commits | filter(attribute="merge_commit", value=false) | group_by(attribute="group") %}
 
 ### {{ group | striptags | trim }}
-{% for commit in commits %}* {% if commit.scope %}**{{ commit.scope }}:** {% endif %}{{ commit.message | replace_regex(from="( +\\(#\\d+\\))+$", to="") | upper_first }}{% if commit.links | length > 0 %} ({% for link in commit.links %}[{{ link.text }}]({{ link.href }}){% if not loop.last %}, {% endif %}{% endfor %}){% else %} ([{{ commit.id | truncate(length=7, end="") }}](https://github.com/Ulauncher/Ulauncher/commit/{{ commit.id }})){% endif %}
+{% for commit in commits %}{% set breaking_footer = commit.footers | filter(attribute="token", value="BREAKING-CHANGE") | first %}* {% if commit.scope %}**{{ commit.scope }}:** {% endif %}{{ commit.message | replace_regex(from="( +\\(#\\d+\\))+$", to="") | upper_first }}{% if commit.links | length > 0 %} ({% for link in commit.links %}[{{ link.text }}]({{ link.href }}){% if not loop.last %}, {% endif %}{% endfor %}){% else %} ([{{ commit.id | truncate(length=7, end="") }}](https://github.com/Ulauncher/Ulauncher/commit/{{ commit.id }})){% endif %}{% if breaking_footer %}
+  > {{ breaking_footer.value | upper_first }}{% endif %}
 {% endfor %}{% endfor %}
 {% else %}
 ## What's Changed
@@ -12,7 +13,7 @@ body = """
 * No user-facing changes were captured for this release.
 {% endif %}
 """
-trim = true
+trim = false
 
 [git]
 conventional_commits = true
@@ -39,7 +40,8 @@ link_parsers = [
 # commit has not yet been released.
 commit_parsers = [
     { footer = "^Amends:", skip = true },
-    { breaking = true, group = "<!-- -1 -->💥 Breaking Changes" },
+    { footer = "^BREAKING[ -]?CHANGE", group = "<!-- -1 -->💥 Breaking Changes", breaking = true },
+    { message = "^[a-z]+(\\(.+\\))?!:", group = "<!-- -1 -->💥 Breaking Changes", breaking = true },
     { message = "^feat(\\(.+\\))?!?:", group = "<!-- 0 -->✨ New Features" },
     { message = "^fix(\\(.+\\))?!?:", group = "<!-- 1 -->🐛 Bug Fixes" },
     { message = "^perf(\\(.+\\))?!?:", group = "<!-- 2 -->⚡ Performance" },

--- a/cliff.toml
+++ b/cliff.toml
@@ -4,8 +4,8 @@ body = """
 ## What's Changed{% for group, commits in commits | filter(attribute="merge_commit", value=false) | group_by(attribute="group") %}
 
 ### {{ group | striptags | trim }}
-{% for commit in commits %}{% set breaking_footer = commit.footers | filter(attribute="token", value="BREAKING-CHANGE") | first %}* {% if commit.scope %}**{{ commit.scope }}:** {% endif %}{{ commit.message | replace_regex(from="( +\\(#\\d+\\))+$", to="") | upper_first }}{% if commit.links | length > 0 %} ({% for link in commit.links %}[{{ link.text }}]({{ link.href }}){% if not loop.last %}, {% endif %}{% endfor %}){% else %} ([{{ commit.id | truncate(length=7, end="") }}](https://github.com/Ulauncher/Ulauncher/commit/{{ commit.id }})){% endif %}{% if breaking_footer %}
-  > {{ breaking_footer.value | upper_first }}{% endif %}
+{% for commit in commits %}* {% if commit.scope %}**{{ commit.scope }}:** {% endif %}{{ commit.message | replace_regex(from="( +\\(#\\d+\\))+$", to="") | upper_first }}{% if commit.links | length > 0 %} ({% for link in commit.links %}[{{ link.text }}]({{ link.href }}){% if not loop.last %}, {% endif %}{% endfor %}){% else %} ([{{ commit.id | truncate(length=7, end="") }}](https://github.com/Ulauncher/Ulauncher/commit/{{ commit.id }})){% endif %}{% if commit.breaking_description and commit.breaking_description != commit.message %}
+  > {{ commit.breaking_description | upper_first }}{% endif %}
 {% endfor %}{% endfor %}
 {% else %}
 ## What's Changed
@@ -40,8 +40,8 @@ link_parsers = [
 # commit has not yet been released.
 commit_parsers = [
     { footer = "^Amends:", skip = true },
-    { footer = "^BREAKING[ -]?CHANGE", group = "<!-- -1 -->💥 Breaking Changes", breaking = true },
-    { message = "^[a-z]+(\\(.+\\))?!:", group = "<!-- -1 -->💥 Breaking Changes", breaking = true },
+    { footer = "^BREAKING[ -]?CHANGE", group = "<!-- -1 -->💥 Breaking Changes" },
+    { message = "^[a-z]+(\\(.+\\))?!:", group = "<!-- -1 -->💥 Breaking Changes" },
     { message = "^feat(\\(.+\\))?!?:", group = "<!-- 0 -->✨ New Features" },
     { message = "^fix(\\(.+\\))?!?:", group = "<!-- 1 -->🐛 Bug Fixes" },
     { message = "^perf(\\(.+\\))?!?:", group = "<!-- 2 -->⚡ Performance" },


### PR DESCRIPTION
This wasn't tested before and effectively didn't even work. I tested and reworked it in a working branch and this will generate as:

### 💥 Breaking Changes
* **cli:** Replace --daemon flag with start subcommand ([61c3b48](https://github.com/Ulauncher/Ulauncher/commit/61c3b48b6e2ea3a9e13865704675a673cb7dc110))
  > `--daemon` and `--no-window` are replaced by the `ulauncher start` subcommand. The old flags still work but print a deprecation warning. Update any custom autostart entries, systemd units, or service files to invoke `ulauncher start`.
* **cli:** Move --verbose to subparsers that use it ([32c4dd9](https://github.com/Ulauncher/Ulauncher/commit/32c4dd9ee45bec4f804be73fbaab8d00be57c9eb))
  > `--verbose` is no longer a universal CLI argument applicable for all commands. It is now only supported for subcommands that produces logs (e.g. `ulauncher start --verbose`).


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix release notes generation to reliably capture and display breaking changes in `git-cliff`. Ensures the "💥 Breaking Changes" section is correctly populated with details.

- **Bug Fixes**
  - Detect breaking changes via `BREAKING CHANGE` footers and any `type(scope)!:` commit; group under "💥 Breaking Changes" with explicit patterns.
  - Show breaking descriptions under each item and keep formatting (`trim = false`).

<sup>Written for commit 99dca8e02c88f9543463485919f5cef5037e011a. Summary will update on new commits. <a href="https://cubic.dev/pr/Ulauncher/Ulauncher/pull/1724?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->



