### PR TITLE
fix(ext): fix extension kill method

### DIFF
--- a/tests/modes/apps/extensions/test_extension_runtime.py
+++ b/tests/modes/apps/extensions/test_extension_runtime.py
@@ -119,7 +119,7 @@ class TestExtensionRuntime:
         exit_handler = Mock()
         runtime: Any = ExtensionRuntime(extid, ["mock/path/to/ext"], None, exit_handler)
 
-        runtime._subprocess.get_exit_status.return_value = None
+        runtime._subprocess.get_identifier.return_value = "12345"
         runtime._msg_controller = Mock()
         runtime.stop()
 
@@ -132,9 +132,17 @@ class TestExtensionRuntime:
         extid = "mock.test_kill__sends_sigkill"
         runtime: Any = ExtensionRuntime(extid, ["mock/path/to/ext"])
 
-        # Simulate process still running
-        runtime._subprocess.get_exit_status.return_value = None
+        runtime._subprocess.get_identifier.return_value = "12345"  # still running
         runtime._kill()
 
-        # Verify SIGKILL is sent
         runtime._subprocess.send_signal.assert_called_once_with(signal.SIGKILL)
+
+    def test_kill__noop_when_already_reaped(self) -> None:
+        """_kill() must not signal once the process has been reaped (get_identifier() is None)."""
+        extid = "mock.test_kill__noop_when_already_reaped"
+        runtime: Any = ExtensionRuntime(extid, ["mock/path/to/ext"])
+
+        runtime._subprocess.get_identifier.return_value = None
+        runtime._kill()
+
+        runtime._subprocess.send_signal.assert_not_called()

--- a/ulauncher/modes/extensions/extension_runtime.py
+++ b/ulauncher/modes/extensions/extension_runtime.py
@@ -104,11 +104,9 @@ class ExtensionRuntime:
         timer(0.5, self._kill)
 
     def _kill(self) -> None:
-        if self._subprocess.get_exit_status() is None:
-            logger.info("Extension %s still running, sending SIGKILL", self._ext_id)
-            # It is possible that the process exited between the check above and this signal,
-            # luckily the subprocess library handles the signal delivery in race-free way, so this
-            # is safe to do.
+        if self._subprocess.get_identifier():
+            logger.info("Sending SIGKILL to extension %s", self._ext_id)
+            # The process may exit between this check and the signal; Gio delivers it race-free.
             self._subprocess.send_signal(signal.SIGKILL)
 
     def read_stderr_line(self) -> None:


### PR DESCRIPTION
Fixes the kill method that runs after the graceful timeout. Useses get_identifier() to test extension liveness before SIGKILL.

_kill() checked get_exit_status() is None to decide whether to kill, but get_exit_status() asserts the process has already exited (emitting a GLib-GIO-CRITICAL on a live process) and returns an int, never None, so the SIGKILL never fired. get_identifier() returns the pid while alive and None once reaped, which is the correct liveness check.

In practice this means a hung extension that ignored the graceful shutdown window was never force-killed, and a GLib-GIO-CRITICAL was logged every time stop() reached _kill() on a still-running process.

I managed to test this by removing `self._msg_controller.close()`. Before the pr that led to an error `GLib-GIO-CRITICAL **: 15:14:00.491: g_subprocess_get_exit_status: assertion 'pid == 0' failed`, the extension would not be kiled, and in the settings you would see "Toggle operation failed".

With this commit it works as expected.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Ensure hung extensions are force-killed after the graceful timeout by checking liveness with get_identifier and sending SIGKILL when still running. This removes GLib-GIO-CRITICAL logs and makes stop/toggle reliable.

- **Bug Fixes**
  - Use get_identifier() (pid present) instead of get_exit_status() to detect a live process.
  - Send SIGKILL only when still running; safe even if the process exits between checks.
  - Tests: verifies SIGKILL is sent when running and is a no-op once reaped; fixes stop test setup.

<sup>Written for commit 9d8777c493fc229fe549591e9221b60f443ec7a6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Ulauncher/Ulauncher/pull/1740?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

