### PR TITLE
refactor(ext-remote): rewrite usings Gio.Subprocess

### DIFF
--- a/tests/modes/apps/extensions/test_extension_remote.py
+++ b/tests/modes/apps/extensions/test_extension_remote.py
@@ -1,14 +1,20 @@
+from __future__ import annotations
+
+import subprocess
+from typing import Any, Callable
 from unittest.mock import MagicMock, patch
 
 import pytest
 
+from ulauncher import api_version
 from ulauncher.modes.extensions import ext_exceptions
 from ulauncher.modes.extensions.extension_remote import (
     ExtensionRemote,
     parse_extension_url,
 )
 
-# @todo: Add missing coverage for _get_refs, get_compatible_hash, download
+# @todo: remaining uncovered paths: the no-git HTTP info/refs fallback, the fetch/clone
+# failure before ls-remote, and download() resolving the hash itself (no commit_hash given).
 
 
 class TestExtensionRemote:
@@ -97,3 +103,97 @@ class TestParseExtensionUrl:
         assert parse_extension_url("https://github.com/user/repo/tree/HEAD").ext_id == "com.github.user.repo"
         assert parse_extension_url("https://gitlab.com/user/repo.git").ext_id == "com.gitlab.user.repo"
         assert parse_extension_url("https://other.host/a/b/c/d").ext_id == "host.other.a.b.c.d"
+
+
+def _call(start: Callable[[Callable[[Any, Exception | None], None]], None]) -> tuple[Any, Exception | None]:
+    """Invoke a callback-based method whose mocked dependencies fire synchronously."""
+    box: dict[str, Any] = {}
+    start(lambda result, error: box.update(result=result, error=error))
+    return box.get("result"), box.get("error")
+
+
+class TestGetCompatibleHash:
+    @patch("ulauncher.modes.extensions.extension_remote.which", return_value="/usr/bin/git")
+    @patch("ulauncher.modes.extensions.extension_remote.isdir", return_value=True)
+    @patch("ulauncher.modes.extensions.extension_remote.run_command")
+    def test_returns_compatible_apiv_ref(self, mock_run: MagicMock, *_: Any) -> None:
+        ls_remote_output = f"def456\trefs/heads/apiv{api_version}\nabc123\tHEAD\n"
+
+        def side_effect(cmd: list[str], callback: Callable[[Any, Any], None], **_kw: Any) -> None:
+            callback(ls_remote_output if "ls-remote" in cmd else "", None)
+
+        mock_run.side_effect = side_effect
+        remote = ExtensionRemote("https://github.com/user/repo")
+        result, error = _call(remote.get_compatible_hash)
+        assert error is None
+        assert result == "def456"
+
+    @patch("ulauncher.modes.extensions.extension_remote.which", return_value="/usr/bin/git")
+    @patch("ulauncher.modes.extensions.extension_remote.isdir", return_value=True)
+    @patch("ulauncher.modes.extensions.extension_remote.run_command")
+    def test_maps_command_failure_to_network_error(self, mock_run: MagicMock, *_: Any) -> None:
+        def side_effect(cmd: list[str], callback: Callable[[Any, Any], None], **_kw: Any) -> None:
+            if "ls-remote" in cmd:
+                callback(None, subprocess.CalledProcessError(128, cmd))
+            else:
+                callback("", None)
+
+        mock_run.side_effect = side_effect
+        remote = ExtensionRemote("https://github.com/user/repo")
+        result, error = _call(remote.get_compatible_hash)
+        assert result is None
+        assert isinstance(error, ext_exceptions.NetworkError)
+
+
+class TestDownload:
+    @patch("ulauncher.modes.extensions.extension_remote.which", return_value="/usr/bin/git")
+    @patch("ulauncher.modes.extensions.extension_remote.os.makedirs")
+    @patch("ulauncher.modes.extensions.extension_remote.run_command")
+    def test_git_checkout_path_returns_hash_and_timestamp(self, mock_run: MagicMock, *_: Any) -> None:
+        def side_effect(cmd: list[str], callback: Callable[[Any, Any], None], **_kw: Any) -> None:
+            callback("1700000000\n" if "show" in cmd else "", None)
+
+        mock_run.side_effect = side_effect
+        # example.com has no download_url_template, so download() takes the git checkout path
+        remote = ExtensionRemote("https://example.com/user/repo")
+        result, error = _call(lambda cb: remote.download(cb, commit_hash="abc123"))
+        assert error is None
+        assert result == ("abc123", 1700000000.0)
+
+    @patch("ulauncher.modes.extensions.extension_remote.download_file")
+    def test_download_failure_maps_to_remote_error(self, mock_download: MagicMock) -> None:
+        def side_effect(_url: str, _dest: str, callback: Callable[[Any, Any], None]) -> None:
+            callback(None, OSError("boom"))
+
+        mock_download.side_effect = side_effect
+        remote = ExtensionRemote("https://github.com/user/repo")
+        result, error = _call(lambda cb: remote.download(cb, commit_hash="abc123"))
+        assert result is None
+        assert isinstance(error, ext_exceptions.RemoteError)
+
+    @patch("ulauncher.modes.extensions.extension_remote.which", return_value="/usr/bin/git")
+    @patch("ulauncher.modes.extensions.extension_remote.os.makedirs")
+    @patch("ulauncher.modes.extensions.extension_remote.run_command")
+    def test_unparsable_commit_timestamp_maps_to_remote_error(self, mock_run: MagicMock, *_: Any) -> None:
+        # A raw ValueError from float() would otherwise escape the Gio callback and hang the bridge.
+        def side_effect(cmd: list[str], callback: Callable[[Any, Any], None], **_kw: Any) -> None:
+            callback("not-a-timestamp" if "show" in cmd else "", None)
+
+        mock_run.side_effect = side_effect
+        remote = ExtensionRemote("https://example.com/user/repo")
+        result, error = _call(lambda cb: remote.download(cb, commit_hash="abc123"))
+        assert result is None
+        assert isinstance(error, ext_exceptions.RemoteError)
+
+    @patch("ulauncher.modes.extensions.extension_remote.untar", side_effect=OSError("disk full"))
+    @patch("ulauncher.modes.extensions.extension_remote.download_file")
+    def test_install_oserror_maps_to_remote_error(self, mock_download: MagicMock, *_: Any) -> None:
+        # A raw OSError from the filesystem install steps must be mapped, not escape the callback.
+        def side_effect(_url: str, _dest: str, callback: Callable[[Any, Any], None]) -> None:
+            callback(_dest, None)
+
+        mock_download.side_effect = side_effect
+        remote = ExtensionRemote("https://github.com/user/repo")
+        result, error = _call(lambda cb: remote.download(cb, commit_hash="abc123"))
+        assert result is None
+        assert isinstance(error, ext_exceptions.RemoteError)

