### PR TITLE
refactor(cli): move legacy flag handling to bin/ulauncher

### DIFF
--- a/bin/ulauncher
+++ b/bin/ulauncher
@@ -10,6 +10,27 @@ print_color() {
   fi
 }
 
+# Rewrite legacy flags before handing argv to python. Direct `python -m ulauncher`
+# invocations bypass this and get argparse's "unrecognized arguments" error instead.
+orig_count=$#
+walked=0
+while [ "$walked" -lt "$orig_count" ]; do
+  arg=$1; shift; walked=$((walked + 1))
+  case "$arg" in
+    --hide-window)
+      print_color 33 "The --hide-window argument has been removed (use --daemon)"; exit 2 ;;
+    --no-extensions)
+      print_color 33 "The --no-extensions argument has been removed (see --help for available commands)"; exit 2 ;;
+    --no-window-shadow)
+      print_color 33 "The --no-window-shadow argument has been removed (configure via the Window shadow size setting in preferences)"; exit 2 ;;
+    --dev)
+      print_color 33 "The --dev argument has been removed (use --verbose)"; set -- "$@" --verbose ;;
+    --no-window)
+      print_color 33 "The --no-window argument has been removed (use --daemon)"; set -- "$@" --daemon ;;
+    *) set -- "$@" "$arg" ;;
+  esac
+done
+
 SCRIPT_PATH=$(readlink -f "$0")
 PROJECT_ROOT=$(dirname "$(dirname "$SCRIPT_PATH")")
 

--- a/tests/test_bin_ulauncher.py
+++ b/tests/test_bin_ulauncher.py
@@ -1,0 +1,50 @@
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+BIN_ULAUNCHER = REPO_ROOT / "bin/ulauncher"
+
+
+@pytest.mark.parametrize(
+    ("flag", "hint"),
+    [
+        ("--hide-window", "use --daemon"),
+        ("--no-extensions", "see --help for available commands"),
+        ("--no-window-shadow", "the Window shadow size setting"),
+    ],
+)
+def test_legacy_terminal_flags_exit_without_python(flag: str, hint: str) -> None:
+    result = subprocess.run([str(BIN_ULAUNCHER), flag], capture_output=True, text=True, check=False)
+    assert result.returncode == 2
+    assert flag in result.stderr
+    assert hint in result.stderr
+    assert result.stdout == ""
+
+
+@pytest.mark.parametrize(
+    ("legacy", "replacement"),
+    [
+        ("--dev", "--verbose"),
+        ("--no-window", "--daemon"),
+    ],
+)
+def test_legacy_rewrite_flags_substitute_and_warn(legacy: str, replacement: str, tmp_path: Path) -> None:
+    # Stub `python3` to record argv and exit; that lets us assert what the wrapper hands to python.
+    log_path = tmp_path / "python.log"
+    stub = tmp_path / "python3"
+    stub.write_text(f"#!/bin/sh\nprintf '%s\\n' \"$@\" > {log_path}\n", encoding="utf-8")
+    stub.chmod(0o755)
+
+    env = {"PATH": f"{tmp_path}:/usr/bin:/bin"}
+    result = subprocess.run([str(BIN_ULAUNCHER), legacy], capture_output=True, text=True, env=env, check=False)
+
+    assert legacy in result.stderr
+    forwarded = log_path.read_text(encoding="utf-8").splitlines()
+    assert "-m" in forwarded
+    assert "ulauncher" in forwarded
+    assert replacement in forwarded
+    assert legacy not in forwarded

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -74,55 +74,6 @@ class TestCLIParse:
         assert captured.out == ""
         assert captured.err == ""
 
-    @pytest.mark.parametrize(
-        ("input_args", "expected_attrs", "removed_attr", "stderr_substring"),
-        [
-            pytest.param(
-                ["--no-window"], {"command": None, "daemon": True}, "no_window", "use --daemon", id="no-window"
-            ),
-            pytest.param(["--dev"], {"command": None, "verbose": True}, "dev", "use --verbose", id="dev"),
-        ],
-    )
-    def test_parse_legacy_argument_shims(
-        self,
-        input_args: list[str],
-        expected_attrs: dict[str, object],
-        removed_attr: str,
-        stderr_substring: str,
-        capsys: pytest.CaptureFixture[str],
-    ) -> None:
-        args = cli.parse(input_args)
-
-        assert_cli_args(args, expected_attrs)
-        assert not hasattr(args, removed_attr)
-
-        captured = capsys.readouterr()
-        assert captured.out == ""
-        assert stderr_substring in captured.err
-
-    @pytest.mark.parametrize(
-        ("input_args", "stderr_substring"),
-        [
-            pytest.param(["--hide-window"], "use --daemon", id="hide-window"),
-            pytest.param(["--no-extensions"], "see --help for available commands", id="no-extensions"),
-            pytest.param(["--no-window-shadow"], "the Window shadow size setting", id="no-window-shadow"),
-        ],
-    )
-    def test_parse_errors(
-        self,
-        input_args: list[str],
-        stderr_substring: str,
-        capsys: pytest.CaptureFixture[str],
-    ) -> None:
-        with pytest.raises(SystemExit) as exc_info:
-            cli.parse(input_args)
-
-        assert exc_info.value.code == 2
-
-        captured = capsys.readouterr()
-        assert captured.out == ""
-        assert stderr_substring in captured.err
-
 
 class TestCLIRunCommand:
     def test_run_command_dispatches_default_app_handler(self, mocker: MockerFixture) -> None:

--- a/ulauncher/cli/__init__.py
+++ b/ulauncher/cli/__init__.py
@@ -10,15 +10,6 @@ from ulauncher.data import BaseDataClass
 from ulauncher.init_helpers import configure_logging, ensure_runtime_dirs
 from ulauncher.utils.lru_cache import lru_cache
 
-_LEGACY_ARGS: dict[str, tuple[str | None, str]] = {
-    "dev": ("verbose", "use --verbose"),
-    "no_window": ("daemon", "use --daemon"),
-    # intentionally break hide_window to prevent legacy XDG autostart entries from starting
-    "hide_window": (None, "use --daemon"),
-    "no_extensions": (None, "see --help for available commands"),
-    "no_window_shadow": (None, "configure via the Window shadow size setting in preferences"),
-}
-
 CommandName = Literal["extensions", "install", "uninstall", "upgrade", "preview"]
 
 
@@ -129,12 +120,6 @@ def _get_parser() -> argparse.ArgumentParser:
         action="store_true",
         help="Run Ulauncher as a background process, without initially showing the window",
     )
-    # deprecated
-    parser.add_argument("--dev", action="store_true", help=argparse.SUPPRESS)
-    parser.add_argument("--hide-window", action="store_true", help=argparse.SUPPRESS)
-    parser.add_argument("--no-extensions", action="store_true", help=argparse.SUPPRESS)
-    parser.add_argument("--no-window", action="store_true", help=argparse.SUPPRESS)
-    parser.add_argument("--no-window-shadow", action="store_true", help=argparse.SUPPRESS)
 
     subparsers = parser.add_subparsers(
         title="commands",
@@ -177,20 +162,5 @@ def run_command(args: CLIArguments) -> int:
 
 def parse(input_args: list[str]) -> CLIArguments:
     """Parse CLI arguments"""
-    parser = _get_parser()
-
-    args = parser.parse_args(args=input_args)
-    namespace = vars(args)
-
-    for legacy_arg, (shim, hint) in _LEGACY_ARGS.items():
-        if namespace.pop(legacy_arg, False):
-            msg = f"The --{legacy_arg.replace('_', '-')} argument has been removed ({hint})"
-            if sys.stderr.isatty():
-                msg = f"\033[33m{msg}\033[0m"
-            sys.stderr.write(f"{msg}\n")
-            if shim:
-                namespace[shim] = True
-            else:
-                sys.exit(2)
-
-    return CLIArguments(**namespace)
+    args = _get_parser().parse_args(args=input_args)
+    return CLIArguments(**vars(args))


### PR DESCRIPTION
Walk argv in the shell wrapper before invoking python: substitute --dev to --verbose and --no-window to --daemon (with a stderr warning), and exit 2 with a stderr warning for --hide-window / --no-extensions / --no-window-shadow. The python-side _LEGACY_ARGS dict, _apply_legacy_rewrites, _emit_warning, and the suppressed argparse entries for the removed flags are all gone.

Direct \`python -m ulauncher --dev\` (etc.) now produces argparse's standard "unrecognized arguments" error; the user-facing launcher script preserves the prior behavior end to end.

Tests for the legacy shims move to tests/test_bin_ulauncher.py, which exercises the wrapper via subprocess.

This effectively won't matter a lot yet but:
1. The fatal legacy flag error are now faster since they won't load Python. Not a huge benefit though.
2. The code to handle this in the shell script is less bloated and easier to maintain than Python's argparse.
3. Most importantly: This change is needed for later  performance improvements (moving the `ulauncher-toggle` functionality into the main binary, but aligning with/supporting the main binary cli and flags).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Moved legacy CLI flag handling from Python argparse to the `bin/ulauncher` wrapper. Preserves user-facing warnings and rewrites, simplifies the Python CLI, and exits earlier on removed flags.

- **Refactors**
  - Rewrite legacy flags in shell: `--dev` → `--verbose`, `--no-window` → `--daemon`; exit 2 with warnings for `--hide-window`, `--no-extensions`, `--no-window-shadow`.
  - Remove legacy shims and suppressed argparse entries from `ulauncher/cli`.
  - Add `tests/test_bin_ulauncher.py` (subprocess-based); drop legacy parsing tests from `tests/test_cli.py`.

- **Migration**
  - If calling `python -m ulauncher`, use `--verbose` instead of `--dev` and `--daemon` instead of `--no-window`.
  - `--hide-window`, `--no-extensions`, and `--no-window-shadow` now error with code 2; use `--daemon`, `--help`, or preferences as applicable.
  - Prefer invoking via `bin/ulauncher` to keep legacy warnings and rewrites.

<sup>Written for commit 066776889825a1413c2d9ce845af7f75d9ca04e8. Summary will update on new commits. <a href="https://cubic.dev/pr/Ulauncher/Ulauncher/pull/1728?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

