### PR TITLE
refactor(ext_remote): rewrite usings Gio.Subprocess

### DIFF
--- a/tests/modes/apps/extensions/test_extension_remote.py
+++ b/tests/modes/apps/extensions/test_extension_remote.py
@@ -1,14 +1,20 @@
+from __future__ import annotations
+
+import subprocess
+from typing import Any, Callable
 from unittest.mock import MagicMock, patch
 
 import pytest
 
+from ulauncher import api_version
 from ulauncher.modes.extensions import ext_exceptions
 from ulauncher.modes.extensions.extension_remote import (
     ExtensionRemote,
     parse_extension_url,
 )
 
-# @todo: Add missing coverage for _get_refs, get_compatible_hash, download
+# @todo: remaining uncovered paths: the no-git HTTP info/refs fallback, the fetch/clone
+# failure before ls-remote, and download() resolving the hash itself (no commit_hash given).
 
 
 class TestExtensionRemote:
@@ -97,3 +103,102 @@ class TestParseExtensionUrl:
         assert parse_extension_url("https://github.com/user/repo/tree/HEAD").ext_id == "com.github.user.repo"
         assert parse_extension_url("https://gitlab.com/user/repo.git").ext_id == "com.gitlab.user.repo"
         assert parse_extension_url("https://other.host/a/b/c/d").ext_id == "host.other.a.b.c.d"
+
+
+def _call(
+    start: Callable[[Callable[[Any], None], Callable[[Exception], None]], None],
+) -> tuple[Any, Exception | None]:
+    """Invoke a callback-based method whose mocked dependencies fire synchronously."""
+    box: dict[str, Any] = {}
+    start(
+        lambda result: box.update(result=result, error=None),
+        lambda error: box.update(result=None, error=error),
+    )
+    return box.get("result"), box.get("error")
+
+
+class TestGetCompatibleHash:
+    @patch("ulauncher.modes.extensions.extension_remote.which", return_value="/usr/bin/git")
+    @patch("ulauncher.modes.extensions.extension_remote.isdir", return_value=True)
+    @patch("ulauncher.modes.extensions.extension_remote.run_command")
+    def test_returns_compatible_apiv_ref(self, mock_run: MagicMock, *_: Any) -> None:
+        ls_remote_output = f"def456\trefs/heads/apiv{api_version}\nabc123\tHEAD\n"
+
+        def side_effect(cmd: list[str], on_success: Callable[[Any], None], _on_error: Any, **_kw: Any) -> None:
+            on_success(ls_remote_output if "ls-remote" in cmd else "")
+
+        mock_run.side_effect = side_effect
+        remote = ExtensionRemote("https://github.com/user/repo")
+        result, error = _call(remote.get_compatible_hash)
+        assert error is None
+        assert result == "def456"
+
+    @patch("ulauncher.modes.extensions.extension_remote.which", return_value="/usr/bin/git")
+    @patch("ulauncher.modes.extensions.extension_remote.isdir", return_value=True)
+    @patch("ulauncher.modes.extensions.extension_remote.run_command")
+    def test_maps_command_failure_to_network_error(self, mock_run: MagicMock, *_: Any) -> None:
+        def side_effect(cmd: list[str], on_success: Callable[[Any], None], on_error: Callable[[Any], None]) -> None:
+            if "ls-remote" in cmd:
+                on_error(subprocess.CalledProcessError(128, cmd))
+            else:
+                on_success("")
+
+        mock_run.side_effect = side_effect
+        remote = ExtensionRemote("https://github.com/user/repo")
+        result, error = _call(remote.get_compatible_hash)
+        assert result is None
+        assert isinstance(error, ext_exceptions.NetworkError)
+
+
+class TestDownload:
+    @patch("ulauncher.modes.extensions.extension_remote.which", return_value="/usr/bin/git")
+    @patch("ulauncher.modes.extensions.extension_remote.os.makedirs")
+    @patch("ulauncher.modes.extensions.extension_remote.run_command")
+    def test_git_checkout_path_returns_hash_and_timestamp(self, mock_run: MagicMock, *_: Any) -> None:
+        def side_effect(cmd: list[str], on_success: Callable[[Any], None], _on_error: Any, **_kw: Any) -> None:
+            on_success("1700000000\n" if "show" in cmd else "")
+
+        mock_run.side_effect = side_effect
+        # example.com has no download_url_template, so download() takes the git checkout path
+        remote = ExtensionRemote("https://example.com/user/repo")
+        result, error = _call(lambda on_success, on_error: remote.download(on_success, on_error, commit_hash="abc123"))
+        assert error is None
+        assert result == ("abc123", 1700000000.0)
+
+    @patch("ulauncher.modes.extensions.extension_remote.download_file")
+    def test_download_failure_maps_to_remote_error(self, mock_download: MagicMock) -> None:
+        def side_effect(_url: str, _dest: str, _on_success: Any, on_error: Callable[[Any], None]) -> None:
+            on_error(OSError("boom"))
+
+        mock_download.side_effect = side_effect
+        remote = ExtensionRemote("https://github.com/user/repo")
+        result, error = _call(lambda on_success, on_error: remote.download(on_success, on_error, commit_hash="abc123"))
+        assert result is None
+        assert isinstance(error, ext_exceptions.RemoteError)
+
+    @patch("ulauncher.modes.extensions.extension_remote.which", return_value="/usr/bin/git")
+    @patch("ulauncher.modes.extensions.extension_remote.os.makedirs")
+    @patch("ulauncher.modes.extensions.extension_remote.run_command")
+    def test_unparsable_commit_timestamp_maps_to_remote_error(self, mock_run: MagicMock, *_: Any) -> None:
+        # A raw ValueError from float() would otherwise escape the Gio callback and hang the bridge.
+        def side_effect(cmd: list[str], on_success: Callable[[Any], None], _on_error: Any, **_kw: Any) -> None:
+            on_success("not-a-timestamp" if "show" in cmd else "")
+
+        mock_run.side_effect = side_effect
+        remote = ExtensionRemote("https://example.com/user/repo")
+        result, error = _call(lambda on_success, on_error: remote.download(on_success, on_error, commit_hash="abc123"))
+        assert result is None
+        assert isinstance(error, ext_exceptions.RemoteError)
+
+    @patch("ulauncher.modes.extensions.extension_remote.untar", side_effect=OSError("disk full"))
+    @patch("ulauncher.modes.extensions.extension_remote.download_file")
+    def test_install_oserror_maps_to_remote_error(self, mock_download: MagicMock, *_: Any) -> None:
+        # A raw OSError from the filesystem install steps must be mapped, not escape the callback.
+        def side_effect(_url: str, dest: str, on_success: Callable[[Any], None], _on_error: Any) -> None:
+            on_success(dest)
+
+        mock_download.side_effect = side_effect
+        remote = ExtensionRemote("https://github.com/user/repo")
+        result, error = _call(lambda on_success, on_error: remote.download(on_success, on_error, commit_hash="abc123"))
+        assert result is None
+        assert isinstance(error, ext_exceptions.RemoteError)