--- a/tests/utils/test_socket_msg_controller.py
+++ b/tests/utils/test_socket_msg_controller.py
@@ -1,8 +1,9 @@
 from __future__ import annotations
 
+import contextlib
 import json
 import socket
-from typing import Any
+from typing import Any, Generator
 from unittest.mock import Mock
 
 import pytest
@@ -25,15 +26,30 @@ def process_pending_events(iterations: int = 10) -> None:
 
 
 @pytest.fixture
-def socket_pair() -> tuple[socket.socket, socket.socket]:
-    return socket.socketpair(socket.AF_UNIX, socket.SOCK_STREAM)
+def socket_pair() -> Generator[tuple[socket.socket, socket.socket], None, None]:
+    parent, child = socket.socketpair(socket.AF_UNIX, socket.SOCK_STREAM)
+    yield parent, child
+    # Suppress errors: tests or the controller may already have closed these fds.
+    with contextlib.suppress(OSError):
+        parent.close()
+    with contextlib.suppress(OSError):
+        child.close()
 
 
 @pytest.fixture
-def controller_pair(socket_pair: tuple[socket.socket, socket.socket]) -> tuple[SocketMsgController, socket.socket]:
+def controller_pair(
+    socket_pair: tuple[socket.socket, socket.socket],
+) -> Generator[tuple[SocketMsgController, socket.socket], None, None]:
     parent, child = socket_pair
     controller = SocketMsgController(parent.fileno())
-    return controller, child
+    yield controller, child
+    # Close child first so any pending read_line_async gets EOF and stops re-queuing.
+    with contextlib.suppress(OSError):
+        child.close()
+    controller.close()
+    # Drain pending GLib I/O callbacks so the fd watch is removed before new tests
+    # allocate fds that might reuse the same fd numbers.
+    process_pending_events()
 
 
 class TestSocketMsgController:

--- a/tests/utils/test_subprocess_utils.py
+++ b/tests/utils/test_subprocess_utils.py
@@ -1,0 +1,53 @@
+from __future__ import annotations
+
+import subprocess
+import sys
+from typing import Any, Callable
+
+from ulauncher.gi import GLib
+from ulauncher.utils.subprocess_utils import run_command
+
+
+def _drive(
+    start: Callable[[Callable[[Any, Exception | None], None]], None], timeout_ms: int = 10000
+) -> tuple[Any, Exception | None]:
+    """Run a callback-based helper to completion under a private GLib main loop."""
+    box: dict[str, Any] = {}
+    loop = GLib.MainLoop()
+
+    def done(result: Any, error: Exception | None) -> None:
+        box["result"], box["error"] = result, error
+        loop.quit()
+
+    def on_timeout() -> bool:
+        box["timeout"] = True
+        loop.quit()
+        return False
+
+    source_id = GLib.timeout_add(timeout_ms, on_timeout)
+    start(done)
+    loop.run()
+    timed_out = "timeout" in box
+    if not timed_out:
+        GLib.source_remove(source_id)
+    assert not timed_out, "callback did not fire before timeout"
+    return box["result"], box["error"]
+
+
+def test_run_command_success() -> None:
+    result, error = _drive(lambda cb: run_command([sys.executable, "-c", "print('hello')"], cb))
+    assert error is None
+    assert result.strip() == "hello"
+
+
+def test_run_command_nonzero_exit() -> None:
+    result, error = _drive(lambda cb: run_command([sys.executable, "-c", "import sys; sys.exit(3)"], cb))
+    assert result is None
+    assert isinstance(error, subprocess.CalledProcessError)
+    assert error.returncode == 3
+
+
+def test_run_command_spawn_failure() -> None:
+    result, error = _drive(lambda cb: run_command(["definitely-not-a-real-binary-xyz"], cb))
+    assert result is None
+    assert isinstance(error, GLib.Error)

--- a/tests/utils/test_subprocess_utils.py
+++ b/tests/utils/test_subprocess_utils.py
@@ -2,10 +2,11 @@ from __future__ import annotations
 
 import subprocess
 import sys
+from pathlib import Path
 from typing import Any, Callable
 
 from ulauncher.gi import GLib
