### PR TITLE
feat(perf): add performance check make targets

### DIFF
--- a/makefile
+++ b/makefile
@@ -128,7 +128,7 @@ run-container:
 
 #=Lint/test Commands
 
-.PHONY: check lint format check-container check-all pyrefly ruff rumdl typos pytest
+.PHONY: check lint format check-container check-all pyrefly ruff rumdl typos pytest perf perf-compare
 
 # Run all linters
 lint: venv typos ruff pyrefly rumdl
@@ -174,6 +174,68 @@ pytest: venv
 		echo -e "xvfb-run detected. Running pytest in a virtual X server environment."
 		xvfb-run --auto-servernum -- pytest -p no:cacheprovider $(PYTEST_ARGS) tests
 	fi
+
+# Print the median first-draw time (in ms) across $$ITERATIONS runs of `bin/ulauncher start`.
+# Drives the probe in ulauncher/ui/ulauncher_window.py (gated on ULAUNCHER_PERF_START_BOOTTIME,
+# so this has zero effect on normal runs). DBUS_SESSION_BUS_ADDRESS=disabled: forces
+# GApplication into local-only mode so the test doesn't collide with a developer's running
+# ulauncher daemon, and sidesteps the xdg-desktop-portal / a11y activation storm that
+# `dbus-run-session` triggers on Wayland. Override with `make perf ITERATIONS=N`.
+perf:
+	@set -euo pipefail
+	root=$${ULAUNCHER_PERF_REPO_ROOT:-.}
+	iterations=$${ITERATIONS:-5}
+	samples=""
+	for _ in $$(seq 1 $$iterations); do
+		# Captured as late as possible (right before exec) so the measurement window matches
+		# what a hotkey-triggered dbus activation would see.
+		read -r t0 _ < /proc/uptime
+		# cd into the target checkout: `python -m ulauncher` (invoked by bin/ulauncher)
+		# prepends '' to sys.path BEFORE the PYTHONPATH the wrapper exports, so cwd decides
+		# which ulauncher package gets imported. Without this, perf-compare would silently
+		# import the current branch's code for both runs. `timeout` surfaces a missing probe
+		# (e.g. comparing against a base older than this commit) as a clear failure.
+		# `|| true` so a probe-less binary (the timeout path) reaches the diagnostic below
+		# instead of failing silently via set -e on the assignment's non-zero exit.
+		output=$$(cd "$$root" && DBUS_SESSION_BUS_ADDRESS=disabled: ULAUNCHER_PERF_START_BOOTTIME=$$t0 timeout 30 ./bin/ulauncher start 2>&1) || true
+		ms=$$(printf '%s\n' "$$output" | awk -F= '/^ULAUNCHER_PERF first_draw_ms=/ {print $$2; exit}')
+		if [ -z "$$ms" ]; then echo "probe output not found (likely missing in $$root); last subprocess output:" >&2; printf '%s\n' "$$output" >&2; exit 1; fi
+		samples+="$$ms"$$'\n'
+	done
+	printf '%s' "$$samples" | sort -n | awk -v n=$$iterations '
+		{ a[NR] = $$1 }
+		END {
+			if (n % 2 == 1) printf "%.1f\n", a[(n + 1) / 2]
+			else printf "%.1f\n", (a[n/2] + a[n/2+1]) / 2
+		}'
+
+# Run `make perf` against BASE (default main) in a temporary worktree, then again here;
+# reports the delta. Honors ITERATIONS like `make perf`.
+perf-compare:
+	@set -euo pipefail
+	base=$${BASE:-main}
+	current=$$(git rev-parse --abbrev-ref HEAD)
+	if [ "$$current" = "$$base" ]; then
+		echo "Currently on $$base; check out the branch to compare first."
+		exit 1
+	fi
+	# Per-sample variance on this benchmark is large (single runs span 30%+ of the median),
+	# so a pairwise comparison needs more samples than the standalone `make perf` ballpark.
+	# 20 keeps each side under ~6s while pulling the noise floor to ~2-3%; deltas under ~5%
+	# should still be treated as noise without rerunning. Override with `ITERATIONS=...`.
+	export ITERATIONS=$${ITERATIONS:-20}
+	worktree=$$(mktemp -d)
+	trap "git worktree remove --force $$worktree 2>/dev/null || true; rm -rf $$worktree" EXIT
+	git worktree add --quiet --detach "$$worktree" "$$base"
+
+	# ULAUNCHER_PERF_REPO_ROOT redirects the inline `perf` recipe at the worktree's checkout
+	# so the same measurement code runs against both sides even when base predates this target.
+	base_ms=$$(ULAUNCHER_PERF_REPO_ROOT="$$worktree" $(MAKE) -s perf)
+	current_ms=$$($(MAKE) -s perf)
+	awk -v b="$$base_ms" -v c="$$current_ms" -v bn="$$base" -v cn="$$current" 'BEGIN {
+		d = c - b; p = d / b * 100; w = (d > 0) ? "slower" : "faster"
+		printf "[%s] %.1fms\n[%s] %.1fms\ndelta: %+.1fms (%+.1f%%, %s)\n", bn, b, cn, c, d, p, w
+	}'
 
 # Auto format the code
 format: venv