--- a/tests/modes/apps/extensions/test_extension_remote.py
+++ b/tests/modes/apps/extensions/test_extension_remote.py
@@ -137,7 +137,9 @@ class TestGetCompatibleHash:
     @patch("ulauncher.modes.extensions.extension_remote.isdir", return_value=True)
     @patch("ulauncher.modes.extensions.extension_remote.run_command")
     def test_maps_command_failure_to_network_error(self, mock_run: MagicMock, *_: Any) -> None:
-        def side_effect(cmd: list[str], on_success: Callable[[Any], None], on_error: Callable[[Any], None]) -> None:
+        def side_effect(
+            cmd: list[str], on_success: Callable[[Any], None], on_error: Callable[[Any], None], **_kw: Any
+        ) -> None:
             if "ls-remote" in cmd:
                 on_error(subprocess.CalledProcessError(128, cmd))
             else:

--- a/tests/utils/test_subprocess_utils.py
+++ b/tests/utils/test_subprocess_utils.py
@@ -2,10 +2,11 @@ from __future__ import annotations
 
 import subprocess
 import sys
+from pathlib import Path
 from typing import Any, Callable
 
 from ulauncher.gi import GLib
-from ulauncher.utils.subprocess_utils import run_command
+from ulauncher.utils.subprocess_utils import download_file, run_command
 
 
 def _drive(
@@ -55,3 +56,20 @@ def test_run_command_spawn_failure() -> None:
     result, error = _drive(lambda ok, err: run_command(["definitely-not-a-real-binary-xyz"], ok, err))
     assert result is None
     assert isinstance(error, GLib.Error)
+
+
+def test_download_file_success(tmp_path: Path) -> None:
+    src = tmp_path / "src.txt"
+    src.write_text("payload")
+    dest = tmp_path / "out.txt"
+    result, error = _drive(lambda ok, err: download_file(src.as_uri(), str(dest), ok, err))
+    assert error is None
+    assert result == str(dest)
+    assert dest.read_text() == "payload"
+
+
+def test_download_file_failure(tmp_path: Path) -> None:
+    dest = tmp_path / "out.txt"
+    result, error = _drive(lambda ok, err: download_file("file:///nonexistent/nope.txt", str(dest), ok, err))
+    assert result is None
+    assert error is not None

--- a/ulauncher/modes/extensions/extension_controller.py
+++ b/ulauncher/modes/extensions/extension_controller.py
@@ -68,6 +68,45 @@ stopped_listeners: dict[str, list[Callable[[], None]]] = defaultdict(list)
 events = EventBus()
 
 
+def _run_gio_blocking(start: Callable[[Callable[[Any], None], Callable[[Exception], None]], None]) -> Any:
+    """Drive a callback-based Gio operation to completion synchronously on the calling thread.
+
+    Temporary bridge for step one of the asyncio/threading removal: extension_remote is now
+    callback-based, but ExtensionController is still async and runs in worker threads (ext_handlers)
+    or the CLI's asyncio loop. Gio.Subprocess callbacks dispatch on a GLib main context, not the
+    asyncio loop, and no GLib loop runs in those threads, so a plain asyncio.Future shim would
+    never resolve. Running a private GLib main loop (pushed as the thread-default context) drives
+    the operation to completion. Remove this when the controller becomes callback-native.
+    """
+    context = GLib.MainContext.new()
+    context.push_thread_default()
+    box: dict[str, Any] = {}
+    completed = False
+    try:
+        loop = GLib.MainLoop.new(context, False)
+
+        def finish(result: Any = None, error: Exception | None = None) -> None:
+            nonlocal completed
+            box["result"], box["error"] = result, error
+            completed = True
+            loop.quit()
+
+        start(finish, lambda error: finish(error=error))
+        # done() can fire synchronously during start() (e.g. an immediate validation failure
+        # that calls back without spawning a subprocess). Then loop.quit() already ran before
+        # loop.run(), which GLib does not treat as a pending quit, so running the loop would
+        # block forever. Only enter the loop while the callback is still pending.
+        if not completed:
+            loop.run()
+    finally:
+        # Always restore the thread-default context, even if start() raises synchronously
+        # (a synchronous raise propagates to the caller, matching the pre-conversion behavior).
+        context.pop_thread_default()
+    if box.get("error"):
+        raise box["error"]
+    return box.get("result")
+
+
 def _load_preferences(ext_id: str) -> JsonConf:
     return JsonConf.load(f"{paths.EXTENSIONS_CONFIG}/{ext_id}.json")
 
@@ -105,7 +144,9 @@ class ExtensionController:
         logger.info("Installing extension: %s", url)
         remote = ExtensionRemote(url)
         is_new_install = not Path(remote.target_dir).exists()  # noqa: ASYNC240
-        downloaded_hash, commit_timestamp = remote.download(commit_hash, warn_if_overwrite)
+        downloaded_hash, commit_timestamp = _run_gio_blocking(
+            lambda on_success, on_error: remote.download(on_success, on_error, commit_hash, warn_if_overwrite)
+        )
 
         try:
             # install python dependencies from requirements.txt
@@ -240,7 +281,7 @@ class ExtensionController:
         """
         Returns tuple with commit info about a new version
         """
-        commit_hash = ExtensionRemote(self.state.url).get_compatible_hash()
+        commit_hash = _run_gio_blocking(ExtensionRemote(self.state.url).get_compatible_hash)
         has_update = self.state.commit_hash != commit_hash
         return has_update, commit_hash
 

--- a/ulauncher/modes/extensions/extension_remote.py
+++ b/ulauncher/modes/extensions/extension_remote.py
@@ -17,7 +17,7 @@ from ulauncher import (
 from ulauncher.data import BaseDataClass
 from ulauncher.modes.extensions import ext_exceptions
 from ulauncher.modes.extensions.extension_manifest import ExtensionManifest
-from ulauncher.utils.subprocess_utils import OnError, download_file, run_command
+from ulauncher.utils.subprocess_utils import OnError, OnSuccess, download_file, run_command
 from ulauncher.utils.untar import untar
 from ulauncher.utils.version import get_version, satisfies
 
@@ -43,6 +43,99 @@ def _parse_refs_response(response_text: str) -> dict[str, str]:
     return refs
 
 
+class _BareRepo:
+    """Owns the cached bare clone at git_dir.
+
+    Each method maps its own git/OS failure to the matching ext_exceptions error before reporting it to
+    the caller's on_error, so callers thread their raw on_error through without wrapping it per command.
+    """
+
+    def __init__(self, git_dir: str, remote_url: str, url: str) -> None:
+        self._git_dir = git_dir
+        self.remote_url = remote_url
+        self._url = url
+        self._synced = False
+
+    @property
+    def _is_repo(self) -> bool:
+        # ensure it's actually a bare git repo (has an objects dir), not just a directory
+        return isdir(f"{self._git_dir}/objects")
+
+    def _network_failure(self, on_error: OnError) -> OnError:
+        """Wrap a raw fetch/clone error as the NetworkError the caller expects"""
+        return lambda _error: on_error(ext_exceptions.NetworkError(f"Could not fetch remote {self._url}."))
+
+    def _remote_failure(self, on_error: OnError, message: str) -> OnError:
+        """Wrap a raw git error as a RemoteError prefixed with message"""
+        return lambda error: on_error(ext_exceptions.RemoteError(f"{message}: {error}"))
+
+    def _fetch(self, on_done: Callable[[], None], on_error: OnError) -> None:
+        """Fetch bare repo, or clone a fresh one."""
+        fail = self._network_failure(on_error)
+        if self._is_repo:
+            self._run_git(
+                ["fetch", "origin", "+refs/heads/*:refs/heads/*", "--prune", "--prune-tags"],
+                lambda _stdout: on_done(),
+                fail,
+                skip_sync=True,
+            )
+            return
+
+        # Missing, empty, or half-cloned: start from a clean empty dir so the next attempt always
+        # clones rather than fetching a leftover. This self-heals a previously botched clone.
+        rmtree(self._git_dir, ignore_errors=True)
+        try:
+            os.makedirs(self._git_dir)
+        except OSError as error:
+            self._remote_failure(on_error, f"Failed to create repository directory {self._git_dir}")(error)
+            return
+        self._run_git(["clone", "--bare", self.remote_url, "."], lambda _stdout: on_done(), fail, skip_sync=True)
+
+    def ls_remote(self, on_success: OnSuccess, on_error: OnError) -> None:
+        self._run_git(["ls-remote", "."], on_success, on_error)
+
+    def checkout(self, work_tree: str, commit_hash: str, on_done: Callable[[], None], on_error: OnError) -> None:
+        self._run_git(
+            [f"--work-tree={work_tree}", "checkout", commit_hash, "."],
+            lambda _stdout: on_done(),
+            on_error,
+            error_message=f"Failed to checkout commit {commit_hash}",
+        )
+
+    def get_commit_timestamp(self, commit_hash: str, on_success: OnSuccess, on_error: OnError) -> None:
+        self._run_git(
+            ["show", "-s", "--format=%ct", commit_hash],
+            on_success,
+            on_error,
+            error_message=f"Failed to read commit {commit_hash}",
+        )
+
+    def _run_git(
+        self,
+        args: list[str],
+        on_success: OnSuccess,
+        on_error: OnError,
+        *,
+        skip_sync: bool = False,
+        error_message: str | None = None,
+    ) -> None:
+        """Run a git subcommand in the repo's git_dir. Will git fetch first if needed unless passing skip_sync=True."""
+        fail = self._remote_failure(on_error, error_message) if error_message else self._network_failure(on_error)
+
+        def run() -> None:
+            run_command(["git", *args], on_success, fail, cwd=self._git_dir)
+
+        if skip_sync or self._synced:
+            run()
+            return
+
+        def on_fetched() -> None:
+            self._synced = True
+            run()
+
+        self._fetch(on_fetched, on_error)
+
+
 class UrlParseResult(BaseDataClass):
     ext_id: str
     remote_url: str
@@ -65,53 +158,25 @@ class ExtensionRemote(UrlParseResult):
             raise ext_exceptions.UrlError(msg) from e
 
         self.target_dir = f"{paths.USER_EXTENSIONS}/{self.ext_id}"
-        self._git_dir = f"{paths.USER_EXTENSIONS}/.git/{self.ext_id}.git"
+        self._repo = _BareRepo(f"{paths.USER_EXTENSIONS}/.git/{self.ext_id}.git", self.remote_url, self.url)
+
+    def _network_error(self) -> ext_exceptions.NetworkError:
+        return ext_exceptions.NetworkError(f"Could not fetch remote {self.url}.")
 
     def _get_refs(self, on_success: RefsSuccess, on_error: OnError) -> None:
-        network_error = ext_exceptions.NetworkError(f"Could not fetch remote {self.url}.")
-
-        def on_ls_remote(stdout: str) -> None:
-            try:
-                refs = _parse_refs_response(stdout)
-            except ValueError:
-                on_error(network_error)
-                return
-            on_success(refs)
-
-        def on_synced(_stdout: str) -> None:
-            run_command(["git", "ls-remote", self._git_dir], on_ls_remote, lambda _error: on_error(network_error))
-
-        def on_clone_failed(_error: Exception) -> None:
-            # Otherwise the leftover empty dir sends future calls down the fetch path
-            rmtree(self._git_dir, ignore_errors=True)
-            on_error(network_error)
-
         if not which("git"):
             self._get_refs_http(on_success, on_error)
             return
 
-        if isdir(self._git_dir):
-            run_command(
-                [
-                    "git",
-                    f"--git-dir={self._git_dir}",
-                    "fetch",
-                    "origin",
-                    "+refs/heads/*:refs/heads/*",
-                    "--prune",
-                    "--prune-tags",
-                ],
-                on_synced,
-                lambda _error: on_error(network_error),
-            )
-            return
+        def deliver(stdout: str) -> None:
+            try:
+                refs = _parse_refs_response(stdout)
+            except ValueError:
+                on_error(self._network_error())
+                return
+            on_success(refs)
 
-        try:
-            os.makedirs(self._git_dir)
-        except OSError:
-            on_error(network_error)
-            return
-        run_command(["git", "clone", "--bare", self.remote_url, self._git_dir], on_synced, on_clone_failed)
+        self._repo.ls_remote(deliver, on_error)
 
     def _get_refs_http(self, on_success: RefsSuccess, on_error: OnError) -> None:
         # git is not installed: fetch the dumb HTTP info/refs endpoint instead
@@ -237,27 +302,10 @@ class ExtensionRemote(UrlParseResult):
                 return
             on_success((commit_hash, commit_timestamp))
 
-        def on_checkout(_stdout: str) -> None:
-            run_command(
-                ["git", f"--git-dir={self._git_dir}", "show", "-s", "--format=%ct", commit_hash],
-                on_timestamp,
-                lambda e: on_error(ext_exceptions.RemoteError(f"Failed to read commit {commit_hash}: {e}")),
-            )
+        def on_checked_out() -> None:
+            self._repo.get_commit_timestamp(commit_hash, on_timestamp, on_error)
 
-        def run_checkout() -> None:
-            run_command(
-                ["git", f"--git-dir={self._git_dir}", f"--work-tree={self.target_dir}", "checkout", commit_hash, "."],
-                on_checkout,
-                lambda e: on_error(ext_exceptions.RemoteError(f"Failed to checkout commit {commit_hash}: {e}")),
-            )
-
-        if not isdir(self._git_dir):
-            # A pinned install passes commit_hash in and so skips get_compatible_hash(), which is
-            # what clones the bare repo. Bootstrap it so the checkout below has a repo to read from.
-            self._get_refs(lambda _refs: run_checkout(), on_error)
-            return
-
-        run_checkout()
+        self._repo.checkout(self.target_dir, commit_hash, on_checked_out, on_error)
 
     def _extract_and_install(self, tar_path: str, commit_hash: str, output_dir_exists: bool) -> tuple[str, float]:
         # All filesystem steps share the same failure semantics, so they live under one guard.

--- a/ulauncher/modes/extensions/extension_remote.py
+++ b/ulauncher/modes/extensions/extension_remote.py
@@ -1,15 +1,14 @@
 from __future__ import annotations
 
+import contextlib
 import logging
 import os
-import subprocess
 from os.path import basename, getmtime, isdir
 from shutil import move, rmtree, which
 from tarfile import TarError
 from tempfile import NamedTemporaryFile, TemporaryDirectory
-from urllib.error import HTTPError, URLError
+from typing import Callable
 from urllib.parse import urlparse
-from urllib.request import urlopen, urlretrieve
 
 from ulauncher import (
     api_version,
@@ -18,10 +17,30 @@ from ulauncher import (
 from ulauncher.data import BaseDataClass
 from ulauncher.modes.extensions import ext_exceptions
 from ulauncher.modes.extensions.extension_manifest import ExtensionManifest
+from ulauncher.utils.subprocess_utils import OnError, download_file, run_command
 from ulauncher.utils.untar import untar
 from ulauncher.utils.version import get_version, satisfies
 
 logger = logging.getLogger(__name__)
+
+RefsSuccess = Callable[["dict[str, str]"], None]
+HashSuccess = Callable[[str], None]
+DownloadSuccess = Callable[["tuple[str, float]"], None]
+
+
+def _parse_refs_response(response_text: str) -> dict[str, str]:
+    refs: dict[str, str] = {}
+    response = response_text.strip().split("\n")
+    if response:
+        if response[-1] == "0000":
+            # Convert "smart" response, to more readable "dumb" response
+            # See https://www.git-scm.com/docs/http-protocol#_discovering_references
+            response = [r.split("\x00")[0][8:] if r.startswith("0000") else r[4:] for r in response[1:-1]]
+        for row in response:
+            if row:
+                commit, ref = row.split()
+                refs[basename(ref)] = commit
+    return refs
 
 
 class UrlParseResult(BaseDataClass):
@@ -48,95 +67,207 @@ class ExtensionRemote(UrlParseResult):
         self.target_dir = f"{paths.USER_EXTENSIONS}/{self.ext_id}"
         self._git_dir = f"{paths.USER_EXTENSIONS}/.git/{self.ext_id}.git"
 
-    def _get_refs(self) -> dict[str, str]:
-        refs = {}
-        ref = None
+    def _get_refs(self, on_success: RefsSuccess, on_error: OnError) -> None:
+        network_error = ext_exceptions.NetworkError(f"Could not fetch remote {self.url}.")
+
+        def on_ls_remote(stdout: str) -> None:
+            try:
+                refs = _parse_refs_response(stdout)
+            except ValueError:
+                on_error(network_error)
+                return
+            on_success(refs)
+
+        def on_synced(_stdout: str) -> None:
+            run_command(["git", "ls-remote", self._git_dir], on_ls_remote, lambda _error: on_error(network_error))
+
+        def on_clone_failed(_error: Exception) -> None:
+            # Otherwise the leftover empty dir sends future calls down the fetch path
+            rmtree(self._git_dir, ignore_errors=True)
+            on_error(network_error)
+
+        if not which("git"):
+            self._get_refs_http(on_success, on_error)
+            return
+
+        if isdir(self._git_dir):
+            run_command(
+                [
+                    "git",
+                    f"--git-dir={self._git_dir}",
+                    "fetch",
+                    "origin",
+                    "+refs/heads/*:refs/heads/*",
+                    "--prune",
+                    "--prune-tags",
+                ],
+                on_synced,
+                lambda _error: on_error(network_error),
+            )
+            return
+
         try:
-            if which("git"):
-                if isdir(self._git_dir):
-                    subprocess.check_call(
-                        [
-                            "git",
-                            f"--git-dir={self._git_dir}",
-                            "fetch",
-                            "origin",
-                            "+refs/heads/*:refs/heads/*",
-                            "--prune",
-                            "--prune-tags",
-                        ],
-                        stderr=subprocess.DEVNULL,
-                    )
-                else:
-                    os.makedirs(self._git_dir)
-                    try:
-                        subprocess.check_call(
-                            ["git", "clone", "--bare", self.remote_url, self._git_dir],
-                            stderr=subprocess.DEVNULL,
-                        )
-                    except subprocess.CalledProcessError:
-                        # Otherwise the leftover empty dir sends future calls down the fetch path
-                        rmtree(self._git_dir, ignore_errors=True)
-                        raise
+            os.makedirs(self._git_dir)
+        except OSError:
+            on_error(network_error)
+            return
+        run_command(["git", "clone", "--bare", self.remote_url, self._git_dir], on_synced, on_clone_failed)
 
-                response = subprocess.check_output(["git", "ls-remote", self._git_dir]).decode().strip().split("\n")
-            else:
-                with urlopen(f"{self.remote_url}/info/refs?service=git-upload-pack") as reader:
-                    response = reader.read().decode().strip().split("\n")
-            if response:
-                if response[-1] == "0000":
-                    # Convert "smart" response, to more readable "dumb" response
-                    # See https://www.git-scm.com/docs/http-protocol#_discovering_references
-                    response = [r.split("\x00")[0][8:] if r.startswith("0000") else r[4:] for r in response[1:-1]]
+    def _get_refs_http(self, on_success: RefsSuccess, on_error: OnError) -> None:
+        # git is not installed: fetch the dumb HTTP info/refs endpoint instead
+        refs_url = f"{self.remote_url}/info/refs?service=git-upload-pack"
+        with NamedTemporaryFile(suffix=".refs", prefix="ulauncher_refs_", delete=False) as tmp:
+            refs_path = tmp.name
 
-                for row in response:
-                    commit, ref = row.split()
-                    refs[basename(ref)] = commit
+        def remove_tmp() -> None:
+            with contextlib.suppress(OSError):
+                os.remove(refs_path)
 
-        except (HTTPError, URLError) as e:
-            msg = f'Could not access repository resource "{self.url}"'
-            raise ext_exceptions.NetworkError(msg) from e
-        except (subprocess.CalledProcessError, OSError) as e:
-            msg = f'Could not fetch reference "{ref}" for {self.url}.' if ref else f"Could not fetch remote {self.url}."
-            raise ext_exceptions.NetworkError(msg) from e
+        def access_error() -> Exception:
+            return ext_exceptions.NetworkError(f'Could not access repository resource "{self.url}"')
 
-        return refs
+        def on_downloaded(_path: str) -> None:
+            try:
+                with open(refs_path) as reader:
+                    refs = _parse_refs_response(reader.read())
+            except (OSError, ValueError):
+                on_error(access_error())
+                return
+            finally:
+                remove_tmp()
+            on_success(refs)
 
-    def get_compatible_hash(self) -> str:
+        def on_download_failed(_error: Exception) -> None:
+            remove_tmp()
+            on_error(access_error())
+
+        download_file(refs_url, refs_path, on_downloaded, on_download_failed)
+
+    def get_compatible_hash(self, on_success: HashSuccess, on_error: OnError) -> None:
         """
-        Returns the commit hash for the highest compatible version, matching using branch names
+        Resolves the commit hash for the highest compatible version, matching using branch names
         and tags names starting with "apiv", ex "apiv3" and "apiv3.2"
         New method for v6. The new behavior is intentionally undocumented because we still
         want extension devs to use the old way until Ulauncher 5/apiv2 is fully phased out
         """
-        remote_refs = self._get_refs()
-        # Strip the "apiv" prefix so keys are bare version strings ("3", "3.2") usable with get_version
-        compatible = {
-            ver: sha
-            for ref, sha in remote_refs.items()
-            if ref.startswith("apiv") and satisfies(api_version, (ver := ref[4:]))
-        }
 
-        if compatible:
-            return compatible[max(compatible, key=get_version)]
+        def on_refs(remote_refs: dict[str, str]) -> None:
+            # Strip the "apiv" prefix so keys are bare version strings ("3", "3.2") usable with get_version
+            compatible = {
+                ver: sha
+                for ref, sha in remote_refs.items()
+                if ref.startswith("apiv") and satisfies(api_version, (ver := ref[4:]))
+            }
+            if compatible:
+                on_success(compatible[max(compatible, key=get_version)])
+                return
+            # Fall back on "HEAD" as a string as that can be used also
+            on_success(remote_refs.get("HEAD", "HEAD"))
 
-        # Try to get the commit ref for head, fallback on "HEAD" as a string as that can be used also
-        return remote_refs.get("HEAD", "HEAD")
+        self._get_refs(on_refs, on_error)
 
-    def _install_from_archive(self, commit_hash: str, output_dir_exists: bool) -> tuple[str, float]:
-        with NamedTemporaryFile(suffix=".tar.gz", prefix="ulauncher_dl_") as tmp_file:
-            # download() only routes here when the template is set; "" keeps the type a plain str
-            download_url = (self.download_url_template or "").replace("[commit]", commit_hash)
-            try:
-                urlretrieve(download_url, tmp_file.name)
-            except URLError as e:
-                err_msg = f"Failed to download extension from {download_url}: {e}"
-                raise ext_exceptions.RemoteError(err_msg) from e
-            with TemporaryDirectory(prefix="ulauncher_ext_") as tmp_root_dir:
+    def download(
+        self,
+        on_success: DownloadSuccess,
+        on_error: OnError,
+        commit_hash: str | None = None,
+        warn_if_overwrite: bool = False,
+    ) -> None:
+        if commit_hash:
+            self._download_with_hash(commit_hash, warn_if_overwrite, on_success, on_error)
+            return
+
+        def on_hash(resolved_hash: str) -> None:
+            self._download_with_hash(resolved_hash, warn_if_overwrite, on_success, on_error)
+
+        self.get_compatible_hash(on_hash, on_error)
+
+    def _download_with_hash(
+        self, commit_hash: str, warn_if_overwrite: bool, on_success: DownloadSuccess, on_error: OnError
+    ) -> None:
+        output_dir_exists = isdir(self.target_dir)
+        if output_dir_exists and warn_if_overwrite:
+            logger.info('Extension with URL "%s" is already installed. Updating', self.url)
+
+        if self.download_url_template:
+            download_url = self.download_url_template.replace("[commit]", commit_hash)
+            with NamedTemporaryFile(suffix=".tar.gz", prefix="ulauncher_dl_", delete=False) as tmp_file:
+                tmp_path = tmp_file.name
+
+            def remove_tmp() -> None:
+                with contextlib.suppress(OSError):
+                    os.remove(tmp_path)
+
+            def on_downloaded(_path: str) -> None:
                 try:
-                    untar(tmp_file.name, tmp_root_dir)
-                except (TarError, OSError) as e:
-                    err_msg = f"Failed to extract extension from {tmp_file.name}: {e}"
-                    raise ext_exceptions.RemoteError(err_msg) from e
+                    try:
+                        result = self._extract_and_install(tmp_path, commit_hash, output_dir_exists)
+                    except ext_exceptions.ExtensionError as install_error:
+                        on_error(install_error)
+                        return
+                    on_success(result)
+                finally:
+                    remove_tmp()
+
+            def on_download_failed(error: Exception) -> None:
+                remove_tmp()
+                on_error(ext_exceptions.RemoteError(f"Failed to download extension from {download_url}: {error}"))
+
+            download_file(download_url, tmp_path, on_downloaded, on_download_failed)
+            return
+
+        if not which("git"):
+            on_error(ext_exceptions.RemoteError("This extension URL can only be supported if you have git installed."))
+            return
+
+        try:
+            os.makedirs(self.target_dir, exist_ok=True)
+        except OSError as e:
+            on_error(ext_exceptions.RemoteError(f"Failed to create extension directory {self.target_dir}: {e}"))
+            return
+
+        def on_timestamp(stdout: str) -> None:
+            if not stdout:
+                on_error(ext_exceptions.RemoteError(f"Failed to read commit {commit_hash}"))
+                return
+            try:
+                commit_timestamp = float(stdout.strip())
+            except ValueError:
+                on_error(ext_exceptions.RemoteError(f"Failed to parse commit timestamp for {commit_hash}"))
+                return
+            on_success((commit_hash, commit_timestamp))
+
+        def on_checkout(_stdout: str) -> None:
+            run_command(
+                ["git", f"--git-dir={self._git_dir}", "show", "-s", "--format=%ct", commit_hash],
+                on_timestamp,
+                lambda e: on_error(ext_exceptions.RemoteError(f"Failed to read commit {commit_hash}: {e}")),
+            )
+
+        def run_checkout() -> None:
+            run_command(
+                ["git", f"--git-dir={self._git_dir}", f"--work-tree={self.target_dir}", "checkout", commit_hash, "."],
+                on_checkout,
+                lambda e: on_error(ext_exceptions.RemoteError(f"Failed to checkout commit {commit_hash}: {e}")),
+            )
+
+        if not isdir(self._git_dir):
+            # A pinned install passes commit_hash in and so skips get_compatible_hash(), which is
+            # what clones the bare repo. Bootstrap it so the checkout below has a repo to read from.
+            self._get_refs(lambda _refs: run_checkout(), on_error)
+            return
+
+        run_checkout()
+
+    def _extract_and_install(self, tar_path: str, commit_hash: str, output_dir_exists: bool) -> tuple[str, float]:
+        # All filesystem steps share the same failure semantics, so they live under one guard.
+        # shutil.Error subclasses OSError, so move() failures are covered too. The intentional
+        # RemoteError/CompatibilityError raises are ExtensionError (not OSError) and propagate as-is.
+        # This must not let a raw OSError escape: it runs inside a Gio callback, where an uncaught
+        # exception would be swallowed and hang _run_gio_blocking instead of reaching the caller.
+        try:
+            with TemporaryDirectory(prefix="ulauncher_ext_") as tmp_root_dir:
+                untar(tar_path, tmp_root_dir)
                 subdirs = os.listdir(tmp_root_dir)
                 if len(subdirs) != 1:
                     msg = f"Invalid archive for {self.url}."
@@ -148,52 +279,13 @@ class ExtensionRemote(UrlParseResult):
                         msg = f"{manifest.name} does not support Ulauncher API v{api_version}."
                         raise ext_exceptions.CompatibilityError(msg)
                     logger.warning("Falling back on using API 2.0 version for %s.", self.url)
-
                 if output_dir_exists:
                     rmtree(self.target_dir)
                 move(tmp_dir, self.target_dir)
-        return commit_hash, getmtime(self.target_dir)
-
-    def download(self, commit_hash: str | None = None, warn_if_overwrite: bool = False) -> tuple[str, float]:
-        if not commit_hash:
-            commit_hash = self.get_compatible_hash()
-        output_dir_exists = isdir(self.target_dir)
-
-        if output_dir_exists and warn_if_overwrite:
-            logger.info('Extension with URL "%s" is already installed. Updating', self.url)
-
-        if self.download_url_template:
-            return self._install_from_archive(commit_hash, output_dir_exists)
-
-        if not which("git"):
-            msg = "This extension URL can only be supported if you have git installed."
-            raise ext_exceptions.RemoteError(msg)
-
-        if not isdir(self._git_dir):
-            # A pinned install passes commit_hash in and so skips get_compatible_hash(), which is
-            # what clones the bare repo. Bootstrap it so the checkout below has a repo to read from.
-            self._get_refs()
-
-        os.makedirs(self.target_dir, exist_ok=True)
-
-        try:
-            subprocess.run(
-                ["git", f"--git-dir={self._git_dir}", f"--work-tree={self.target_dir}", "checkout", commit_hash, "."],
-                check=True,
-                stderr=subprocess.DEVNULL,
-            )
-            commit_timestamp = float(
-                subprocess.check_output(
-                    ["git", f"--git-dir={self._git_dir}", "show", "-s", "--format=%ct", commit_hash]
-                )
-                .decode()
-                .strip()
-            )
-        except subprocess.CalledProcessError as e:
-            err_msg = f"Failed to checkout commit {commit_hash}: {e}"
-            raise ext_exceptions.RemoteError(err_msg) from e
-        else:
-            return commit_hash, commit_timestamp
+            return commit_hash, getmtime(self.target_dir)
+        except (TarError, OSError) as e:
+            msg = f"Failed to install extension from {tar_path}: {e}"
+            raise ext_exceptions.RemoteError(msg) from e
 
 
 def parse_extension_url(input_url: str) -> UrlParseResult:

--- a/ulauncher/utils/subprocess_utils.py
+++ b/ulauncher/utils/subprocess_utils.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import subprocess
+import sys
 from typing import Callable
 
 from ulauncher.gi import Gio, GLib
@@ -38,3 +39,20 @@ def run_command(cmd: list[str], on_success: OnSuccess, on_error: OnError, *, cwd
         on_success(stdout)
 
     proc.communicate_utf8_async(None, None, on_done)
+
+
+# Run Python/urllib.request in a Gio.Subprocess to avoid needing a dependency like libsoup, gvfsd-http, curl or wget.
+_DOWNLOAD_SCRIPT = (
+    "import sys, urllib.request, shutil; "
+    "shutil.copyfileobj(urllib.request.urlopen(sys.argv[1], timeout=30), open(sys.argv[2], 'wb'))"
+)
+
+
+def download_file(url: str, dest_path: str, on_success: OnSuccess, on_error: OnError) -> None:
+    """Download url to dest_path without blocking. Calls on_success(dest_path) or on_error(error).
+    See _DOWNLOAD_SCRIPT for why this spawns Python."""
+    run_command(
+        [sys.executable, "-c", _DOWNLOAD_SCRIPT, url, dest_path],
+        lambda _stdout: on_success(dest_path),
+        on_error,
+    )


### PR DESCRIPTION
## Summary
Convert extension remote handling to use Gio.Subprocess, reusing the helper from #1733, and adding a download helper. This makes subprocess usage non-blocking and more robust.

Although to take benefit of the improvements we will need to remove the crutch (`_run_gio_blocking`) and make the full implementation. But that will need a bigger API-breaking refactor that I wanted to avoid in this PR.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Refactors extension remote Git and downloads to non-blocking `Gio.Subprocess` callbacks, improving robustness and avoiding blocking I/O. Adds `download_file` and a temporary GLib-loop bridge to keep the controller API unchanged.

- **Refactors**
  - Rewrote `extension_remote` to use `run_command`/`download_file`; removed blocking `subprocess`/`urllib` paths.
  - Extracted `_BareRepo` to own the bare repo lifecycle (clone/fetch/checkout/timestamps) with clear error mapping.
  - Kept HTTP `info/refs` fallback when `git` is missing, now via `download_file`.
  - Made `get_compatible_hash` and `download` callback-based; `ExtensionController.install/check_update` use `_run_gio_blocking` to bridge.

- **Bug Fixes**
  - Consistent mapping of failures to `NetworkError`/`RemoteError` (clone/fetch/checkout/download/untar/timestamp parse).
  - Self-heals broken bare repos by recreating the directory on failed clones.
  - Prevents hangs from exceptions inside callbacks and immediate-completion cases.
  - Expanded tests for refs resolution, downloads, error paths, and added `download_file` tests.

<sup>Written for commit 916836c713c06a959c232926997dd1e2b5795b77. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Ulauncher/Ulauncher/pull/1734?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

