### PR TITLE
fix(cli): escape and validate query in ulauncher-toggle

### DIFF
--- a/bin/ulauncher-toggle
+++ b/bin/ulauncher-toggle
@@ -8,7 +8,12 @@ do
   arg="$1"
   shift
   if [ "$arg" = "--query" ] || [ "$arg" = "-q" ]; then
-    gapplication action io.ulauncher.Ulauncher set-query "'$1'"
+    if [ "$#" -eq 0 ]; then
+      printf '%s\n' 'ulauncher-toggle: missing value for --query/-q' >&2
+      exit 2
+    fi
+    escaped_query=$(printf '%s' "$1" | sed -e 's/\\/\\\\/g' -e "s/'/\\\\'/g")
+    gapplication action io.ulauncher.Ulauncher set-query "'$escaped_query'"
     exit 0
   fi
 done


### PR DESCRIPTION
Pass the query through GVariant escaping, so values containing single quotes or backslashes are not misparsed, and fail loudly when --query/-q is given without a value instead of sending an empty query.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Escape and validate the `--query`/`-q` argument in `ulauncher-toggle` to prevent GVariant misparsing and avoid sending empty queries. Queries with single quotes or backslashes now work, and the command fails fast when a value is missing.

- **Bug Fixes**
  - Escape single quotes and backslashes before calling `gapplication` (`io.ulauncher.Ulauncher set-query`).
  - Print an error and exit with code 2 when `--query`/`-q` is provided without a value.

<sup>Written for commit 365103fd25b52e0e774aec97b12795bcd32b4e17. Summary will update on new commits. <a href="https://cubic.dev/pr/Ulauncher/Ulauncher/pull/1727?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

