### PR TITLE
fix(ext): fix legacy PreferencesEvent not being emitted reliably

### DIFF
--- a/ulauncher/api/extension.py
+++ b/ulauncher/api/extension.py
@@ -198,8 +198,7 @@ class Extension:
         Subscribes to events and connects to Ulauncher socket server
         """
         self.subscribe(events[EventType.UPDATE_PREFERENCES], PreferencesUpdateEventListener())
-        # Synthesize the deprecated PreferencesEvent locally so legacy extensions get it on every
-        # start. The prefs come from the env, so this fires regardless of how the process was started.
+        # Trigger legacy preferences load event synthetically
         self._do_trigger_event({"type": EventType.LEGACY_PREFERENCES_LOAD, "args": [self.preferences]})
         self._client.connect()
 

--- a/ulauncher/api/extension.py
+++ b/ulauncher/api/extension.py
@@ -198,7 +198,7 @@ class Extension:
         Subscribes to events and connects to Ulauncher socket server
         """
         self.subscribe(events[EventType.UPDATE_PREFERENCES], PreferencesUpdateEventListener())
-        # Trigger legacy preferences load event synthetically
+        # Trigger legacy preferences load event synthetically since the app no longer sends it
         self._do_trigger_event({"type": EventType.LEGACY_PREFERENCES_LOAD, "args": [self.preferences]})
         self._client.connect()
 

--- a/ulauncher/api/extension.py
+++ b/ulauncher/api/extension.py
@@ -198,6 +198,9 @@ class Extension:
         Subscribes to events and connects to Ulauncher socket server
         """
         self.subscribe(events[EventType.UPDATE_PREFERENCES], PreferencesUpdateEventListener())
+        # Synthesize the deprecated PreferencesEvent locally so legacy extensions get it on every
+        # start. The prefs come from the env, so this fires regardless of how the process was started.
+        self._do_trigger_event({"type": EventType.LEGACY_PREFERENCES_LOAD, "args": [self.preferences]})
         self._client.connect()
 
     def clipboard_store(self, text: str) -> None:

--- a/ulauncher/modes/extensions/extension_mode.py
+++ b/ulauncher/modes/extensions/extension_mode.py
@@ -53,9 +53,6 @@ class ExtensionMode(Mode):
         for ext in extension_registry.load_all():
             if ext.state.is_enabled:
                 ext.start()
-                # legacy_preferences_load is useless and deprecated
-                prefs = {p_id: pref.value for p_id, pref in ext.preferences.items()}
-                ext.send_message({"type": EventType.LEGACY_PREFERENCES_LOAD, "args": [prefs]})
 
     def has_trigger_changes(self) -> bool:
         return not self._trigger_cache


### PR DESCRIPTION
Fixes two broken contracts:
* The legacy PreferencesEvent should be sent consistently when the extension has started and has the preferences.
* The legacy preferences format should also contain the keywords, because it did in v5.

Instead of actually sending the event from the app we trigger the event from the extension runtime.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Ensures the legacy `PreferencesEvent` is emitted on every extension start and includes keywords, matching v5 behavior. The event is now synthesized in the extension runtime instead of being sent from the app.

- **Bug Fixes**
  - Trigger `LEGACY_PREFERENCES_LOAD` in `ulauncher/api/extension.py` at startup using current preferences and remove the old send from `ulauncher/modes/extensions/extension_mode.py`, so it fires on enable, update, preview, and all starts.
  - Include keywords in the legacy preferences payload.

<sup>Written for commit 3d1d3b14d45dde035da524f9b36fe8ecf44fc7ba. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Ulauncher/Ulauncher/pull/1742?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