--- a/ulauncher/cli/commands/start.py
+++ b/ulauncher/cli/commands/start.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import contextlib
 import logging
+import os
 import sys
 from types import TracebackType
 
@@ -73,6 +74,15 @@ def run(_: CLIArguments) -> int:
     v5_to_v6()
 
     app = UlauncherApp()
+
+    # Perf-test probe (see UlauncherWindow.on_initial_draw): when ULAUNCHER_PERF_START_BOOTTIME
+    # is set, schedule the launcher to open as soon as the main loop is idle so the probe can
+    # measure cold-start to first input. Without this, `ulauncher start` would register as a
+    # daemon and idle until an external D-Bus activation arrived.
+    if os.environ.get("ULAUNCHER_PERF_START_BOOTTIME"):
+        from ulauncher.gi import GLib
+
+        GLib.idle_add(app.show_launcher)
 
     with contextlib.suppress(KeyboardInterrupt):
         app.start(activate=False)

--- a/ulauncher/ui/ulauncher_window.py
+++ b/ulauncher/ui/ulauncher_window.py
@@ -1,6 +1,9 @@
 from __future__ import annotations
 
 import logging
+import os
+import sys
+import time
 from typing import Any, Iterable
 
 from gi.repository import Gdk, Gtk
@@ -213,6 +216,16 @@ class UlauncherWindow(Gtk.ApplicationWindow):
     ######################################
 
     def on_initial_draw(self, *_: tuple[Any]) -> None:
+        # ULAUNCHER_PERF_START_BOOTTIME is a perf-test probe (see tests/perf/test_startup_perf.py).
+        # When set, report elapsed time from the caller's externally-captured /proc/uptime and
+        # exit before deferred_init - this is the earliest point at which keyboard input registers.
+        if t0 := os.environ.get("ULAUNCHER_PERF_START_BOOTTIME"):
+            elapsed_ms = (time.clock_gettime(time.CLOCK_BOOTTIME) - float(t0)) * 1000
+            sys.stdout.write(f"ULAUNCHER_PERF first_draw_ms={elapsed_ms:.2f}\n")
+            sys.stdout.flush()
+            if app := self.get_application():
+                app.quit()
+            return
         logger.info("Window shown")
         self.disconnect_by_func(self.on_initial_draw)
         GLib.idle_add(self.deferred_init)


### PR DESCRIPTION
`make perf` runs bin/ulauncher N times (default 5) and prints the median time to UlauncherWindow.on_initial_draw - the earliest point at which the launcher window accepts keyboard input. `make perf-compare` runs the same against a worktree at BASE (default main) and reports the delta against the current branch.

The shipped probe in on_initial_draw and the idle_add hook in `ulauncher start` are both gated on ULAUNCHER_PERF_START_BOOTTIME, so normal runs are unaffected. DBUS_SESSION_BUS_ADDRESS=disabled: forces GApplication into local-only mode in the benchmark so it does not collide with a developer's running ulauncher daemon and sidesteps the xdg-desktop-portal / a11y activation storm that dbus-run-session triggers on Wayland.

5 iterations (the standalone `make perf` ballpark) is far too noisy for pairwise comparison -- single-sample variance routinely spans 30% of the median, so 5-sample medians can disagree by 10%+ run-to-run on identical code. 20 keeps each side under ~6s but pulls the comparison's noise floor into the ~2-3% range, which is the practical minimum for spotting real regressions.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add `make perf` and `make perf-compare` to measure cold-start time to first input (time to `UlauncherWindow.on_initial_draw`). Adds a gated startup probe; normal runs are unchanged.

- **New Features**
  - `make perf`: runs `bin/ulauncher start` N times (default 5) and prints the median ms to first draw/input.
  - `make perf-compare`: benchmarks `BASE` (default `main`) in a temporary worktree vs the current branch; prints delta and percent. Defaults to 20 iterations to reduce noise; override with `ITERATIONS=N`.
  - Probe: when `ULAUNCHER_PERF_START_BOOTTIME` is set, `on_initial_draw` outputs `ULAUNCHER_PERF first_draw_ms=<ms>` and exits; `start` schedules `show_launcher` via `GLib.idle_add` to trigger the measurement.
  - Isolation: sets `DBUS_SESSION_BUS_ADDRESS=disabled:` so the app runs in local-only mode and avoids D-Bus/portal side effects during the benchmark.

<sup>Written for commit 9a2d88115c1e69d58acb059f6919d759a459b9af. Summary will update on new commits. <a href="https://cubic.dev/pr/Ulauncher/Ulauncher/pull/1729?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

