### PR TITLE
refactor: simplify ext preview arg handling

### DIFF
--- a/ulauncher/cli/commands/preview.py
+++ b/ulauncher/cli/commands/preview.py
@@ -121,9 +121,7 @@ def run(args: CLIArguments) -> int:
         return 1
     logger.info("Extension ID: %s", ext_id)
 
-    preview_message = {"ext_id": ext_id, "path": str(path), "with_debugger": args.with_debugger}
-    logger.debug("Sending preview request over D-Bus: %s", preview_message)
-    dbus_trigger_event("extensions:preview_ext", preview_message)
+    dbus_trigger_event("extensions:preview_ext", ext_id, str(path), args.with_debugger)
 
     logger.info(
         "Extension '%s' started.\nSee extension's output along with the Ulauncher's in %s",
@@ -142,5 +140,5 @@ def run(args: CLIArguments) -> int:
     _wait_for_interrupt(ext_id)
 
     logger.info("Stopping '%s'...", ext_id)
-    dbus_trigger_event("extensions:stop_preview", {"preview_ext_id": f"{ext_id}.preview", "original_ext_id": ext_id})
+    dbus_trigger_event("extensions:stop_preview", f"{ext_id}.preview", ext_id)
     return 0

--- a/ulauncher/modes/extensions/extension_mode.py
+++ b/ulauncher/modes/extensions/extension_mode.py
@@ -322,32 +322,8 @@ class ExtensionMode(Mode):
         self._pending_callback = None
 
     @events.on
-    def preview_ext(self, payload: dict[str, Any] | None = None) -> None:
-        """Handle a preview extension request coming from the CLI (via D-Bus).
-
-        Stage: run the extension from an arbitrary filesystem path WITHOUT installing it.
-
-        Expected payload example:
-            {
-              "ext_id": "my-extension",
-              "path": "/abs/path/to/extension",
-              "with_debugger": false
-            }
-        """
-
-        if not payload or not isinstance(payload, dict):  # basic guard
-            logger.error("preview_ext called without valid payload: %s", payload)
-            return
-
-        ext_id = payload.get("ext_id")
-        path = payload.get("path")
-        with_debugger = bool(payload.get("with_debugger"))
-        if not isinstance(ext_id, str) or not ext_id.strip():
-            logger.error("preview_ext called without valid ext_id: %s", payload)
-            return
-        if not isinstance(path, str) or not path.strip():
-            logger.error("preview_ext called without valid path: %s", payload)
-            return
+    def preview_ext(self, ext_id: str, path: str, with_debugger: bool = False) -> None:
+        """Handle a preview extension request coming from the CLI (via D-Bus)."""
 
         logger.info(
             "[preview] Received preview request for ext_id=%s path=%s debugger=%s",
@@ -414,25 +390,8 @@ class ExtensionMode(Mode):
             load_preview_extension(ext_id)
 
     @events.on
-    def stop_preview(self, payload: dict[str, Any] | None = None) -> None:
-        """Handle stopping a preview extension and restoring the previous version if any.
-
-        Expected payload example:
-            {
-              "preview_ext_id": "my-extension.preview",
-              "original_ext_id": "my-extension"
-            }
-        """
-        if not payload or not isinstance(payload, dict):
-            logger.error("stop_preview called without valid payload: %s", payload)
-            return
-
-        preview_ext_id = payload.get("preview_ext_id")
-        original_ext_id = payload.get("original_ext_id")
-
-        if not preview_ext_id or not original_ext_id:
-            logger.error("stop_preview called without required fields: %s", payload)
-            return
+    def stop_preview(self, preview_ext_id: str, original_ext_id: str) -> None:
+        """Handle stopping a preview extension and restoring the previous version if any."""
 
         logger.info(
             "[preview] Received stop preview request for preview_ext_id=%s, original_ext_id=%s",


### PR DESCRIPTION
There was no need to handle all this logic, or to document the payload or verifying that ext_id and path are not non-empty strings (after trimming white-spaces). We are the ones sending this message.

This is a better fix for concern 2-3 from #1597 (concern 1 remains)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Simplifies the extension preview D-Bus API by switching from dict payloads to typed arguments. Removes redundant validation since the CLI is the sole caller.

- **Refactors**
  - CLI now sends positional args via `dbus_trigger_event` for `extensions:preview_ext` and `extensions:stop_preview`.
  - Handlers updated to `preview_ext(self, ext_id: str, path: str, with_debugger: bool = False)` and `stop_preview(self, preview_ext_id: str, original_ext_id: str)`.
  - Removed payload parsing, string trimming checks, and related error logs.

<sup>Written for commit 32e62e969aa72891ae86371f8d3f9a9b1bc0e377. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Ulauncher/Ulauncher/pull/1739?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

