### PR TITLE
feat(cli): major subcommand rework

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -24,7 +24,7 @@ body:
     id: logs
     attributes:
       label: Log output
-      description: Run Ulauncher from the shell with `ulauncher -v` and copy and paste the log output or grab the log from the previous session (`~/.local/share/ulauncher/last.log` for v5 or `~/.local/state/ulauncher/last.log` for v6). This will be automatically formatted into code, so no need for backticks.
+      description: For Ulauncher v6 - Run Ulauncher from the shell with `ulauncher start --verbose` and copy and paste the log output or grab the log from the previous session `~/.local/state/ulauncher/last.log`. This will be automatically formatted into code, so no need for backticks. For Ulauncher v5, the command is instead `ulauncher --verbose` and the log path is `~/.local/share/ulauncher/last.log`
       render: shell
   - type: checkboxes
     id: communication-guidelines

--- a/bin/ulauncher
+++ b/bin/ulauncher
@@ -1,5 +1,11 @@
 #!/bin/sh
 
+# Wrap a string as a GVariant text-format string literal,
+# escaping backslashes and single quotes per the GVariant syntax.
+gvariant_string() {
+  printf "'%s'" "$(printf '%s' "$1" | sed -e 's/\\/\\\\/g' -e "s/'/\\\\'/g")"
+}
+
 # Print $2 to stderr (with backslash escapes like \n interpreted), wrapped in the ANSI SGR
 # code $1 when stderr is a TTY.
 print_color() {
@@ -10,7 +16,7 @@ print_color() {
   fi
 }
 
-# Rewrite legacy flags before handing argv to python. Direct `python -m ulauncher`
+# Rewrite legacy flags before any further argv handling. Direct `python -m ulauncher`
 # invocations bypass this and get argparse's "unrecognized arguments" error instead.
 orig_count=$#
 walked=0
@@ -32,6 +38,42 @@ while [ "$walked" -lt "$orig_count" ]; do
     *) set -- "$@" "$arg" ;;
   esac
 done
+
+# Fast path: bypass Python for the performance-critical commands (bare invocation, `show`,
+# `show <query>`, `toggle`). Any flag, unknown subcommand, or extra positional defers to
+# Python so it can produce the real parse output/error.
+subcmd=''
+query=''
+has_query=0
+needs_argparse=0
+for arg in "$@"; do
+  case "$arg" in
+    -*) needs_argparse=1 ;;
+    *)
+      if [ -z "$subcmd" ]; then
+        subcmd=$arg
+      elif [ "$subcmd" = show ] && [ "$has_query" -eq 0 ]; then
+        query=$arg; has_query=1
+      else
+        needs_argparse=1
+      fi
+      ;;
+  esac
+done
+
+if [ "$needs_argparse" -eq 0 ]; then
+  case "$subcmd" in
+    '')      exec gapplication action io.ulauncher.Ulauncher show-window ;;
+    toggle)  exec gapplication action io.ulauncher.Ulauncher toggle-window ;;
+    show)
+      if [ "$has_query" -eq 1 ]; then
+        exec gapplication action io.ulauncher.Ulauncher set-query "$(gvariant_string "$query")"
+      else
+        exec gapplication action io.ulauncher.Ulauncher show-window
+      fi
+      ;;
+  esac
+fi
 
 SCRIPT_PATH=$(readlink -f "$0")
 PROJECT_ROOT=$(dirname "$(dirname "$SCRIPT_PATH")")

--- a/bin/ulauncher
+++ b/bin/ulauncher
@@ -18,15 +18,17 @@ while [ "$walked" -lt "$orig_count" ]; do
   arg=$1; shift; walked=$((walked + 1))
   case "$arg" in
     --hide-window)
-      print_color 33 "The --hide-window argument has been removed (use --daemon)"; exit 2 ;;
+      print_color 33 "The --hide-window argument has been removed (use start)"; exit 2 ;;
     --no-extensions)
       print_color 33 "The --no-extensions argument has been removed (see --help for available commands)"; exit 2 ;;
     --no-window-shadow)
       print_color 33 "The --no-window-shadow argument has been removed (configure via the Window shadow size setting in preferences)"; exit 2 ;;
     --dev)
       print_color 33 "The --dev argument has been removed (use --verbose)"; set -- "$@" --verbose ;;
+    --daemon)
+      print_color 33 "The --daemon argument has been removed (use start)"; set -- "$@" start ;;
     --no-window)
-      print_color 33 "The --no-window argument has been removed (use --daemon)"; set -- "$@" --daemon ;;
+      print_color 33 "The --no-window argument has been removed (use start)"; set -- "$@" start ;;
     *) set -- "$@" "$arg" ;;
   esac
 done

--- a/io.ulauncher.Ulauncher.service
+++ b/io.ulauncher.Ulauncher.service
@@ -1,3 +1,3 @@
 [D-BUS Service]
 Name=io.ulauncher.Ulauncher
-Exec=/usr/bin/ulauncher
+Exec=/usr/bin/ulauncher start

--- a/makefile
+++ b/makefile
@@ -76,7 +76,7 @@ run:
 	else
 		killall -eq ulauncher || true
 	fi
-	./bin/ulauncher --verbose
+	./bin/ulauncher start --verbose
 
 # Start a bash session in the Ulauncher Docker build container (Ubuntu). Set CONTAINER_CMD to run a command non-interactively.
 run-container:

--- a/makefile
+++ b/makefile
@@ -250,6 +250,9 @@ manpage:
 		exit 1
 	fi
 	help2man --section=1 --name="Feature rich application Launcher for Linux" --no-info ./bin/ulauncher > ulauncher.1
+	# help2man renders any heading with a trailing colon as .SS (indented subsection).
+	# Convert those to .SH with uppercased names, which is the man page section convention.
+	sed -i 's/^\.SS "\(.*\):"$$/.SH \U\1/' ulauncher.1
 	echo -e "Generated manpage\n"
 	echo -e "Run '${BOLD}${GREEN}man -l ulauncher.1${RESET}' if you want to preview it."
 

