### PR TITLE
refactor(ext-deps): convert dependency install to Gio.Subprocess

### DIFF
--- a/tests/modes/apps/extensions/test_extension_dependencies.py
+++ b/tests/modes/apps/extensions/test_extension_dependencies.py
@@ -1,3 +1,6 @@
+from __future__ import annotations
+
+import subprocess
 import sys
 from typing import Any, Callable
 from unittest.mock import MagicMock, mock_open
@@ -5,6 +8,7 @@ from unittest.mock import MagicMock, mock_open
 import pytest
 from pytest_mock import MockerFixture
 
+from ulauncher.modes.extensions import ext_exceptions
 from ulauncher.modes.extensions.extension_dependencies import ExtensionDependencies
 
 
@@ -29,8 +33,8 @@ def builtins_open(mocker: MockerFixture) -> Any:
 
 
 @pytest.fixture
-def subprocess_run(mocker: MockerFixture) -> MagicMock:
-    return mocker.patch("subprocess.run")
+def run_command(mocker: MockerFixture) -> MagicMock:
+    return mocker.patch("ulauncher.modes.extensions.extension_dependencies.run_command")
 
 
 @pytest.mark.usefixtures("isfile", "isdir")
@@ -43,14 +47,20 @@ def test_get_dependencies_path(
 
 @pytest.mark.usefixtures("builtins_open")
 def test_install(
-    subprocess_run: MagicMock,
+    run_command: MagicMock,
     extension_dependencies: ExtensionDependencies,
     isfile: MagicMock,
 ) -> None:
     isfile.return_value = True
-    subprocess_run.return_value = MagicMock(stdout="Installation successful", returncode=0)
 
-    extension_dependencies.install()
+    def side_effect(_cmd: list[str], on_success: Callable[[str], None], _on_error: Any) -> None:
+        on_success("Installation successful")
+
+    run_command.side_effect = side_effect
+    on_success = MagicMock()
+    on_error = MagicMock()
+
+    extension_dependencies.install(on_success, on_error)
 
     expected_command = [
         sys.executable,
@@ -62,4 +72,47 @@ def test_install(
         "--target",
         "/fake/path/.dependencies",
     ]
-    subprocess_run.assert_called_once_with(expected_command, check=True, capture_output=True, text=True)
+    assert run_command.call_args.args[0] == expected_command
+    on_success.assert_called_once_with("Installation successful")
+    on_error.assert_not_called()
+
+
+def test_install_without_requirements(
+    run_command: MagicMock,
+    extension_dependencies: ExtensionDependencies,
+    isfile: MagicMock,
+) -> None:
+    isfile.return_value = False  # no requirements.txt
+
+    on_success = MagicMock()
+    on_error = MagicMock()
+
+    extension_dependencies.install(on_success, on_error)
+
+    run_command.assert_not_called()
+    on_success.assert_called_once_with("")
+    on_error.assert_not_called()
+
+
+@pytest.mark.usefixtures("builtins_open")
+def test_install_failure_maps_to_dependency_error(
+    run_command: MagicMock,
+    extension_dependencies: ExtensionDependencies,
+    isfile: MagicMock,
+) -> None:
+    isfile.return_value = True
+
+    def side_effect(cmd: list[str], _on_success: Any, on_error: Callable[[Exception], None]) -> None:
+        on_error(subprocess.CalledProcessError(1, cmd, stderr="pip exploded"))
+
+    run_command.side_effect = side_effect
+    on_success = MagicMock()
+    on_error = MagicMock()
+
+    extension_dependencies.install(on_success, on_error)
+
+    on_success.assert_not_called()
+    on_error.assert_called_once()
+    error = on_error.call_args.args[0]
+    assert isinstance(error, ext_exceptions.DependencyError)
+    assert "pip exploded" in str(error)

--- a/ulauncher/modes/extensions/extension_controller.py
+++ b/ulauncher/modes/extensions/extension_controller.py
@@ -151,7 +151,7 @@ class ExtensionController:
         try:
             # install python dependencies from requirements.txt
             deps = ExtensionDependencies(remote.ext_id, remote.target_dir)
-            deps.install()
+            _run_gio_blocking(deps.install)
         except ext_exceptions.DependencyError:
             # clean up broken install
             rmtree(remote.target_dir)

--- a/ulauncher/modes/extensions/extension_dependencies.py
+++ b/ulauncher/modes/extensions/extension_dependencies.py
@@ -1,11 +1,11 @@
 from __future__ import annotations
 
 import logging
-import subprocess
 import sys
 from os.path import isdir, isfile
 
 from ulauncher.modes.extensions import ext_exceptions
+from ulauncher.utils.subprocess_utils import OnError, OnSuccess, run_command
 
 logger = logging.getLogger(__name__)
 
@@ -36,18 +36,21 @@ class ExtensionDependencies:
 
         return deps_path
 
-    def install(self) -> None:
+    def install(self, on_success: OnSuccess, on_error: OnError) -> None:
         """
-        Install the dependencies for the extension.
-        Runs `pip install -r extension-X/requirements.txt --target extension-X/deps`
+        Install the dependencies for the extension, without blocking.
+        Runs `pip install -r extension-X/requirements.txt --target extension-X/.dependencies`.
+        Calls on_success(stdout) when finished (including when there's nothing to install), or
+        on_error(DependencyError) if pip fails.
         """
         try:
             requirements = self._read_requirements()
         except OSError as e:
-            err_msg = f"Could not read {self.path}/requirements.txt: {e}"
-            raise ext_exceptions.DependencyError(err_msg) from e
+            on_error(ext_exceptions.DependencyError(f"Could not read {self.path}/requirements.txt: {e}"))
+            return
 
         if not requirements:
+            on_success("")
             return
 
         command = [
@@ -63,14 +66,17 @@ class ExtensionDependencies:
         command_str = " ".join(command)
         logger.info("Installing dependencies for %s. Running: %s", self.ext_id, command_str)
 
-        try:
-            result = subprocess.run(command, check=True, capture_output=True, text=True)
-            logger.info("Installation successful. Output: %s", result.stdout)
-        except subprocess.CalledProcessError as e:
-            output = e.stderr or e.stdout
-            logger.exception("Error during installation. Output: %s", output)
-            err_msg = f"$ {command_str}\n{output}"
-            raise ext_exceptions.DependencyError(err_msg) from e
+        def on_installed(stdout: str) -> None:
+            logger.info("Installation successful. Output: %s", stdout)
+            on_success(stdout)
+
+        def on_failed(error: Exception) -> None:
+            # run_command reports a non-zero pip exit as CalledProcessError, whose stderr/stdout hold the diagnostics
+            output = getattr(error, "stderr", None) or getattr(error, "output", None) or str(error)
+            logger.error("Error during installation. Output: %s", output, exc_info=error)
+            on_error(ext_exceptions.DependencyError(f"$ {command_str}\n{output}"))
+
+        run_command(command, on_installed, on_failed)
 
     def _read_requirements(self) -> str | None:
         """

--- a/ulauncher/modes/extensions/extension_mode.py
+++ b/ulauncher/modes/extensions/extension_mode.py
@@ -42,6 +42,7 @@ class ExtensionMode(Mode):
     _trigger_cache: dict[str, tuple[str, str]]  # keyword: (trigger_id, ext_id)
     _pending_callback: Callable[[EffectMessage | list[Result]], None] | None = None
     _request_id: int = 0
+    _pending_preview_id: str | None = None
 
     def __init__(self) -> None:
         self._trigger_cache = {}
@@ -358,30 +359,43 @@ class ExtensionMode(Mode):
         def load_preview_extension(ext_id: str) -> None:
             preview_ext_id = f"{ext_id}.preview"
             if controller := extension_registry.load(preview_ext_id, path):
-                controller.is_preview = True
+                ext = controller  # bind a non-optional local for the closures below
+                ext.is_preview = True
 
-                # install python dependencies from requirements.txt
-                from ulauncher.modes.extensions import ext_exceptions
+                # install python dependencies from requirements.txt, then launch
                 from ulauncher.modes.extensions.extension_dependencies import ExtensionDependencies
+
+                # _pending_preview_id is a single-instance cancellation token: stop_preview clears it
+                # to abort a start still queued behind the dep install. Preview is one-at-a-time by
+                # design (the debugger binds a fixed port), so concurrent previews are unsupported; a
+                # superseded start aborts on the mismatch checks below without restoring its original.
+                self._pending_preview_id = preview_ext_id
 
                 def restore_shadowed_original() -> None:
                     if (original := extension_registry.get(ext_id)) and original.shadowed_by_preview:
                         original.shadowed_by_preview = False
                         self.run_ext_batch_job([ext_id], ["start"])
 
-                deps = ExtensionDependencies(controller.id, controller.path)
-                try:
-                    deps.install()
-                except ext_exceptions.DependencyError:
-                    logger.exception("[preview] Failed to install dependencies for '%s'", preview_ext_id)
-                    restore_shadowed_original()
-                    return
+                def on_deps_installed(_stdout: str) -> None:
+                    if self._pending_preview_id != preview_ext_id:
+                        return
+                    self._pending_preview_id = None
+                    if ext.start(with_debugger=with_debugger):
+                        logger.info("[preview] Preview extension '%s' started successfully", preview_ext_id)
+                    else:
+                        logger.error("[preview] Failed to start preview extension '%s'", preview_ext_id)
+                        restore_shadowed_original()
 
-                if controller.start(with_debugger=with_debugger):
-                    logger.info("[preview] Preview extension '%s' started successfully", preview_ext_id)
-                else:
-                    logger.error("[preview] Failed to start preview extension '%s'", preview_ext_id)
+                def on_deps_error(error: Exception) -> None:
+                    if self._pending_preview_id != preview_ext_id:
+                        return
+                    self._pending_preview_id = None
+                    logger.error("[preview] Failed to install dependencies for '%s': %s", preview_ext_id, error)
                     restore_shadowed_original()
+
+                deps = ExtensionDependencies(ext.id, ext.path)
+                # deps.install must run on the GLib main loop so use idle_add since this can run from a worker thread.
+                GLib.idle_add(lambda: deps.install(on_deps_installed, on_deps_error))
 
         def on_stopped(ext_id: str) -> None:
             logger.info("[preview] Extension '%s' stopped", ext_id)
@@ -425,6 +439,10 @@ class ExtensionMode(Mode):
             preview_ext_id,
             original_ext_id,
         )
+
+        # Cancel a start still deferred behind a dependency install (both run on the main loop).
+        if self._pending_preview_id == preview_ext_id:
+            self._pending_preview_id = None
 
         # Try to restart the original extension
         def restart_original_extension(ext_id: str) -> None:


### PR DESCRIPTION
Replace the blocking subprocess.run in ExtensionDependencies.install with the callback-based run_command (Gio.Subprocess). install() now takes callback methods instead of returning/raising.

ExtensionController stays async/backwards-compatible through the existing _run_gio_blocking bridge.

This is step one of removing blocking subprocess calls from the extension dependency path. Making ExtensionController callback-native (and dropping _run_gio_blocking plus the asyncio/thread wrappers in the callers) is deferred to a separate change.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Converted extension dependency installs to non-blocking `Gio.Subprocess` via `run_command`, replacing `subprocess.run`. Preview installs no longer freeze the UI; start is deferred until deps finish and can be canceled.

- **Refactors**
  - `ExtensionDependencies.install` is now `install(on_success, on_error)`; no requirements call `on_success("")`; pip and read errors map to `ext_exceptions.DependencyError` with stderr.
  - `ExtensionController` stays compatible via `_run_gio_blocking(deps.install)`.
  - Preview installs run on the GLib main loop using `GLib.idle_add`; start only on success; cancel on stop, restoring the original extension on failure.
  - Tests updated to mock `run_command` and cover success, no requirements, and failure mapping.

<sup>Written for commit 403a882c8463ccaf2123d05a7e0bd7155b06cf91. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Ulauncher/Ulauncher/pull/1735?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

