### PR TITLE
perf: defer loading PreferencesWindow

### DIFF
--- a/ulauncher/ui/app.py
+++ b/ulauncher/ui/app.py
@@ -13,7 +13,6 @@ import ulauncher
 from ulauncher import app_id, first_run
 from ulauncher.gi import Gio, GLib
 from ulauncher.internals.result import Result
-from ulauncher.ui.preferences.preferences_window import PreferencesWindow
 from ulauncher.ui.ulauncher_window import UlauncherWindow
 from ulauncher.utils.eventbus import EventBus
 from ulauncher.utils.settings import Settings
@@ -191,6 +190,8 @@ class UlauncherApp(Gtk.Application):
     def show_preferences(self, page: str | None = None) -> None:
         # Register prefs in self.windows before closing main, so the main destroy handler
         # sees a remaining window and doesn't quit the app on non-persistent setups.
+        from ulauncher.ui.preferences.preferences_window import PreferencesWindow
+
         preferences = cast("PreferencesWindow | None", self.windows.get("preferences"))
         if preferences and preferences.get_window() is None:
             logger.warning("Ignoring stale Preferences window reference (suspecting a memory leak)")


### PR DESCRIPTION
Should give  very small upstart perf benefit (the perf workflow might not even recognize it because it's just on the treshold).

Update: all three of the runs have to give a bigger than 5% perf benefit for it to show - so it was very close.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Defer loading the Preferences window until it’s opened to reduce startup overhead. Moves the `PreferencesWindow` import into `show_preferences()`, so the preferences UI code isn’t loaded during app init.

<sup>Written for commit 2016573d63c39559267b74254630b0ba9632b26a. Summary will update on new commits. <a href="https://cubic.dev/pr/Ulauncher/Ulauncher/pull/1731?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