--- a/nix/default.nix
+++ b/nix/default.nix
@@ -158,7 +158,7 @@ let
         logfile="$test_dir/log.txt"
         env -i HOME="$test_dir" \
           "$(command -v xvfb-run)" --auto-servernum -- \
-          $out/bin/ulauncher --verbose &>"$logfile" &
+          $out/bin/ulauncher start --verbose &>"$logfile" &
         ulauncher_pid=$!
 
         while IFS= read -r line; do

--- a/nix/default.nix
+++ b/nix/default.nix
@@ -97,6 +97,7 @@ let
       patchShebangs bin/ulauncher bin/ulauncher-toggle
 
       substituteInPlace \
+          bin/ulauncher \
           bin/ulauncher-toggle \
           io.ulauncher.Ulauncher.desktop \
         --replace-fail gapplication ${glib}/bin/gapplication

--- a/tests/test_bin_ulauncher.py
+++ b/tests/test_bin_ulauncher.py
@@ -12,7 +12,7 @@ BIN_ULAUNCHER = REPO_ROOT / "bin/ulauncher"
 @pytest.mark.parametrize(
     ("flag", "hint"),
     [
-        ("--hide-window", "use --daemon"),
+        ("--hide-window", "use start"),
         ("--no-extensions", "see --help for available commands"),
         ("--no-window-shadow", "the Window shadow size setting"),
     ],
@@ -29,7 +29,8 @@ def test_legacy_terminal_flags_exit_without_python(flag: str, hint: str) -> None
     ("legacy", "replacement"),
     [
         ("--dev", "--verbose"),
-        ("--no-window", "--daemon"),
+        ("--daemon", "start"),
+        ("--no-window", "start"),
     ],
 )
 def test_legacy_rewrite_flags_substitute_and_warn(legacy: str, replacement: str, tmp_path: Path) -> None:

--- a/tests/test_bin_ulauncher.py
+++ b/tests/test_bin_ulauncher.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import os
 import subprocess
 from pathlib import Path
 
@@ -7,6 +8,16 @@ import pytest
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
 BIN_ULAUNCHER = REPO_ROOT / "bin/ulauncher"
+
+
+def _stub_gapplication(tmp_path: Path, *, exit_code: int = 0) -> tuple[Path, dict[str, str]]:
+    log_path = tmp_path / "gapplication.log"
+    stub = tmp_path / "gapplication"
+    stub.write_text(f"#!/bin/sh\nprintf '%s\\n' \"$@\" > {log_path}\nexit {exit_code}\n", encoding="utf-8")
+    stub.chmod(0o755)
+    env = os.environ.copy()
+    env["PATH"] = f"{tmp_path}:{env['PATH']}"
+    return log_path, env
 
 
 @pytest.mark.parametrize(
@@ -49,3 +60,47 @@ def test_legacy_rewrite_flags_substitute_and_warn(legacy: str, replacement: str,
     assert "ulauncher" in forwarded
     assert replacement in forwarded
     assert legacy not in forwarded
+
+
+@pytest.mark.parametrize(
+    ("argv", "expected_lines"),
+    [
+        ([], ["action", "io.ulauncher.Ulauncher", "show-window"]),
+        (["show"], ["action", "io.ulauncher.Ulauncher", "show-window"]),
+        (["show", "foo bar"], ["action", "io.ulauncher.Ulauncher", "set-query", "'foo bar'"]),
+        (["show", "Tony's app"], ["action", "io.ulauncher.Ulauncher", "set-query", "'Tony\\'s app'"]),
+        (["show", "back\\slash"], ["action", "io.ulauncher.Ulauncher", "set-query", "'back\\\\slash'"]),
+        (["toggle"], ["action", "io.ulauncher.Ulauncher", "toggle-window"]),
+    ],
+)
+def test_fast_path_execs_gapplication(tmp_path: Path, argv: list[str], expected_lines: list[str]) -> None:
+    log_path, env = _stub_gapplication(tmp_path)
+    subprocess.run([str(BIN_ULAUNCHER), *argv], check=True, env=env)
+    assert log_path.read_text(encoding="utf-8").splitlines() == expected_lines
+
+
+@pytest.mark.parametrize(
+    "argv",
+    [
+        ["--version"],
+        ["--help"],
+        ["-h"],
+        ["show", "--help"],
+        ["show", "--verbose"],
+        ["start"],
+        ["extensions"],
+        ["show", "foo", "bar"],  # extra positional disqualifies fast path
+    ],
+)
+def test_fast_path_defers_to_python(tmp_path: Path, argv: list[str]) -> None:
+    # When the fast path can't handle argv, gapplication must NOT be exec'd; control should
+    # reach the Python invocation (which we stub via PATH to a no-op python3 to keep the test
+    # offline-fast).
+    log_path, env = _stub_gapplication(tmp_path)
+    python_stub = tmp_path / "python3"
+    python_stub.write_text("#!/bin/sh\nexit 0\n", encoding="utf-8")
+    python_stub.chmod(0o755)
+
+    subprocess.run([str(BIN_ULAUNCHER), *argv], check=False, env=env)
+
+    assert not log_path.exists(), f"fast path should not have run gapplication for {argv!r}"

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -17,12 +17,12 @@ class TestCLIParse:
         [
             pytest.param(
                 [],
-                {"command": None, "verbose": False, "daemon": False},
+                {"command": None, "verbose": False},
                 id="defaults",
             ),
-            pytest.param(["--daemon"], {"command": None, "daemon": True}, id="daemon"),
             pytest.param(["--verbose"], {"command": None, "verbose": True}, id="verbose"),
             pytest.param(["-v"], {"command": None, "verbose": True}, id="v-short"),
+            pytest.param(["start"], {"command": "start"}, id="start"),
             pytest.param(["extensions"], {"command": "extensions"}, id="extensions"),
             pytest.param(["install", "git://example"], {"command": "install", "input": "git://example"}, id="install"),
             pytest.param(["uninstall", "ext-id"], {"command": "uninstall", "input": "ext-id"}, id="uninstall"),
@@ -76,7 +76,7 @@ class TestCLIParse:
 
 
 class TestCLIRunCommand:
-    def test_run_command_dispatches_default_app_handler(self, mocker: MockerFixture) -> None:
+    def test_run_command_dispatches_default_start_handler(self, mocker: MockerFixture) -> None:
         ensure_runtime_dirs = mocker.patch("ulauncher.cli.ensure_runtime_dirs")
         mocker.patch("ulauncher.cli.configure_logging")
         handler = mocker.Mock(return_value=True)
@@ -87,5 +87,5 @@ class TestCLIRunCommand:
         assert cli.run_command(args) is True
 
         ensure_runtime_dirs.assert_called_once_with()
-        load_handler.assert_called_once_with("ulauncher.cli.commands.app:run")
+        load_handler.assert_called_once_with("start")
         handler.assert_called_once_with(args)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -23,7 +23,8 @@ class TestCLIParse:
             pytest.param(["show"], {"command": "show", "query": None}, id="show"),
             pytest.param(["show", "foo"], {"command": "show", "query": "foo"}, id="show-with-query"),
             pytest.param(["toggle"], {"command": "toggle"}, id="toggle"),
-            pytest.param(["--verbose"], {"command": "show", "verbose": True}, id="verbose-default-command"),
+            pytest.param(["show", "--verbose"], {"command": "show", "verbose": True}, id="show-verbose"),
+            pytest.param(["--verbose"], {"command": "show", "verbose": True}, id="bare-verbose"),
             pytest.param(["start"], {"command": "start"}, id="start"),
             pytest.param(["extensions"], {"command": "extensions"}, id="extensions"),
             pytest.param(["install", "git://example"], {"command": "install", "input": "git://example"}, id="install"),
@@ -35,6 +36,14 @@ class TestCLIParse:
                 ["preview", "--with-debugger", "/tmp/demo"],
                 {"command": "preview", "path": "/tmp/demo", "with_debugger": True},
                 id="preview-with-debugger",
+            ),
+            pytest.param(["start", "--verbose"], {"command": "start", "verbose": True}, id="start-verbose"),
+            pytest.param(["--verbose", "start"], {"command": "start", "verbose": True}, id="verbose-before-start"),
+            pytest.param(["-v", "extensions"], {"command": "extensions", "verbose": True}, id="v-before-extensions"),
+            pytest.param(
+                ["--verbose", "install", "git://example"],
+                {"command": "install", "input": "git://example", "verbose": True},
+                id="verbose-before-install",
             ),
         ],
     )
