### PR TITLE
feat(extensions): progressive (streamed) responses from generator listeners

### DIFF
--- a/docs/architecture/extension-ipc.md
+++ b/docs/architecture/extension-ipc.md
@@ -56,3 +56,31 @@ Extensions run in **separate processes** as the same user as Ulauncher (not sand
 4. Extension handles action → may send new results back
 
 All communication is asynchronous using GLib's event loop.
+
+## Partial (Streamed) Responses
+
+Extension listeners that return a generator stream their results progressively: the
+accumulated results are sent as responses marked `"partial": true`, throttled to at most
+one per `ULAUNCHER_PARTIAL_RESPONSE_INTERVAL` seconds (default 0.1), followed by a final
+unmarked, unthrottled response with the complete list. Yields landing within the
+interval are not lost: they are included in the next response — the next partial, or the
+final one if nothing else is yielded. Ulauncher keeps the response callback alive until
+the final response, so each partial replaces the rendered list.
+
+`ULAUNCHER_PARTIAL_RESPONSES=1` is exported by the app when spawning extension
+processes. `ULAUNCHER_PARTIAL_RESPONSE_INTERVAL` is only read by the extension process
+from its inherited environment — a tuning knob the app never sets.
+
+Yielding a `Result` appends it to the streamed list; yielding a `list[Result]` replaces
+it, so producers can update results they already sent (e.g. an LLM answer growing as
+tokens arrive). If the generator raises, the error is logged and the accumulated results
+are sent as the final response, so the request always terminates.
+
+This only happens when the app advertises support via the `ULAUNCHER_PARTIAL_RESPONSES=1`
+environment variable; otherwise generators are collected into a single response, because
+older apps treat the first response as final. Stale partials are discarded through the
+existing `request_id` check; when newer input supersedes the request, the extension stops
+consuming the generator and sends nothing more — not even a final response.
+
+Primary use case: extensions backed by slow producers (LLM APIs, network searches) that
+can render results as they arrive.

--- a/tests/api/test_extension.py
+++ b/tests/api/test_extension.py
@@ -1,10 +1,14 @@
+from __future__ import annotations
+
 import logging
 import os
-from unittest.mock import patch
+from typing import Any, Iterator
+from unittest.mock import MagicMock, patch
 
 from pytest_mock import MockerFixture
 
 from ulauncher.api.extension import Extension
+from ulauncher.internals.result import Result
 
 
 class TestExtension:
@@ -24,3 +28,122 @@ class TestExtension:
             Extension()
 
         assert basic_config.call_args_list[0].kwargs["level"] == logging.DEBUG
+
+
+class TestExtensionPartialResponses:
+    def _make_extension(self, mocker: MockerFixture, env: dict[str, str]) -> Extension:
+        mocker.patch("ulauncher.api.extension.Client")
+        mocker.patch("ulauncher.api.extension.logging.basicConfig")
+        mocker.patch("ulauncher.api.extension.signal.signal")
+        # Run idle callbacks synchronously so client.send calls can be asserted directly
+        mocker.patch("ulauncher.api.extension.GLib.idle_add", side_effect=lambda fn, *args: fn(*args))
+
+        with patch.dict(os.environ, {"ULAUNCHER_EXTENSION_ID": "com.example.test", **env}):
+            return Extension()
+
+    def _sent_responses(self, extension: Extension) -> list[dict[str, Any]]:
+        send_mock = extension._client.send  # type: ignore[attr-defined]
+        assert isinstance(send_mock, MagicMock)
+        return [call.args[1] for call in send_mock.call_args_list if call.args[0] == "response"]
+
+    def test_generator_streams_partials_when_supported(self, mocker: MockerFixture) -> None:
+        extension = self._make_extension(
+            mocker, {"ULAUNCHER_PARTIAL_RESPONSES": "1", "ULAUNCHER_PARTIAL_RESPONSE_INTERVAL": "0"}
+        )
+        results = [Result(name=f"item{i}") for i in range(3)]
+
+        def listener(_query: str) -> Iterator[Result]:
+            yield from results
+
+        extension.run_event_listener({"type": "event:input_trigger"}, listener, ("query",), input_request_id=0)
+
+        responses = self._sent_responses(extension)
+        assert len(responses) == 4, "expected one partial per result plus the final response"
+        assert all(response.get("partial") for response in responses[:3])
+        assert "partial" not in responses[3]
+        assert [len(response["effect"]) for response in responses] == [1, 2, 3, 3]
+
+    def test_generator_is_collected_without_capability_flag(self, mocker: MockerFixture) -> None:
+        extension = self._make_extension(mocker, {})
+
+        def listener(_query: str) -> Iterator[Result]:
+            yield from (Result(name=f"item{i}") for i in range(3))
+
+        extension.run_event_listener({"type": "event:input_trigger"}, listener, ("query",), input_request_id=0)
+
+        responses = self._sent_responses(extension)
+        assert len(responses) == 1, "without the capability flag the generator must be collected"
+        assert "partial" not in responses[0]
+        assert len(responses[0]["effect"]) == 3
+
+    def test_partials_are_throttled(self, mocker: MockerFixture) -> None:
+        extension = self._make_extension(
+            mocker, {"ULAUNCHER_PARTIAL_RESPONSES": "1", "ULAUNCHER_PARTIAL_RESPONSE_INTERVAL": "1000"}
+        )
+
+        def listener(_query: str) -> Iterator[Result]:
+            yield from (Result(name=f"item{i}") for i in range(10))
+
+        extension.run_event_listener({"type": "event:input_trigger"}, listener, ("query",), input_request_id=0)
+
+        responses = self._sent_responses(extension)
+        assert len(responses) == 2, "expected the leading partial and the final response only"
+        assert responses[0].get("partial")
+        assert "partial" not in responses[1]
+        assert len(responses[1]["effect"]) == 10
+
+    def test_yielded_lists_replace_accumulated_results(self, mocker: MockerFixture) -> None:
+        extension = self._make_extension(
+            mocker, {"ULAUNCHER_PARTIAL_RESPONSES": "1", "ULAUNCHER_PARTIAL_RESPONSE_INTERVAL": "0"}
+        )
+
+        def listener(_query: str) -> Iterator[Result | list[Result]]:
+            yield [Result(name="answer: hello")]
+            yield [Result(name="answer: hello world!")]
+            yield Result(name="extra item")
+
+        extension.run_event_listener({"type": "event:input_trigger"}, listener, ("query",), input_request_id=0)
+
+        responses = self._sent_responses(extension)
+        assert [len(response["effect"]) for response in responses] == [1, 1, 2, 2]
+        assert responses[1]["effect"][0]["name"] == "answer: hello world!"
+        assert responses[3]["effect"][1]["name"] == "extra item"
+
+    def test_failing_generator_still_sends_a_final_response(self, mocker: MockerFixture) -> None:
+        extension = self._make_extension(
+            mocker, {"ULAUNCHER_PARTIAL_RESPONSES": "1", "ULAUNCHER_PARTIAL_RESPONSE_INTERVAL": "1000"}
+        )
+
+        def listener(_query: str) -> Iterator[Result]:
+            yield Result(name="item0")
+            msg = "boom"
+            raise RuntimeError(msg)
+
+        extension.run_event_listener({"type": "event:input_trigger"}, listener, ("query",), input_request_id=0)
+
+        responses = self._sent_responses(extension)
+        assert "partial" not in responses[-1], "the app must always receive a final response"
+        assert len(responses[-1]["effect"]) == 1
+
+    def test_superseded_request_stops_consuming_the_generator(self, mocker: MockerFixture) -> None:
+        extension = self._make_extension(
+            mocker, {"ULAUNCHER_PARTIAL_RESPONSES": "1", "ULAUNCHER_PARTIAL_RESPONSE_INTERVAL": "0"}
+        )
+        consumed: list[str] = []
+
+        def listener(_query: str) -> Iterator[Result]:
+            consumed.append("first")
+            yield Result(name="first")
+            extension._input_request_id += 1  # a newer input arrived mid-stream
+            consumed.append("second")
+            yield Result(name="second")
+            consumed.append("third")
+            yield Result(name="third")
+
+        extension.run_event_listener({"type": "event:input_trigger"}, listener, ("query",), input_request_id=0)
+
+        assert consumed == ["first", "second"], "iteration must stop once the request is superseded"
+        responses = self._sent_responses(extension)
+        assert len(responses) == 1
+        assert responses[0].get("partial")
+        assert len(responses[0]["effect"]) == 1, "no final response must be sent for a superseded request"

--- a/tests/internals/test_effect_utils.py
+++ b/tests/internals/test_effect_utils.py
@@ -29,3 +29,24 @@ class TestShouldClose:
         """OPEN effect should close the window."""
         effect = effects.open("/path/to/file")
         assert effect_utils.should_close(effect)
+
+
+class TestConvertToEffectMessage:
+    def test_iterable_results_are_collected(self) -> None:
+        from ulauncher.internals.result import Result
+
+        results = [Result(name="a"), Result(name="b")]
+        assert effect_utils.convert_to_effect_message(iter(results)) == results
+
+    def test_yielded_lists_replace_previous_results(self) -> None:
+        """Mirrors the streamed semantics: a yielded list replaces, a Result appends."""
+        from ulauncher.internals.result import Result
+
+        def listener_output():  # noqa: ANN202
+            yield [Result(name="answer: hello")]
+            yield [Result(name="answer: hello world!")]
+            yield Result(name="extra item")
+
+        converted = effect_utils.convert_to_effect_message(listener_output())
+        assert isinstance(converted, list)
+        assert [result.name for result in converted] == ["answer: hello world!", "extra item"]

--- a/tests/modes/extensions/test_extension_controller.py
+++ b/tests/modes/extensions/test_extension_controller.py
@@ -1,0 +1,31 @@
+from types import SimpleNamespace
+from unittest.mock import MagicMock, PropertyMock
+
+from pytest_mock import MockerFixture
+
+from ulauncher.modes.extensions.extension_controller import ExtensionController
+
+
+def test_start__advertises_partial_responses_capability(mocker: MockerFixture) -> None:
+    """Without this env flag extensions silently stop streaming (see api/extension.py)."""
+    controller = object.__new__(ExtensionController)
+    controller.id = "test.ext"
+    controller.path = "/tmp/test.ext"
+    controller.state = MagicMock()
+    controller.shadowed_by_preview = False
+    controller.manifest = MagicMock(triggers={})
+
+    mocker.patch.object(ExtensionController, "is_running", new_callable=PropertyMock, return_value=False)
+    mocker.patch.object(ExtensionController, "preferences", new_callable=PropertyMock, return_value={})
+    deps = mocker.patch("ulauncher.modes.extensions.extension_controller.ExtensionDependencies")
+    deps.return_value.get_dependencies_path.return_value = ""
+    mocker.patch(
+        "ulauncher.modes.extensions.extension_controller.cli.get_args",
+        return_value=SimpleNamespace(verbose=False),
+    )
+    runtime = mocker.patch("ulauncher.modes.extensions.extension_controller.ExtensionRuntime")
+
+    controller.start()  # returns is_running, which is mocked — the spawn env is what matters here
+
+    env = runtime.call_args.args[2]
+    assert env["ULAUNCHER_PARTIAL_RESPONSES"] == "1"

--- a/tests/modes/extensions/test_extension_mode.py
+++ b/tests/modes/extensions/test_extension_mode.py
@@ -1,5 +1,11 @@
 from types import SimpleNamespace
+from typing import TYPE_CHECKING, Any, cast
 from unittest.mock import MagicMock, PropertyMock
+
+import pytest
+
+if TYPE_CHECKING:
+    from collections.abc import Iterator
 
 from pytest_mock import MockerFixture
 
@@ -55,3 +61,51 @@ def test_update_preferences__uses_emitted_old_preferences(mocker: MockerFixture)
     ext.send_message.assert_called_once_with(
         {"type": EventType.UPDATE_PREFERENCES, "args": ["city", "Berlin", "Stockholm"]}
     )
+
+
+@pytest.fixture
+def pending_callback_setup() -> "Iterator[SimpleNamespace]":
+    from ulauncher.modes.extensions import extension_mode
+
+    mode = object.__new__(extension_mode.ExtensionMode)
+    mode.active_ext = cast("Any", SimpleNamespace(id="test.ext", get_icon_value=MagicMock(return_value="icon.png")))
+    mode._request_id = 1
+    mode._pending_callback = MagicMock()
+    extension_mode.events.set_self(mode)
+    yield SimpleNamespace(mode=mode, callback=mode._pending_callback)
+    extension_mode.events.set_self(None)  # the EventBus self is global state
+
+
+def test_handle_response__partial_keeps_the_callback_alive(pending_callback_setup: SimpleNamespace) -> None:
+    setup = pending_callback_setup
+
+    setup.mode.handle_response("test.ext", {"request_id": 1, "partial": True, "effect": [{"name": "a"}]})
+
+    setup.callback.assert_called_once()
+    assert setup.mode._pending_callback is setup.callback
+
+    setup.mode.handle_response("test.ext", {"request_id": 1, "effect": [{"name": "a"}, {"name": "b"}]})
+
+    assert setup.callback.call_count == 2
+    assert setup.mode._pending_callback is None
+
+
+def test_handle_response__partial_flag_is_ignored_for_non_list_effects(
+    pending_callback_setup: SimpleNamespace,
+) -> None:
+    setup = pending_callback_setup
+
+    setup.mode.handle_response("test.ext", {"request_id": 1, "partial": True, "effect": {"type": "effect:do_nothing"}})
+
+    setup.callback.assert_called_once()
+    assert setup.mode._pending_callback is None
+
+
+def test_handle_response__outdated_partial_is_ignored(pending_callback_setup: SimpleNamespace) -> None:
+    setup = pending_callback_setup
+    setup.mode._request_id = 2
+
+    setup.mode.handle_response("test.ext", {"request_id": 1, "partial": True, "effect": [{"name": "a"}]})
+
+    setup.callback.assert_not_called()
+    assert setup.mode._pending_callback is setup.callback

--- a/tests/ui/test_item_navigation.py
+++ b/tests/ui/test_item_navigation.py
@@ -6,6 +6,7 @@ from unittest.mock import MagicMock
 import pytest
 from pytest_mock import MockerFixture
 
+from ulauncher.internals.result import Result
 from ulauncher.ui.item_navigation import ItemNavigation
 from ulauncher.ui.query_history import QueryHistory
 from ulauncher.ui.result_widget import ResultWidget
@@ -61,3 +62,28 @@ class TestItemNavigation:
         nav.select(4)
         nav.go_down()
         items[0].select.assert_called_once_with()
+
+    def test_select_preferred__reselects_matching_result(self, nav: ItemNavigation, items: list[MagicMock]) -> None:
+        for index, item in enumerate(items):
+            item.result.name = f"item{index}"
+        nav.select_preferred("query", Result(name="item3"))
+        assert nav.index == 3
+        items[3].select.assert_called_once_with()
+
+    def test_select_preferred__falls_back_to_default_when_result_is_gone(
+        self, nav: ItemNavigation, items: list[MagicMock]
+    ) -> None:
+        for index, item in enumerate(items):
+            item.result.name = f"item{index}"
+        nav.select_preferred("query", Result(name="removed"))
+        assert nav.index == 0
+
+    def test_select_preferred__falls_back_to_default_without_previous_result(self, nav: ItemNavigation) -> None:
+        nav.select_preferred("query", None)
+        assert nav.index == 0
+
+    def test_select_preferred__first_of_duplicate_names_wins(self, nav: ItemNavigation, items: list[MagicMock]) -> None:
+        for item in items:
+            item.result.name = "same"
+        nav.select_preferred("query", Result(name="same"))
+        assert nav.index == 0

--- a/ulauncher/api/extension.py
+++ b/ulauncher/api/extension.py
@@ -7,7 +7,8 @@ import os
 import signal
 import threading
 from collections import defaultdict
-from typing import Any, Callable, Iterable, cast
+from time import monotonic
+from typing import Any, Callable, Iterable, Iterator, cast
 
 from ulauncher.api.client.Client import Client
 from ulauncher.api.client.EventListener import EventListener
@@ -48,6 +49,9 @@ class Extension:
         self._input_request_id: int = 0
         self._input_debounce_timer: TimerContext | None = None
         self._input_debounce_delay = float(os.getenv("ULAUNCHER_INPUT_DEBOUNCE", "0.05"))
+        # Apps without this capability flag treat the first response as final
+        self._partial_responses_enabled = os.getenv("ULAUNCHER_PARTIAL_RESPONSES") == "1"
+        self._partial_response_interval = float(os.getenv("ULAUNCHER_PARTIAL_RESPONSE_INTERVAL", "0.1"))
         self._result_cache: dict[int, Result] = {}
         signal.signal(signal.SIGTERM, lambda *_: self._client.unload())
         with contextlib.suppress(Exception):
@@ -164,17 +168,43 @@ class Extension:
         args: tuple[Any],
         input_request_id: int | None = None,
     ) -> None:
-        # For extensions using yield to generate results, the method call will take no time, while
-        # the conversion step will actually be the slow part. So we need to check staleness after both.
         input_effect_msg = method(*args)
+        if self._partial_responses_enabled and isinstance(input_effect_msg, Iterator):
+            self._stream_event_response(event, input_effect_msg, input_request_id)
+            return
+        # collecting a generator can be slow; staleness is re-checked in _send_response
         effect_msg = effect_utils.convert_to_effect_message(input_effect_msg)
         # Schedule the response on the main thread to avoid races on shared state
         GLib.idle_add(self._send_response, event, effect_msg, input_request_id)
 
+    def _stream_event_response(
+        self,
+        event: dict[str, Any],
+        results_iter: Iterator[Result | list[Result]],
+        input_request_id: int | None,
+    ) -> None:
+        """Stream throttled partial result lists, then an unthrottled final response."""
+        accumulated: list[Result] = []
+        last_sent = 0.0
+        try:
+            for result in results_iter:
+                if input_request_id is not None and input_request_id != self._input_request_id:
+                    return  # superseded; the app would discard any response
+                accumulated = effect_utils.append_or_replace(accumulated, result)
+                now = monotonic()
+                if now - last_sent >= self._partial_response_interval:
+                    last_sent = now
+                    # copies: this thread and _send_response both mutate them before idle runs
+                    GLib.idle_add(self._send_response, {**event, "partial": True}, list(accumulated), input_request_id)
+        except Exception:  # extension code: anything can raise
+            # the app waits forever without a final response
+            self.logger.exception("Generator listener failed mid-stream")
+        GLib.idle_add(self._send_response, event, accumulated, input_request_id)
+
     def _send_response(
         self,
         event: dict[str, Any],
-        effect_msg: effects.EffectMessage | None,
+        effect_msg: effects.EffectMessage | list[Result] | None,
         input_request_id: int | None,
     ) -> bool:
         if input_request_id is not None and input_request_id != self._input_request_id:

--- a/ulauncher/internals/effect_utils.py
+++ b/ulauncher/internals/effect_utils.py
@@ -86,4 +86,16 @@ def convert_to_effect_message(input_data: EffectMessageInput | None) -> EffectMe
             return cast("EffectMessage", input_data)  # TypedDict unions can't be narrowed by runtime checks
         err_msg = f"Invalid effect message dict: {input_data}"
         raise ValueError(err_msg)
-    return list(cast("Iterable[Result]", input_data))  # collect/flatten iterators to lists
+    results: list[Result] = []
+    for item in cast("Iterable[Result | list[Result]]", input_data):
+        results = append_or_replace(results, item)
+    return results
+
+
+def append_or_replace(results: list[Result], item: Result | list[Result]) -> list[Result]:
+    """A produced Result appends, a produced list replaces — lets producers update
+    results they already produced (e.g. a growing LLM answer)."""
+    if isinstance(item, list):
+        return list(item)
+    results.append(item)
+    return results

--- a/ulauncher/internals/effects.py
+++ b/ulauncher/internals/effects.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any, Final, Iterable, Literal, TypedDict, Union
+from typing import TYPE_CHECKING, Any, Final, Iterable, List, Literal, TypedDict, Union
 
 # if type checking import Result
 if TYPE_CHECKING:
@@ -69,7 +69,8 @@ EffectMessage = Union[
 ]
 
 # Input format that we will convert to an EffectMessage
-EffectMessageInput = Union[EffectMessage, bool, str, Iterable["Result"]]
+# iterables may mix Results (append) and lists of Results (replace what came before)
+EffectMessageInput = Union[EffectMessage, bool, str, Iterable[Union["Result", List["Result"]]]]
 
 
 def do_nothing() -> DoNothing:

--- a/ulauncher/modes/extensions/extension_controller.py
+++ b/ulauncher/modes/extensions/extension_controller.py
@@ -357,6 +357,8 @@ class ExtensionController:
             "EXTENSION_PREFERENCES": json.dumps(v2_prefs, separators=(",", ":")),
             "ULAUNCHER_EXTENSION_ID": self.id,
             "ULAUNCHER_INPUT_DEBOUNCE": str(self.manifest.input_debounce),
+            # without this flag extensions must not stream (first response = final)
+            "ULAUNCHER_PARTIAL_RESPONSES": "1",
         }
 
         # socketpair/spawnv can fail for host-environment reasons (fd exhaustion, fork limits,

--- a/ulauncher/modes/extensions/extension_mode.py
+++ b/ulauncher/modes/extensions/extension_mode.py
@@ -25,6 +25,7 @@ events = EventBus("extensions")
 class ExtensionResponse(TypedDict, total=False):
     request_id: int
     keep_app_open: bool