-from ulauncher.utils.subprocess_utils import run_command
+from ulauncher.utils.subprocess_utils import download_file, run_command
 
 
 def _drive(
@@ -51,3 +52,20 @@ def test_run_command_spawn_failure() -> None:
     result, error = _drive(lambda cb: run_command(["definitely-not-a-real-binary-xyz"], cb))
     assert result is None
     assert isinstance(error, GLib.Error)
+
+
+def test_download_file_success(tmp_path: Path) -> None:
+    src = tmp_path / "src.txt"
+    src.write_text("payload")
+    dest = tmp_path / "out.txt"
+    result, error = _drive(lambda cb: download_file(src.as_uri(), str(dest), cb))
+    assert error is None
+    assert result == str(dest)
+    assert dest.read_text() == "payload"
+
+
+def test_download_file_failure(tmp_path: Path) -> None:
+    dest = tmp_path / "out.txt"
+    result, error = _drive(lambda cb: download_file("file:///nonexistent/nope.txt", str(dest), cb))
+    assert result is None
+    assert error is not None

--- a/ulauncher/modes/extensions/extension_controller.py
+++ b/ulauncher/modes/extensions/extension_controller.py
@@ -68,6 +68,37 @@ stopped_listeners: dict[str, list[Callable[[], None]]] = defaultdict(list)
 events = EventBus()
 
 
+def _run_gio_blocking(start: Callable[[Callable[[Any, Any], None]], None]) -> Any:
+    """Drive a callback-based Gio operation to completion synchronously on the calling thread.
+
+    Temporary bridge for step one of the asyncio/threading removal: extension_remote is now
+    callback-based, but ExtensionController is still async and runs in worker threads (ext_handlers)
+    or the CLI's asyncio loop. Gio.Subprocess callbacks dispatch on a GLib main context, not the
+    asyncio loop, and no GLib loop runs in those threads, so a plain asyncio.Future shim would
+    never resolve. Running a private GLib main loop (pushed as the thread-default context) drives
+    the operation to completion. Remove this when the controller becomes callback-native.
+    """
+    context = GLib.MainContext.new()
+    context.push_thread_default()
+    box: dict[str, Any] = {}
+    try:
+        loop = GLib.MainLoop.new(context, False)
+
+        def done(result: Any, error: Exception | None) -> None:
+            box["result"], box["error"] = result, error
+            loop.quit()
+
+        start(done)
+        loop.run()
+    finally:
+        # Always restore the thread-default context, even if start() raises synchronously
+        # (a synchronous raise propagates to the caller, matching the pre-conversion behavior).
+        context.pop_thread_default()
+    if box.get("error"):
+        raise box["error"]
+    return box.get("result")
+
+
 def _load_preferences(ext_id: str) -> JsonConf:
     return JsonConf.load(f"{paths.EXTENSIONS_CONFIG}/{ext_id}.json")
 
@@ -105,7 +136,9 @@ class ExtensionController:
         logger.info("Installing extension: %s", url)
         remote = ExtensionRemote(url)
         is_new_install = not Path(remote.target_dir).exists()  # noqa: ASYNC240
-        commit_hash, commit_timestamp = remote.download(commit_hash, warn_if_overwrite)
+        commit_hash, commit_timestamp = _run_gio_blocking(
+            lambda cb: remote.download(cb, commit_hash, warn_if_overwrite)
+        )
 
         try:
             # install python dependencies from requirements.txt
@@ -240,7 +273,7 @@ class ExtensionController:
         """
         Returns tuple with commit info about a new version
         """
-        commit_hash = ExtensionRemote(self.state.url).get_compatible_hash()
+        commit_hash = _run_gio_blocking(ExtensionRemote(self.state.url).get_compatible_hash)
         has_update = self.state.commit_hash != commit_hash
         return has_update, commit_hash
 

--- a/ulauncher/modes/extensions/extension_remote.py
+++ b/ulauncher/modes/extensions/extension_remote.py
@@ -1,15 +1,14 @@
 from __future__ import annotations
 
+import contextlib
 import logging
 import os
-import subprocess
 from os.path import basename, getmtime, isdir
 from shutil import move, rmtree, which
 from tarfile import TarError
 from tempfile import NamedTemporaryFile, TemporaryDirectory
-from urllib.error import HTTPError, URLError
+from typing import Callable
 from urllib.parse import urlparse
-from urllib.request import urlopen, urlretrieve
 
 from ulauncher import (
     api_version,
@@ -18,10 +17,15 @@ from ulauncher import (
 from ulauncher.data import BaseDataClass
 from ulauncher.modes.extensions import ext_exceptions
 from ulauncher.modes.extensions.extension_manifest import ExtensionManifest
+from ulauncher.utils.subprocess_utils import download_file, run_command
 from ulauncher.utils.untar import untar
 from ulauncher.utils.version import get_version, satisfies
 
 logger = logging.getLogger(__name__)
+
+RefsCallback = Callable[["dict[str, str] | None", "Exception | None"], None]
+HashCallback = Callable[["str | None", "Exception | None"], None]
+DownloadCallback = Callable[["tuple[str, float] | None", "Exception | None"], None]
 
 
 class UrlParseResult(BaseDataClass):
@@ -48,139 +52,219 @@ class ExtensionRemote(UrlParseResult):
         self.target_dir = f"{paths.USER_EXTENSIONS}/{self.ext_id}"
         self._git_dir = f"{paths.USER_EXTENSIONS}/.git/{self.ext_id}.git"
 
-    def _get_refs(self) -> dict[str, str]:
-        refs = {}
-        ref = None
-        try:
-            if which("git"):
-                if isdir(self._git_dir):
-                    subprocess.check_call(
-                        [
-                            "git",
-                            f"--git-dir={self._git_dir}",
-                            "fetch",
-                            "origin",
-                            "+refs/heads/*:refs/heads/*",
-                            "--prune",
-                            "--prune-tags",
-                        ],
-                        stderr=subprocess.DEVNULL,
-                    )
-                else:
-                    os.makedirs(self._git_dir)
-                    subprocess.check_call(
-                        ["git", "clone", "--bare", self.remote_url, self._git_dir],
-                        stderr=subprocess.DEVNULL,
-                    )
-
-                response = subprocess.check_output(["git", "ls-remote", self._git_dir]).decode().strip().split("\n")
-            else:
-                with urlopen(f"{self.remote_url}/info/refs?service=git-upload-pack") as reader:
-                    response = reader.read().decode().strip().split("\n")
+    def _get_refs(self, callback: RefsCallback) -> None:
+        def parse_response(response_text: str) -> dict[str, str]:
+            refs: dict[str, str] = {}
+            response = response_text.strip().split("\n")
             if response:
                 if response[-1] == "0000":
                     # Convert "smart" response, to more readable "dumb" response
                     # See https://www.git-scm.com/docs/http-protocol#_discovering_references
                     response = [r.split("\x00")[0][8:] if r.startswith("0000") else r[4:] for r in response[1:-1]]
-
                 for row in response:
-                    commit, ref = row.split()
-                    refs[basename(ref)] = commit
+                    if row:
+                        commit, ref = row.split()
+                        refs[basename(ref)] = commit
+            return refs
 
-        except (HTTPError, URLError) as e:
-            msg = f'Could not access repository resource "{self.url}"'
-            raise ext_exceptions.NetworkError(msg) from e
-        except (subprocess.CalledProcessError, OSError) as e:
-            msg = f'Could not fetch reference "{ref}" for {self.url}.' if ref else f"Could not fetch remote {self.url}."
-            raise ext_exceptions.NetworkError(msg) from e
+        def on_ls_remote(stdout: str | None, error: Exception | None) -> None:
+            if error:
+                callback(None, ext_exceptions.NetworkError(f"Could not fetch remote {self.url}."))
+                return
+            try:
+                refs = parse_response(stdout or "")
+            except ValueError:
+                callback(None, ext_exceptions.NetworkError(f"Could not fetch remote {self.url}."))
+                return
+            callback(refs, None)
 
-        return refs
+        def after_sync(_stdout: str | None, error: Exception | None) -> None:
+            if error:
+                callback(None, ext_exceptions.NetworkError(f"Could not fetch remote {self.url}."))
+                return
+            run_command(["git", "ls-remote", self._git_dir], on_ls_remote)
 
-    def get_compatible_hash(self) -> str:
+        if which("git"):
+            if isdir(self._git_dir):
+                run_command(
+                    [
+                        "git",
+                        f"--git-dir={self._git_dir}",
+                        "fetch",
+                        "origin",
+                        "+refs/heads/*:refs/heads/*",
+                        "--prune",
+                        "--prune-tags",
+                    ],
+                    after_sync,
+                )
+            else:
+                try:
+                    os.makedirs(self._git_dir)
+                except OSError:
+                    callback(None, ext_exceptions.NetworkError(f"Could not fetch remote {self.url}."))
+                    return
+                run_command(["git", "clone", "--bare", self.remote_url, self._git_dir], after_sync)
+            return
+
+        # git is not installed: fetch the dumb HTTP info/refs endpoint instead
+        refs_url = f"{self.remote_url}/info/refs?service=git-upload-pack"
+        with NamedTemporaryFile(suffix=".refs", prefix="ulauncher_refs_", delete=False) as tmp:
+            refs_path = tmp.name
+
+        def on_refs_downloaded(_path: str | None, error: Exception | None) -> None:
+            try:
+                if error:
+                    callback(None, ext_exceptions.NetworkError(f'Could not access repository resource "{self.url}"'))
+                    return
+                with open(refs_path) as reader:
+                    refs = parse_response(reader.read())
+            except (OSError, ValueError):
+                callback(None, ext_exceptions.NetworkError(f'Could not access repository resource "{self.url}"'))
+                return
+            finally:
+                with contextlib.suppress(OSError):
+                    os.remove(refs_path)
+            callback(refs, None)
+
+        download_file(refs_url, refs_path, on_refs_downloaded)
+
+    def get_compatible_hash(self, callback: HashCallback) -> None:
         """
-        Returns the commit hash for the highest compatible version, matching using branch names
+        Resolves the commit hash for the highest compatible version, matching using branch names
         and tags names starting with "apiv", ex "apiv3" and "apiv3.2"
         New method for v6. The new behavior is intentionally undocumented because we still
         want extension devs to use the old way until Ulauncher 5/apiv2 is fully phased out
         """
-        remote_refs = self._get_refs()
-        # Strip the "apiv" prefix so keys are bare version strings ("3", "3.2") usable with get_version
-        compatible = {
-            ver: sha
-            for ref, sha in remote_refs.items()
-            if ref.startswith("apiv") and satisfies(api_version, (ver := ref[4:]))
-        }
 
-        if compatible:
-            return compatible[max(compatible, key=get_version)]
+        def on_refs(remote_refs: dict[str, str] | None, error: Exception | None) -> None:
+            if error or remote_refs is None:
+                callback(None, error)
+                return
+            # Strip the "apiv" prefix so keys are bare version strings ("3", "3.2") usable with get_version
+            compatible = {
+                ver: sha
+                for ref, sha in remote_refs.items()
+                if ref.startswith("apiv") and satisfies(api_version, (ver := ref[4:]))
+            }
+            if compatible:
+                callback(compatible[max(compatible, key=get_version)], None)
+                return
+            # Fall back on "HEAD" as a string as that can be used also
+            callback(remote_refs.get("HEAD", "HEAD"), None)
 
-        # Try to get the commit ref for head, fallback on "HEAD" as a string as that can be used also
-        return remote_refs.get("HEAD", "HEAD")
+        self._get_refs(on_refs)
 
-    def download(self, commit_hash: str | None = None, warn_if_overwrite: bool = False) -> tuple[str, float]:
-        if not commit_hash:
-            commit_hash = self.get_compatible_hash()
+    def download(
+        self,
+        callback: DownloadCallback,
+        commit_hash: str | None = None,
+        warn_if_overwrite: bool = False,
+    ) -> None:
+        if commit_hash:
+            self._download_with_hash(commit_hash, warn_if_overwrite, callback)
+            return
+
+        def on_hash(resolved_hash: str | None, error: Exception | None) -> None:
+            if error or resolved_hash is None:
+                callback(None, error)
+                return
+            self._download_with_hash(resolved_hash, warn_if_overwrite, callback)
+
+        self.get_compatible_hash(on_hash)
+
+    def _download_with_hash(self, commit_hash: str, warn_if_overwrite: bool, callback: DownloadCallback) -> None:
         output_dir_exists = isdir(self.target_dir)
-
         if output_dir_exists and warn_if_overwrite:
             logger.info('Extension with URL "%s" is already installed. Updating', self.url)
 
         if self.download_url_template:
-            with NamedTemporaryFile(suffix=".tar.gz", prefix="ulauncher_dl_") as tmp_file:
-                download_url = self.download_url_template.replace("[commit]", commit_hash)
-                try:
-                    urlretrieve(download_url, tmp_file.name)
-                except URLError as e:
-                    err_msg = f"Failed to download extension from {download_url}: {e}"
-                    raise ext_exceptions.RemoteError(err_msg) from e
-                with TemporaryDirectory(prefix="ulauncher_ext_") as tmp_root_dir:
-                    try:
-                        untar(tmp_file.name, tmp_root_dir)
-                    except (TarError, OSError) as e:
-                        err_msg = f"Failed to extract extension from {tmp_file.name}: {e}"
-                        raise ext_exceptions.RemoteError(err_msg) from e
-                    subdirs = os.listdir(tmp_root_dir)
-                    if len(subdirs) != 1:
-                        msg = f"Invalid archive for {self.url}."
-                        raise ext_exceptions.RemoteError(msg)
-                    tmp_dir = f"{tmp_root_dir}/{subdirs[0]}"
-                    manifest = ExtensionManifest.load(f"{tmp_dir}/manifest.json")
-                    if not satisfies(api_version, manifest.api_version):
-                        if not satisfies("2.0", manifest.api_version):
-                            msg = f"{manifest.name} does not support Ulauncher API v{api_version}."
-                            raise ext_exceptions.CompatibilityError(msg)
-                        logger.warning("Falling back on using API 2.0 version for %s.", self.url)
+            download_url = self.download_url_template.replace("[commit]", commit_hash)
+            with NamedTemporaryFile(suffix=".tar.gz", prefix="ulauncher_dl_", delete=False) as tmp_file:
+                tmp_path = tmp_file.name
 
-                    if output_dir_exists:
-                        rmtree(self.target_dir)
-                    move(tmp_dir, self.target_dir)
-            commit_timestamp = getmtime(self.target_dir)
-            return commit_hash, commit_timestamp
+            def on_downloaded(_path: str | None, error: Exception | None) -> None:
+                try:
+                    if error:
+                        callback(
+                            None,
+                            ext_exceptions.RemoteError(f"Failed to download extension from {download_url}: {error}"),
+                        )
+                        return
+                    try:
+                        result = self._extract_and_install(tmp_path, commit_hash, output_dir_exists)
+                    except ext_exceptions.ExtensionError as install_error:
+                        callback(None, install_error)
+                        return
+                    callback(result, None)
+                finally:
+                    with contextlib.suppress(OSError):
+                        os.remove(tmp_path)
+
+            download_file(download_url, tmp_path, on_downloaded)
+            return
 
         if not which("git"):
-            msg = "This extension URL can only be supported if you have git installed."
-            raise ext_exceptions.RemoteError(msg)
+            callback(
+                None, ext_exceptions.RemoteError("This extension URL can only be supported if you have git installed.")
+            )
+            return
 
         os.makedirs(self.target_dir, exist_ok=True)
 
+        def after_checkout(_stdout: str | None, error: Exception | None) -> None:
+            if error:
+                callback(None, ext_exceptions.RemoteError(f"Failed to checkout commit {commit_hash}: {error}"))
+                return
+
+            def after_show(stdout: str | None, show_error: Exception | None) -> None:
+                if show_error or stdout is None:
+                    callback(None, ext_exceptions.RemoteError(f"Failed to checkout commit {commit_hash}: {show_error}"))
+                    return
+                try:
+                    commit_timestamp = float(stdout.strip())
+                except ValueError:
+                    callback(None, ext_exceptions.RemoteError(f"Failed to parse commit timestamp for {commit_hash}"))
+                    return
+                callback((commit_hash, commit_timestamp), None)
+
+            run_command(
+                ["git", f"--git-dir={self._git_dir}", "show", "-s", "--format=%ct", commit_hash],
+                after_show,
+            )
+
+        run_command(
+            ["git", f"--git-dir={self._git_dir}", f"--work-tree={self.target_dir}", "checkout", commit_hash, "."],
+            after_checkout,
+        )
+
+    def _extract_and_install(self, tar_path: str, commit_hash: str, output_dir_exists: bool) -> tuple[str, float]:
+        # All filesystem steps share the same failure semantics, so they live under one guard.
+        # shutil.Error subclasses OSError, so move() failures are covered too. The intentional
+        # RemoteError/CompatibilityError raises are ExtensionError (not OSError) and propagate as-is.
+        # This must not let a raw OSError escape: it runs inside a Gio callback, where an uncaught
+        # exception would be swallowed and hang _run_gio_blocking instead of reaching the caller.
         try:
-            subprocess.run(
-                ["git", f"--git-dir={self._git_dir}", f"--work-tree={self.target_dir}", "checkout", commit_hash, "."],
-                check=True,
-                stderr=subprocess.DEVNULL,
-            )
-            commit_timestamp = float(
-                subprocess.check_output(
-                    ["git", f"--git-dir={self._git_dir}", "show", "-s", "--format=%ct", commit_hash]
-                )
-                .decode()
-                .strip()
-            )
-        except subprocess.CalledProcessError as e:
-            err_msg = f"Failed to checkout commit {commit_hash}: {e}"
-            raise ext_exceptions.RemoteError(err_msg) from e
-        else:
-            return commit_hash, commit_timestamp
+            with TemporaryDirectory(prefix="ulauncher_ext_") as tmp_root_dir:
+                untar(tar_path, tmp_root_dir)
+                subdirs = os.listdir(tmp_root_dir)
+                if len(subdirs) != 1:
+                    msg = f"Invalid archive for {self.url}."
+                    raise ext_exceptions.RemoteError(msg)
+                tmp_dir = f"{tmp_root_dir}/{subdirs[0]}"
+                manifest = ExtensionManifest.load(f"{tmp_dir}/manifest.json")
+                if not satisfies(api_version, manifest.api_version):
+                    if not satisfies("2.0", manifest.api_version):
+                        msg = f"{manifest.name} does not support Ulauncher API v{api_version}."
+                        raise ext_exceptions.CompatibilityError(msg)
+                    logger.warning("Falling back on using API 2.0 version for %s.", self.url)
+                if output_dir_exists:
+                    rmtree(self.target_dir)
+                move(tmp_dir, self.target_dir)
+            return commit_hash, getmtime(self.target_dir)
+        except (TarError, OSError) as e:
+            msg = f"Failed to install extension from {tar_path}: {e}"
+            raise ext_exceptions.RemoteError(msg) from e
 
 
 def parse_extension_url(input_url: str) -> UrlParseResult:

--- a/ulauncher/utils/subprocess_utils.py
+++ b/ulauncher/utils/subprocess_utils.py
@@ -34,7 +34,8 @@ def run_command(cmd: list[str], callback: CommandCallback, *, cwd: str | None = 
             callback(None, error)
             return
         if not subprocess_.get_successful():
-            exit_status = subprocess_.get_exit_status()
+            # if killed by a signal: report it as a negative status (subprocess convention)
+            exit_status = subprocess_.get_exit_status() if subprocess_.get_if_exited() else -subprocess_.get_term_sig()
             callback(None, subprocess.CalledProcessError(exit_status, cmd, output=stdout, stderr=stderr))
             return
         callback(stdout, None)

--- a/ulauncher/utils/subprocess_utils.py
+++ b/ulauncher/utils/subprocess_utils.py
@@ -1,0 +1,41 @@
+from __future__ import annotations
+
+import subprocess
+from typing import Callable
+
+from ulauncher.gi import Gio, GLib
+
+# callback(stdout, error): exactly one is set. On success error is None and stdout is the
+# captured standard output. On failure stdout is None and error is an exception (a
+# subprocess.CalledProcessError for non-zero exits, or GLib.Error for spawn/communicate failures).
+# The inner quotes keep the PEP 604 unions as strings so this evaluates on Python 3.8.
+CommandCallback = Callable[["str | None", "Exception | None"], None]
+
+
+def run_command(cmd: list[str], callback: CommandCallback, *, cwd: str | None = None) -> None:
+    """Run a one-shot command via Gio.Subprocess and deliver its stdout (or error) to callback."""
+    launcher = Gio.SubprocessLauncher.new(Gio.SubprocessFlags.STDOUT_PIPE | Gio.SubprocessFlags.STDERR_PIPE)
+    if cwd:
+        launcher.set_cwd(cwd)
+
+    try:
+        proc = launcher.spawnv(cmd)
+    except GLib.Error as error:
+        # spawnv raises synchronously; schedule via idle_add so the callback fires
+        # inside the caller's main loop iteration rather than before loop.run().
+        GLib.idle_add(callback, None, error)
+        return
+
+    def on_done(subprocess_: Gio.Subprocess, result: Gio.AsyncResult) -> None:
+        try:
+            _, stdout, stderr = subprocess_.communicate_utf8_finish(result)
+        except GLib.Error as error:
+            callback(None, error)
+            return
+        if not subprocess_.get_successful():
+            exit_status = subprocess_.get_exit_status()
+            callback(None, subprocess.CalledProcessError(exit_status, cmd, output=stdout, stderr=stderr))
+            return
+        callback(stdout, None)
+
+    proc.communicate_utf8_async(None, None, on_done)

--- a/ulauncher/utils/subprocess_utils.py
+++ b/ulauncher/utils/subprocess_utils.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import subprocess
+import sys
 from typing import Callable
 
 from ulauncher.gi import Gio, GLib
@@ -39,3 +40,28 @@ def run_command(cmd: list[str], callback: CommandCallback, *, cwd: str | None = 
         callback(stdout, None)
 
     proc.communicate_utf8_async(None, None, on_done)
+
+
+# Run Python/urllib.request inside a Gio.Subprocess to avoid needing a dependency like libsoup, gvfsd-http, curl or wget
+_DOWNLOAD_SCRIPT = (
+    "import sys, urllib.request, shutil; "
+    "r = urllib.request.urlopen(sys.argv[1], timeout=30); "
+    "f = open(sys.argv[2], 'wb'); "
+    "shutil.copyfileobj(r, f); "
+    "f.close(); r.close()"
+)
+
+# callback(dest_path, error): dest_path is the saved file path on success, error is set on failure.
+DownloadCallback = Callable[["str | None", "Exception | None"], None]
+
+
+def download_file(url: str, dest_path: str, callback: DownloadCallback) -> None:
+    """Download url to dest_path without blocking. See _DOWNLOAD_SCRIPT for why this spawns Python."""
+
+    def on_done(_stdout: str | None, error: Exception | None) -> None:
+        if error:
+            callback(None, error)
+            return
+        callback(dest_path, None)
+
+    run_command([sys.executable, "-c", _DOWNLOAD_SCRIPT, url, dest_path], on_done)


### PR DESCRIPTION
## Summary
Convert extension remote handling to use Gio.Subprocess with small one-shot helpers, and add a dependency-free download helper. This makes subprocess usage non-blocking, simpler, and more robust.

### What changed
- Added: ulauncher/utils/subprocess_utils.py -  run_command (Gio.Subprocess one-shot) and download_file helper  
- Modified: ulauncher/modes/extensions/extension_remote.py (refactor to callbacks + Gio.Subprocess)  
- Modified: ulauncher/modes/extensions/extension_controller.py (integration changes)  
- Tests: added tests/utils/test_subprocess_utils.py; updated tests/modes/apps/extensions/test_extension_remote.py and tests/utils/test_socket_msg_controller.py

### Why
Avoid blocking the GTK main thread, improve subprocess lifecycle handling, and remove an external dependency for downloads.

### Compatibility
No public extension API changes expected. Although to take benefit of the improvements we will need to remove the crutch (`_run_gio_blocking`) and make the full implementation, which will turn other APIs into callbacks.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Refactored extension remote handling to use `Gio.Subprocess` with callback helpers, making operations non-blocking and removing the external download dependency.

- **Refactors**
  - Converted `extension_remote` to callbacks powered by `run_command` and `download_file`, with clearer error mapping and no GTK main thread blocking.
  - Added a temporary `_run_gio_blocking` bridge in `ExtensionController.install` and `check_update` to drive callbacks until the controller becomes callback-native.
  - Updated tests and fixed socket controller fixtures to properly close fds and drain GLib callbacks.

- **New Features**
  - Added `ulauncher/utils/subprocess_utils.py` with `run_command` (one-shot `Gio.Subprocess`) and `download_file` (dependency-free downloader via Python).
  - Improved ref resolution when `git` is absent by fetching HTTP `info/refs`.

<sup>Written for commit 0593251e6654b6f4fa95402a371766729a7ffe4b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Ulauncher/Ulauncher/pull/1732?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