@@ -79,12 +88,14 @@ class TestCLIParse:
 
 class TestCLIRunCommand:
     @pytest.mark.parametrize(
-        ("input_args", "command_name", "logging_mode"),
+        ("input_args", "command_name", "logging_mode", "verbose"),
         [
-            pytest.param([], "show", None, id="show"),
-            pytest.param(["toggle"], "toggle", None, id="toggle"),
-            pytest.param(["start"], "start", "app", id="start"),
-            pytest.param(["extensions"], "extensions", "cli", id="extensions"),
+            pytest.param([], "show", None, False, id="show"),
+            pytest.param(["toggle"], "toggle", None, False, id="toggle"),
+            pytest.param(["start"], "start", "app", False, id="start"),
+            pytest.param(["start", "--verbose"], "start", "app", True, id="start-verbose-trailing"),
+            pytest.param(["--verbose", "start"], "start", "app", True, id="start-verbose-leading"),
+            pytest.param(["extensions"], "extensions", "cli", False, id="extensions"),
         ],
     )
     def test_run_command_dispatches_handler_with_expected_bootstrap_mode(
@@ -92,6 +103,7 @@ class TestCLIRunCommand:
         input_args: list[str],
         command_name: str,
         logging_mode: str | None,
+        verbose: bool,
         mocker: MockerFixture,
     ) -> None:
         ensure_runtime_dirs = mocker.patch("ulauncher.cli.ensure_runtime_dirs")
@@ -105,13 +117,24 @@ class TestCLIRunCommand:
 
         if logging_mode is not None:
             ensure_runtime_dirs.assert_called_once_with()
-            configure_logging.assert_called_once_with(verbose=False, use_app_logging=logging_mode == "app")
+            configure_logging.assert_called_once_with(verbose=verbose, use_app_logging=logging_mode == "app")
         else:
             ensure_runtime_dirs.assert_not_called()
             configure_logging.assert_not_called()
 
         load_handler.assert_called_once_with(command_name)
         handler.assert_called_once_with(args)