+    partial: bool
     effect: EffectMessage | list[dict[str, Any]]
 
 
@@ -316,7 +317,11 @@ class ExtensionMode(Mode):
             effect_msg = raw_effect_msg
 
         self._pending_callback(effect_msg)
-        self._pending_callback = None
+        # partials (result lists only) keep the callback alive for the rest of the request
+        if not (response.get("partial") and isinstance(effect_msg, list)):
+            if response.get("partial"):
+                logger.warning("Partial response from %s with a non-list effect ends the request", ext_id)
+            self._pending_callback = None
 
     @events.on
     def preview_ext(self, ext_id: str, path: str, with_debugger: bool = False) -> None:

--- a/ulauncher/ui/item_navigation.py
+++ b/ulauncher/ui/item_navigation.py
@@ -40,6 +40,16 @@ class ItemNavigation:
     def select_default(self, query: str) -> None:
         self.select(self.get_default(query))
 
+    def select_preferred(self, query: str, previous_result: Result | None = None) -> None:
+        """Keep the user's selection across re-renders of the same query, else select
+        the default. Matches by name: first duplicate wins."""
+        if previous_result is not None:
+            for index, widget in enumerate(self.result_widgets):
+                if widget.result.name == previous_result.name:
+                    self.select(index)
+                    return
+        self.select_default(query)
+
     def select(self, index: int) -> None:
         if not 0 < index < len(self.result_widgets):
             index = 0

--- a/ulauncher/ui/ulauncher_window.py
+++ b/ulauncher/ui/ulauncher_window.py
@@ -422,6 +422,9 @@ class UlauncherWindow(Gtk.ApplicationWindow):
         self.prompt_input.set_position(-1)
 
     def show_results(self, results: Iterable[Result]) -> None:
+        # only deliberate (non-default) selections survive re-renders
+        previous_nav = self._results_nav
+        previous_selection = previous_nav.get_active_result() if previous_nav and previous_nav.index > 0 else None
         self._results_nav = None
         self.results.foreach(lambda w: w.destroy())
 
@@ -439,7 +442,7 @@ class UlauncherWindow(Gtk.ApplicationWindow):
                 self.results.add(result_widget)
 
             self._results_nav = ItemNavigation(result_widgets)
-            self._results_nav.select_default(str(self.core.query))
+            self._results_nav.select_preferred(str(self.core.query), previous_selection)
 
             self.results.set_margin_bottom(10)
             self.results.set_margin_top(3)


### PR DESCRIPTION
## Motivation

AI/LLM extensions are now among the most popular Ulauncher extensions (ChatGPT, Gemini, Ollama, Mistral…), and they all share the same UX problem: an LLM answer takes several seconds to complete, and today the extension API only allows **a single rendered response per request** — the user stares at "Loading…" until the full answer arrives, while every chat UI they know renders tokens as they stream.