+
+    def test_run_command_warns_when_verbose_set_on_runtimeless_command(
+        self,
+        mocker: MockerFixture,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        mocker.patch("ulauncher.cli._load_handler", return_value=mocker.Mock(return_value=0))
+
+        cli.run_command(cli.parse(["show", "--verbose"]))
+
+        assert "--verbose has no effect on the show command" in capsys.readouterr().err
 
 
 class TestCLIHelp:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -112,3 +112,35 @@ class TestCLIRunCommand:
 
         load_handler.assert_called_once_with(command_name)
         handler.assert_called_once_with(args)
+
+
+class TestCLIHelp:
+    def test_groups_top_level_commands_in_help_output(self) -> None:
+        help_text = cli._get_parser().format_help()
+        start_summary = cli._get_commands()["start"].summary
+
+        app_group_index = help_text.index("App commands:")
+        show_index = help_text.index("Show the Ulauncher window (default command)")
+        help_index = help_text.index("Show help")
+        extension_group_index = help_text.index("Extension commands:")
+        extensions_index = help_text.index("List installed extensions")
+        preview_index = help_text.index("Preview extension")
+
+        assert app_group_index < show_index < help_index < extension_group_index < extensions_index < preview_index
+        assert "Available commands" not in help_text
+        assert "Options:" not in help_text
+        assert "\nApp commands:\n  start" in help_text
+        assert "\nExtension commands:\n  extensions (e)" in help_text
+        assert f"start {start_summary}" in " ".join(help_text.split())
+
+    def test_subcommand_help_does_not_repeat_top_level_command_groups(self, capsys: pytest.CaptureFixture[str]) -> None:
+        with pytest.raises(SystemExit) as exc_info:
+            cli.parse(["show", "--help"])
+
+        assert exc_info.value.code == 0
+
+        captured = capsys.readouterr()
+        assert "App commands:" not in captured.out
+        assert "Extension commands:" not in captured.out
+        assert "\nOptions:\n" in captured.out
+        assert captured.err == ""

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -17,11 +17,13 @@ class TestCLIParse:
         [
             pytest.param(
                 [],
-                {"command": None, "verbose": False},
-                id="defaults",
+                {"command": "show", "verbose": False, "input": "", "path": "", "query": None, "with_debugger": False},
+                id="defaults-to-show",
             ),
-            pytest.param(["--verbose"], {"command": None, "verbose": True}, id="verbose"),
-            pytest.param(["-v"], {"command": None, "verbose": True}, id="v-short"),
+            pytest.param(["show"], {"command": "show", "query": None}, id="show"),
+            pytest.param(["show", "foo"], {"command": "show", "query": "foo"}, id="show-with-query"),
+            pytest.param(["toggle"], {"command": "toggle"}, id="toggle"),
+            pytest.param(["--verbose"], {"command": "show", "verbose": True}, id="verbose-default-command"),
             pytest.param(["start"], {"command": "start"}, id="start"),
             pytest.param(["extensions"], {"command": "extensions"}, id="extensions"),
             pytest.param(["install", "git://example"], {"command": "install", "input": "git://example"}, id="install"),
@@ -76,16 +78,37 @@ class TestCLIParse:
 
 
 class TestCLIRunCommand:
-    def test_run_command_dispatches_default_start_handler(self, mocker: MockerFixture) -> None:
+    @pytest.mark.parametrize(
+        ("input_args", "command_name", "logging_mode"),
+        [
+            pytest.param([], "show", None, id="show"),
+            pytest.param(["toggle"], "toggle", None, id="toggle"),
+            pytest.param(["start"], "start", "app", id="start"),
+            pytest.param(["extensions"], "extensions", "cli", id="extensions"),
+        ],
+    )
+    def test_run_command_dispatches_handler_with_expected_bootstrap_mode(
+        self,
+        input_args: list[str],
+        command_name: str,
+        logging_mode: str | None,
+        mocker: MockerFixture,
+    ) -> None:
         ensure_runtime_dirs = mocker.patch("ulauncher.cli.ensure_runtime_dirs")
-        mocker.patch("ulauncher.cli.configure_logging")
+        configure_logging = mocker.patch("ulauncher.cli.configure_logging")
         handler = mocker.Mock(return_value=True)
         load_handler = mocker.patch("ulauncher.cli._load_handler", return_value=handler)
 
-        args = cli.parse([])
+        args = cli.parse(input_args)
 
         assert cli.run_command(args) is True
 
-        ensure_runtime_dirs.assert_called_once_with()
-        load_handler.assert_called_once_with("start")
+        if logging_mode is not None:
+            ensure_runtime_dirs.assert_called_once_with()
+            configure_logging.assert_called_once_with(verbose=False, use_app_logging=logging_mode == "app")
+        else:
+            ensure_runtime_dirs.assert_not_called()
+            configure_logging.assert_not_called()
+
+        load_handler.assert_called_once_with(command_name)
         handler.assert_called_once_with(args)

--- a/ulauncher.service
+++ b/ulauncher.service
@@ -8,7 +8,7 @@ BusName=io.ulauncher.Ulauncher
 Type=dbus
 Restart=always
 RestartSec=1
-ExecStart=/usr/bin/ulauncher --daemon
+ExecStart=/usr/bin/ulauncher start
 
 [Install]
 WantedBy=graphical-session.target

--- a/ulauncher/cli/__init__.py
+++ b/ulauncher/cli/__init__.py
@@ -10,11 +10,10 @@ from ulauncher.data import BaseDataClass
 from ulauncher.init_helpers import configure_logging, ensure_runtime_dirs
 from ulauncher.utils.lru_cache import lru_cache
 
-CommandName = Literal["extensions", "install", "uninstall", "upgrade", "preview"]
+CommandName = Literal["start", "extensions", "install", "uninstall", "upgrade", "preview"]
 
 
 class CLIArguments(BaseDataClass):
-    daemon = False
     verbose = False
     input = ""
     path = ""
@@ -31,7 +30,6 @@ class CLICommandArgument(BaseDataClass):
 
 
 class CLICommand(BaseDataClass):
-    handler_path: str = ""
     summary: str = ""  # one-line, shown in the master `ulauncher --help` listing
     description: str = ""  # longer sentence, shown at the top of `ulauncher <cmd> --help`
     aliases: tuple[str, ...] = ()
@@ -47,14 +45,16 @@ def get_args() -> CLIArguments:
 @lru_cache(maxsize=None)
 def _get_commands() -> dict[CommandName, CLICommand]:
     return {
+        "start": CLICommand(
+            summary="Start the Ulauncher background process",
+            description="Start the Ulauncher background process",
+        ),
         "extensions": CLICommand(
-            handler_path="ulauncher.cli.commands.extensions:run",
             aliases=("e",),
             summary="List installed extensions",
             description="List all installed extensions with their status and information",
         ),
         "install": CLICommand(
-            handler_path="ulauncher.cli.commands.install:run",
             aliases=("i",),
             summary="Install an extension from URL",
             description="Install an extension from a Git URL or local path",
@@ -63,14 +63,12 @@ def _get_commands() -> dict[CommandName, CLICommand]:
             ),
         ),
         "uninstall": CLICommand(
-            handler_path="ulauncher.cli.commands.uninstall:run",
             aliases=("rm",),
             summary="Uninstall an extension",
             description="Remove an installed extension by ID or URL",
             arguments=(CLICommandArgument(args=("input",), kwargs={"help": "Extension ID or URL to uninstall"}),),
         ),
         "upgrade": CLICommand(
-            handler_path="ulauncher.cli.commands.upgrade:run",
             aliases=("up",),
             summary="Upgrade extensions",
             description="Upgrade one or all installed extensions to their latest versions",
@@ -86,7 +84,6 @@ def _get_commands() -> dict[CommandName, CLICommand]:
             ),
         ),
         "preview": CLICommand(
-            handler_path="ulauncher.cli.commands.preview:run",
             aliases=("pr",),
             summary="Preview extension",
             description="Starts extension from a local path for development and debugging purposes",
@@ -115,11 +112,6 @@ def _get_parser() -> argparse.ArgumentParser:
     parser.add_argument("--version", action="version", help="Show version", version=f"Ulauncher {version}")
     parser.add_argument("-h", "--help", action="help", help="Show help")
     parser.add_argument("-v", "--verbose", action="store_true", help="Use verbose logging")
-    parser.add_argument(
-        "--daemon",
-        action="store_true",
-        help="Run Ulauncher as a background process, without initially showing the window",
-    )
 
     subparsers = parser.add_subparsers(
         title="commands",
@@ -142,22 +134,16 @@ def _get_parser() -> argparse.ArgumentParser:
     return parser
 
 
-@lru_cache(maxsize=None)
-def _load_handler(handler_path: str) -> CLICommandHandler:
+def _load_handler(command_name: str) -> CLICommandHandler:
     # Keep non-selected command implementations off the default startup path.
-    module_name, function_name = handler_path.split(":")
-    module = importlib.import_module(module_name)
-    return cast("CLICommandHandler", getattr(module, function_name))
+    module = importlib.import_module(f"ulauncher.cli.commands.{command_name}")
+    return cast("CLICommandHandler", module.run)
 
 
 def run_command(args: CLIArguments) -> int:
     ensure_runtime_dirs()
-    if args.command is None:
-        configure_logging(verbose=args.verbose, use_app_logging=True)
-        return _load_handler("ulauncher.cli.commands.app:run")(args)
-    command = _get_commands()[args.command]
-    configure_logging(verbose=args.verbose, use_app_logging=False)
-    return _load_handler(command.handler_path)(args)
+    configure_logging(verbose=args.verbose, use_app_logging=args.command in (None, "start"))
+    return _load_handler(args.command or "start")(args)
 
 
 def parse(input_args: list[str]) -> CLIArguments:

--- a/ulauncher/cli/__init__.py
+++ b/ulauncher/cli/__init__.py
@@ -67,7 +67,6 @@ class CLIArgumentParser(argparse.ArgumentParser):
         self.help_option_actions: tuple[argparse.Action, ...] = (
             self.add_argument("--version", action="version", help="Show version", version=version),
             self.add_argument("-h", "--help", action="help", help="Show help"),
-            self.add_argument("-v", "--verbose", action="store_true", help="Use verbose logging"),
         )
 
     def format_help(self) -> str:
@@ -208,7 +207,7 @@ def _get_commands() -> dict[CommandName, CLICommand]:
 def _get_parser() -> CLIArgumentParser:
     parser = CLIArgumentParser(
         prog="ulauncher",  # override Python 3.14 argparse's `python3 -m ulauncher` auto-prog
-        usage="%(prog)s [OPTIONS] [COMMAND]",
+        usage="%(prog)s [COMMAND] [OPTIONS]",
         description=CLI_DESCRIPTION,
         formatter_class=CLIHelpFormatter,
         version=f"Ulauncher {version}",
@@ -231,6 +230,10 @@ def _get_parser() -> CLIArgumentParser:
         )
         for argument in command.arguments:
             command_parser.add_argument(*argument.args, **argument.kwargs)
+        # Accept --verbose on every subparser so users don't have to remember which commands
+        # use logging. Hidden (and warned-about post-parse) for commands that don't.
+        verbose_help = "Use verbose logging" if command.has_runtime else argparse.SUPPRESS
+        command_parser.add_argument("-v", "--verbose", action="store_true", help=verbose_help)
         command_parser.set_defaults(command=command_name)
 
     return parser
@@ -247,12 +250,22 @@ def run_command(args: CLIArguments) -> int:
     if command.has_runtime:
         ensure_runtime_dirs()
         configure_logging(verbose=args.verbose, use_app_logging=command.group == "App")
+    elif args.verbose:
+        _emit_warning(f"--verbose has no effect on the {args.command} command")
     return _load_handler(args.command)(args)
+
+
+def _emit_warning(msg: str) -> None:
+    if sys.stderr.isatty():
+        msg = f"\033[33m{msg}\033[0m"
+    sys.stderr.write(f"{msg}\n")
 
 
 def parse(input_args: list[str]) -> CLIArguments:
     """Parse CLI arguments"""
-    args = _get_parser().parse_args(args=input_args)
-    namespace = vars(args)
-    namespace["command"] = cast("CommandName", namespace["command"] or "show")
-    return CLIArguments(**namespace)
+    # --verbose/-v used to be a top-level argument, but is now subparser level.
+    # Sorting it last for compatibility.
+    args = sorted(input_args, key=lambda arg: arg in ("-v", "--verbose"))
+    if all(arg in ("-v", "--verbose") for arg in args):
+        args = ["show", *args]
+    return CLIArguments(**vars(_get_parser().parse_args(args=args)))

--- a/ulauncher/cli/__init__.py
+++ b/ulauncher/cli/__init__.py
@@ -4,6 +4,7 @@ import argparse
 import importlib
 import sys
 from typing import Any, Callable, Literal, cast
+from typing import get_args as get_literal_args
 
 from ulauncher import version
 from ulauncher.data import BaseDataClass
@@ -11,6 +12,7 @@ from ulauncher.init_helpers import configure_logging, ensure_runtime_dirs
 from ulauncher.utils.lru_cache import lru_cache
 
 CommandName = Literal["show", "toggle", "start", "extensions", "install", "uninstall", "upgrade", "preview"]
+CommandGroupName = Literal["App", "Extension"]
 
 
 class CLIArguments(BaseDataClass):
@@ -33,9 +35,83 @@ class CLICommandArgument(BaseDataClass):
 class CLICommand(BaseDataClass):
     summary: str = ""  # one-line, shown in the master `ulauncher --help` listing
     description: str = ""  # longer sentence, shown at the top of `ulauncher <cmd> --help`
+    group: CommandGroupName
     aliases: tuple[str, ...] = ()
     arguments: tuple[CLICommandArgument, ...] = ()
     has_runtime: bool = True
+
+
+CLI_DESCRIPTION = (
+    "Ulauncher is a GTK application launcher with support for extensions, "
+    "shortcuts (scripts), calculator, file browser and custom themes."
+)
+
+
+class CLIHelpFormatter(argparse.HelpFormatter):
+    """Normalize argparse section titles used in the custom help output."""
+
+    def start_section(self, heading: str | None) -> None:
+        if heading in ("options", "optional arguments"):  # differs based on Python version
+            heading = "Options"
+        super().start_section(heading)
+
+
+class CLIArgumentParser(argparse.ArgumentParser):
+    """Render top-level help from explicit CLI metadata instead of parser internals."""
+
+    def __init__(self, *args: Any, version: str = "", **kwargs: Any) -> None:
+        super().__init__(*args, add_help=False, **kwargs)
+        # Will appear at the tail of the "App commands" section in --help. Do not add to this
+        # unless you know what you're doing -- Ulauncher's CLI is designed around "verbs" (e.g.
+        # `ulauncher show`) implemented as sub-parsers, with flags only at the sub-parser level.
+        self.help_option_actions: tuple[argparse.Action, ...] = (
+            self.add_argument("--version", action="version", help="Show version", version=version),
+            self.add_argument("-h", "--help", action="help", help="Show help"),
+            self.add_argument("-v", "--verbose", action="store_true", help="Use verbose logging"),
+        )
+
+    def format_help(self) -> str:
+        formatter = self.formatter_class(prog=self.prog)
+        formatter.add_usage(self.usage, (), (), prefix="Usage: ")
+        formatter.add_text(self.description)
+        _add_command_help_sections(formatter, self.help_option_actions)
+        formatter.add_text(self.epilog)
+
+        return formatter.format_help()
+
+
+def _get_command_help_action(command_name: CommandName, command: CLICommand) -> argparse.Action:
+    # Mirrors stdlib's argparse._SubParsersAction._ChoicesPseudoAction: an Action used purely
+    # as a data carrier for the help formatter, never dispatched at parse time.
+    label = command_name
+    if command.aliases:
+        label = f"{command_name} ({', '.join(command.aliases)})"
+
+    return argparse.Action([], command_name, help=command.summary, metavar=label)
+
+
+def _add_command_help_sections(
+    formatter: argparse.HelpFormatter,
+    help_option_actions: tuple[argparse.Action, ...] = (),
+) -> None:
+    commands = _get_commands()
+
+    for group_name in get_literal_args(CommandGroupName):
+        group_actions: list[argparse.Action] = [
+            _get_command_help_action(command_name, command)
+            for command_name, command in commands.items()
+            if command.group == group_name
+        ]
+        # --help/--version live with the App commands rather than in their own "Options" section:
+        # they're command-shaped (run once, print, exit) and there are no real options at the top level.
+        if group_name == "App":
+            group_actions.extend(help_option_actions)
+        if not group_actions:
+            continue
+
+        formatter.start_section(f"{group_name} commands")
+        formatter.add_arguments(group_actions)
+        formatter.end_section()
 
 
 @lru_cache(maxsize=None)
@@ -50,10 +126,12 @@ def _get_commands() -> dict[CommandName, CLICommand]:
         "start": CLICommand(
             summary="Start the Ulauncher background process",
             description="Start the Ulauncher background process",
+            group="App",
         ),
         "show": CLICommand(
             summary="Show the Ulauncher window (default command)",
             description="Show the Ulauncher window",
+            group="App",
             has_runtime=False,
             arguments=(
                 CLICommandArgument(
@@ -65,17 +143,20 @@ def _get_commands() -> dict[CommandName, CLICommand]:
         "toggle": CLICommand(
             summary="Toggle the Ulauncher window",
             description="Toggle the Ulauncher window",
+            group="App",
             has_runtime=False,
         ),
         "extensions": CLICommand(
             aliases=("e",),
             summary="List installed extensions",
             description="List all installed extensions with their status and information",
+            group="Extension",
         ),
         "install": CLICommand(
             aliases=("i",),
             summary="Install an extension from URL",
             description="Install an extension from a Git URL or local path",
+            group="Extension",
             arguments=(
                 CLICommandArgument(args=("input",), kwargs={"help": "Git URL or path of the extension to install"}),
             ),
@@ -84,12 +165,14 @@ def _get_commands() -> dict[CommandName, CLICommand]:
             aliases=("rm",),
             summary="Uninstall an extension",
             description="Remove an installed extension by ID or URL",
+            group="Extension",
             arguments=(CLICommandArgument(args=("input",), kwargs={"help": "Extension ID or URL to uninstall"}),),
         ),
         "upgrade": CLICommand(
             aliases=("up",),
             summary="Upgrade extensions",
             description="Upgrade one or all installed extensions to their latest versions",
+            group="Extension",
             arguments=(
                 CLICommandArgument(
                     args=("input",),
@@ -105,6 +188,7 @@ def _get_commands() -> dict[CommandName, CLICommand]:
             aliases=("pr",),
             summary="Preview extension",
             description="Starts extension from a local path for development and debugging purposes",
+            group="Extension",
             arguments=(
                 CLICommandArgument(
                     args=("--with-debugger",),
@@ -121,22 +205,20 @@ def _get_commands() -> dict[CommandName, CLICommand]:
 
 
 @lru_cache(maxsize=None)
-def _get_parser() -> argparse.ArgumentParser:
-    parser = argparse.ArgumentParser(
+def _get_parser() -> CLIArgumentParser:
+    parser = CLIArgumentParser(
         prog="ulauncher",  # override Python 3.14 argparse's `python3 -m ulauncher` auto-prog
         usage="%(prog)s [OPTIONS] [COMMAND]",
-        description="Ulauncher is a GTK application launcher with support for extensions, shortcuts (scripts), calculator, file browser and custom themes.",  # noqa: E501
-        add_help=False,
+        description=CLI_DESCRIPTION,
+        formatter_class=CLIHelpFormatter,
+        version=f"Ulauncher {version}",
     )
-    parser.add_argument("--version", action="version", help="Show version", version=f"Ulauncher {version}")
-    parser.add_argument("-h", "--help", action="help", help="Show help")
-    parser.add_argument("-v", "--verbose", action="store_true", help="Use verbose logging")
 
     subparsers = parser.add_subparsers(
-        title="commands",
-        description="Available commands",
+        parser_class=argparse.ArgumentParser,
         dest="command",
-        help="Command help",
+        # disable auto generated subparser help (we want to control how its rendered)
+        help=argparse.SUPPRESS,
     )
 
     for command_name, command in _get_commands().items():
@@ -145,6 +227,7 @@ def _get_parser() -> argparse.ArgumentParser:
             aliases=list(command.aliases),
             help=command.summary,
             description=command.description,
+            formatter_class=CLIHelpFormatter,
         )
         for argument in command.arguments:
             command_parser.add_argument(*argument.args, **argument.kwargs)
@@ -163,7 +246,7 @@ def run_command(args: CLIArguments) -> int:
     command = _get_commands()[args.command]
     if command.has_runtime:
         ensure_runtime_dirs()
-        configure_logging(verbose=args.verbose, use_app_logging=args.command == "start")
+        configure_logging(verbose=args.verbose, use_app_logging=command.group == "App")
     return _load_handler(args.command)(args)
 
 

--- a/ulauncher/cli/__init__.py
+++ b/ulauncher/cli/__init__.py
@@ -10,15 +10,16 @@ from ulauncher.data import BaseDataClass
 from ulauncher.init_helpers import configure_logging, ensure_runtime_dirs
 from ulauncher.utils.lru_cache import lru_cache
 
-CommandName = Literal["start", "extensions", "install", "uninstall", "upgrade", "preview"]
+CommandName = Literal["show", "toggle", "start", "extensions", "install", "uninstall", "upgrade", "preview"]
 
 
 class CLIArguments(BaseDataClass):
     verbose = False
     input = ""
     path = ""
+    query: str | None = None
     with_debugger = False
-    command: CommandName | None = None
+    command: CommandName = "show"
 
 
 CLICommandHandler = Callable[[CLIArguments], int]
@@ -34,6 +35,7 @@ class CLICommand(BaseDataClass):
     description: str = ""  # longer sentence, shown at the top of `ulauncher <cmd> --help`
     aliases: tuple[str, ...] = ()
     arguments: tuple[CLICommandArgument, ...] = ()
+    has_runtime: bool = True
 
 
 @lru_cache(maxsize=None)
@@ -48,6 +50,22 @@ def _get_commands() -> dict[CommandName, CLICommand]:
         "start": CLICommand(
             summary="Start the Ulauncher background process",
             description="Start the Ulauncher background process",
+        ),
+        "show": CLICommand(
+            summary="Show the Ulauncher window (default command)",
+            description="Show the Ulauncher window",
+            has_runtime=False,
+            arguments=(
+                CLICommandArgument(
+                    args=("query",),
+                    kwargs={"nargs": argparse.OPTIONAL, "default": None, "help": "Optional query to populate"},
+                ),
+            ),
+        ),
+        "toggle": CLICommand(
+            summary="Toggle the Ulauncher window",
+            description="Toggle the Ulauncher window",
+            has_runtime=False,
         ),
         "extensions": CLICommand(
             aliases=("e",),
@@ -105,6 +123,7 @@ def _get_commands() -> dict[CommandName, CLICommand]:
 @lru_cache(maxsize=None)
 def _get_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(
+        prog="ulauncher",  # override Python 3.14 argparse's `python3 -m ulauncher` auto-prog
         usage="%(prog)s [OPTIONS] [COMMAND]",
         description="Ulauncher is a GTK application launcher with support for extensions, shortcuts (scripts), calculator, file browser and custom themes.",  # noqa: E501
         add_help=False,
@@ -141,12 +160,16 @@ def _load_handler(command_name: str) -> CLICommandHandler:
 
 
 def run_command(args: CLIArguments) -> int:
-    ensure_runtime_dirs()
-    configure_logging(verbose=args.verbose, use_app_logging=args.command in (None, "start"))
-    return _load_handler(args.command or "start")(args)
+    command = _get_commands()[args.command]
+    if command.has_runtime:
+        ensure_runtime_dirs()
+        configure_logging(verbose=args.verbose, use_app_logging=args.command == "start")
+    return _load_handler(args.command)(args)
 
 
 def parse(input_args: list[str]) -> CLIArguments:
     """Parse CLI arguments"""
     args = _get_parser().parse_args(args=input_args)
-    return CLIArguments(**vars(args))
+    namespace = vars(args)
+    namespace["command"] = cast("CommandName", namespace["command"] or "show")
+    return CLIArguments(**namespace)

--- a/ulauncher/cli/commands/show.py
+++ b/ulauncher/cli/commands/show.py
@@ -1,0 +1,12 @@
+import os
+from typing import NoReturn
+
+from ulauncher.cli import CLIArguments
+
+
+def run(cli_args: CLIArguments) -> NoReturn:
+    if cli_args.query is not None:
+        escaped = cli_args.query.replace("\\", "\\\\").replace("'", "\\'")
+        os.execlp("gapplication", "gapplication", "action", "io.ulauncher.Ulauncher", "set-query", f"'{escaped}'")
+    else:
+        os.execlp("gapplication", "gapplication", "action", "io.ulauncher.Ulauncher", "show-window")

--- a/ulauncher/cli/commands/start.py
+++ b/ulauncher/cli/commands/start.py
@@ -75,6 +75,6 @@ def run(cli_args: CLIArguments) -> int:
     app = UlauncherApp()
 
     with contextlib.suppress(KeyboardInterrupt):
-        app.start(activate=not cli_args.daemon)
+        app.start(activate=cli_args.command is None)
 
     return 0

--- a/ulauncher/cli/commands/start.py
+++ b/ulauncher/cli/commands/start.py
@@ -8,7 +8,7 @@ from types import TracebackType
 from ulauncher.cli import CLIArguments
 
 
-def run(cli_args: CLIArguments) -> int:
+def run(_: CLIArguments) -> int:
     from ulauncher import init_helpers
 
     init_helpers.init_x11_threads()
@@ -75,6 +75,6 @@ def run(cli_args: CLIArguments) -> int:
     app = UlauncherApp()
 
     with contextlib.suppress(KeyboardInterrupt):
-        app.start(activate=cli_args.command is None)
+        app.start(activate=False)
 
     return 0

--- a/ulauncher/cli/commands/toggle.py
+++ b/ulauncher/cli/commands/toggle.py
@@ -1,0 +1,8 @@
+import os
+from typing import NoReturn
+
+from ulauncher.cli import CLIArguments
+
+
+def run(_: CLIArguments) -> NoReturn:
+    os.execlp("gapplication", "gapplication", "action", "io.ulauncher.Ulauncher", "toggle-window")

--- a/ulauncher/ui/app.py
+++ b/ulauncher/ui/app.py
@@ -28,7 +28,7 @@ class UlauncherApp(Gtk.Application):
     # new instances sends the signals to the registered one
     # So all methods except __init__ runs on the main app
     query = ""
-    # One-shot: set to True to make the next activation a no-op (e.g. for --daemon startup).
+    # One-shot: set to True to make the next activation a no-op.
     skip_next_activate: bool = False
     # Whether the app should keep running with no windows open. Set in setup() from the
     # systemd unit state (or keep_alive fallback) and kept in sync by toggle_hold().

--- a/ulauncher/ui/preferences/views/shortcuts.py
+++ b/ulauncher/ui/preferences/views/shortcuts.py
@@ -143,7 +143,7 @@ class ShortcutsView(views.BaseView):
                 "<b>Script shortcut example</b> (send notification)\n"
                 '<code>#!/bin/bash\nnotify-send "Notification" "$*"</code>\n\n'
                 "*1 Note that scripts must start with a shebang (<code>#!</code>)\n"
-                "*2 Run <code>ulauncher --verbose</code> to see any output from scripts"
+                "*2 Run <code>ulauncher start --verbose</code> to see any output from scripts"
             ),
             use_markup=True,
             halign=Gtk.Align.START,


### PR DESCRIPTION
Reshapes the `ulauncher` CLI around explicit subcommands and adds a shell fast-path for the hot paths (`show`, `toggle`).

### What changes

- **`start` replaces `--daemon`**: launching the long-running app is now `ulauncher start`. `--daemon` still work but emit a deprecation warning and forward to `start` (`--hide-window`, which is intentionally broken to neutralize stale XDG autostart entries).
- **`show` and `toggle` subcommands**: replaces the old D-Bus-via-Python path for window control and `ulauncher-toggle`. `ulauncher` with no args implicitly becomes `show`.
- **Shell fast-path**: `bin/ulauncher` is now a POSIX shell script that detects the empty/`show`/`toggle` cases and dispatches directly to `gapplication action` without spinning up Python. Anything else (or `-h`, `--version`, unknown flags) falls through to `python3 -m ulauncher` for the real parse/error. `bin/ulauncher-toggle` becomes a thin wrapper.
- **`--help` grouping**: top-level help groups commands by `App` vs `Extension` using a custom formatter driven from CLI metadata rather than argparse internals. `--help` / `--version` are rendered alongside App commands.
- **`--verbose` moved to subparsers**: only the subcommands that actually use it carry the flag. `get_args` re-sorts argv so the old global position still parses.
- Run-from-`__main__`: adds `ulauncher/__main__.py` so the shell wrapper can use `python3 -m ulauncher`. `ULAUNCHER_SYSTEM_PREFIX` is passed explicitly since `sys.argv[0]` no longer points at the install prefix in that mode.
- Service files (`io.ulauncher.Ulauncher.service`, `ulauncher.service`) updated to invoke `ulauncher start`.

`--help` output before PR:
<img width="1540" height="830" alt="image" src="https://github.com/user-attachments/assets/25dacfa9-0fa6-4ce4-9692-8e273abe7a64" />

`--help` output with PR:

<img width="1732" height="684" alt="image" src="https://github.com/user-attachments/assets/a82a9b58-0be1-42bc-853c-97ff2ccedf36" />



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reworked the `ulauncher` CLI around explicit subcommands, added a fast shell path for `show`/`toggle`, and made `start` replace `--daemon`. Bare `ulauncher` now runs `show`; services/systemd/Nix call `ulauncher start`; help is grouped and the manpage is cleaner.

- **New Features**
  - Added `start`, `show`, and `toggle`; bare `ulauncher` defaults to `show` and supports `show [query]`.
  - Fast path: `bin/ulauncher` execs `gapplication` for empty/`show`/`toggle` with GVariant-safe quoting; any flags or extra args defer to Python.
  - Help groups commands under App vs Extension; subcommand help is simpler; `--help`/`--version` appear with App commands; manpage headings normalized in `makefile`.
  - `--verbose` moved to subcommands; legacy position still parses; on `show`/`toggle` it warns and has no effect.
  - D-Bus/systemd services now run `ulauncher start`; tests cover fast path, help grouping, parser behavior, and verbose handling.
  - Nix: patch/wrap `bin/ulauncher` and `bin/ulauncher-toggle`; replace `gapplication` with absolute path; install checks use `start`.

- **Migration**
  - Use `ulauncher start` instead of `--daemon` or `--no-window` (it does not open the window).
  - `ulauncher-toggle` is deprecated; use `ulauncher toggle` or `ulauncher show "<text>"`.
  - `--verbose` is subcommand-only; it’s ignored (with a warning) on `show`/`toggle`.
  - Legacy flags (`--dev`, `--hide-window`, `--no-extensions`, `--no-window-shadow`, `--daemon`, `--no-window`) now warn; some exit with an error.

<sup>Written for commit de7da21695169c2d24cf3ef9ccdcf40ac7dfd9ef. Summary will update on new commits. <a href="https://cubic.dev/pr/Ulauncher/Ulauncher/pull/1725?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->