This PR makes generator listeners stream: results are rendered progressively, exactly like the API v3 `yield` syntax already suggests. Follows up on the exchange in discussion #1736 ("Making it actually progressive is harder and hasn't been requested until now, but it should be possible").

Tested end-to-end on GNOME Wayland with a real extension streaming SSE chunks from the Mistral API ([demo branch](https://github.com/PhilMeyr/ulauncher-mistral/tree/feat/streaming-demo)).

## Design

- **Extension side** (`api/extension.py`): when a listener returns a generator, the accumulated results are sent as responses marked `"partial": true`, throttled (default 0.1s, tunable via `ULAUNCHER_PARTIAL_RESPONSE_INTERVAL`), followed by an unthrottled final response. Yielding a `Result` appends; yielding a `list[Result]` **replaces** the accumulated results — needed for content that grows over time (an LLM answer) rather than a growing list of items. The same semantics apply when generators are collected without streaming (shared helper `effect_utils.append_or_replace`).
- **App side** (`extension_mode.py`): `handle_response` keeps `_pending_callback` alive while responses are partial (result lists only — a malformed partial is logged and ends the request). The existing `request_id` staleness check applies to partials unchanged, and the extension stops consuming the generator as soon as its request is superseded.
- **Capability negotiation**: the app advertises support via the `ULAUNCHER_PARTIAL_RESPONSES=1` env var. Without it, extensions collect generators into a single response (today's behavior) — old app + new extension and new app + old extension both keep working. No manifest or API version change.
- **Robustness**: if the generator raises mid-stream, the error is logged and the accumulated results are sent as the final response, so the request always terminates.
- **Selection preservation** (`ui/`): re-renders previously reset the keyboard selection to the default, which would make the selection jump on every partial. `show_results` now carries deliberate (user-moved) selections over to the next render by result name. This also fixes the existing selection jump when the "Loading…" placeholder is replaced.

## Notes

- The UI callback was already safely re-callable (it's how the placeholder replacement works); the single-response constraint was only in `handle_response` and in the generator collection.
- No extension API change: `Iterable[Result]` listeners and `yield` are already legal — they just render progressively now.
- Out of scope (pre-existing behavior, unchanged): extension exceptions are not surfaced to the UI — a listener that raises still only logs in the extension process. Streaming extensions can catch their own errors and yield error results.
- Tests cover: partial/final sequencing, throttling, replace-vs-append semantics, superseded-request abort, mid-stream generator failure, no-capability fallback, the capability handshake, partial handling and staleness app-side, and selection preservation.
- I read CONTRIBUTING's preference for discussing features first — happy to move this conversation to a Discussion if you prefer; opening as a PR to make the proposal concrete, following up on #1736.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds progressive (streamed) responses for extension generator listeners so results render as they arrive, greatly improving UX for LLM-backed extensions. Backward compatible: without the capability flag, generators are collected into a single final response.

- **New Features**
  - Stream partial result lists when `ULAUNCHER_PARTIAL_RESPONSES=1`, throttled by `ULAUNCHER_PARTIAL_RESPONSE_INTERVAL` (default 0.1s), followed by an unthrottled final response.
  - Yield semantics: yielding a `Result` appends; yielding `list[Result]` replaces the list (supports growing content like LLM answers).
  - App keeps the pending callback alive for partials and replaces the rendered list on each partial; staleness check via `request_id` still applies.
  - Generator errors mid-stream log and still produce a final response; iteration stops immediately when a request is superseded.
  - App advertises capability to extensions via `ULAUNCHER_PARTIAL_RESPONSES=1`; no manifest or API version change. Docs updated.

- **Bug Fixes**
  - Preserve deliberate keyboard selection across result re-renders to prevent selection jumps (also fixes jump when replacing the “Loading…” placeholder).

<sup>Written for commit 03d1109a41741faee987abc2a561f77032abc0d3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Ulauncher/Ulauncher/pull/1743?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

