### PR TITLE
feat(ui): opt-in multi-line (non-truncated) results via Result.wrap

### DIFF
--- a/tests/ui/test_result_widget.py
+++ b/tests/ui/test_result_widget.py
@@ -1,3 +1,4 @@
+from typing import cast
 from unittest.mock import MagicMock
 
 import pytest
@@ -34,3 +35,37 @@ class TestResultWidget:
         assert result_wgt.shortcut_label.get_text() == "Alt+1"
         result_wgt.set_index(2)
         assert result_wgt.shortcut_label.get_text() == "Alt+3"
+
+    def test_wrap__name_and_description_labels_wrap_instead_of_ellipsizing(self) -> None:
+        from gi.repository import Gtk, Pango
+
+        res = Result(name="long name", description="long descr", wrap=True)
+        widget = ResultWidget(res, 0, Query("", None))
+
+        name_label = cast("Gtk.Label", widget.title_box.get_children()[0])
+        descr_label = cast("Gtk.Label", widget.text_container.get_children()[1])
+        for label in (name_label, descr_label):
+            assert label.get_line_wrap()
+            assert label.get_ellipsize() == Pango.EllipsizeMode.NONE
+
+    def test_wrap__defaults_to_single_ellipsized_line(self) -> None:
+        from gi.repository import Gtk, Pango
+
+        res = Result(name="long name", description="long descr")
+        widget = ResultWidget(res, 0, Query("", None))
+
+        name_label = cast("Gtk.Label", widget.title_box.get_children()[0])
+        descr_label = cast("Gtk.Label", widget.text_container.get_children()[1])
+        for label in (name_label, descr_label):
+            assert not label.get_line_wrap()
+            assert label.get_ellipsize() == Pango.EllipsizeMode.MIDDLE
+
+    def test_wrap__highlighting_is_skipped(self) -> None:
+        from gi.repository import Gtk
+
+        res = Result(name="wrapped name", wrap=True, highlightable=True)
+        widget = ResultWidget(res, 0, Query("wrap", None))
+
+        # highlighting would split the name over multiple labels, which cannot wrap as one paragraph
+        assert len(widget.title_box.get_children()) == 1
+        assert cast("Gtk.Label", widget.title_box.get_children()[0]).get_text() == "wrapped name"

--- a/tests/ui/test_result_widget.py
+++ b/tests/ui/test_result_widget.py
@@ -67,5 +67,7 @@ class TestResultWidget:
         widget = ResultWidget(res, 0, Query("wrap", None))
 
         # highlighting would split the name over multiple labels, which cannot wrap as one paragraph
-        assert len(widget.title_box.get_children()) == 1
-        assert cast("Gtk.Label", widget.title_box.get_children()[0]).get_text() == "wrapped name"
+        children = widget.title_box.get_children()
+        assert len(children) == 1
+        assert cast("Gtk.Label", children[0]).get_text() == "wrapped name"
+        assert not any("item-highlight" in c.get_style_context().list_classes() for c in children)

--- a/tests/ui/test_ulauncher_window.py
+++ b/tests/ui/test_ulauncher_window.py
@@ -1,0 +1,84 @@
+from types import SimpleNamespace
+from typing import Any, cast
+from unittest.mock import MagicMock
+
+from pytest_mock import MockerFixture
+
+from ulauncher.ui.ulauncher_window import UlauncherWindow
+
+
+def _make_window(max_content_height: int, current_min: int) -> SimpleNamespace:
+    scroller = MagicMock()
+    scroller.get_property.return_value = max_content_height
+    scroller.get_min_content_height.return_value = current_min
+    # GTK widgets cannot be built without a display; the method only touches the scroller
+    window = cast("Any", SimpleNamespace(results_scroller=scroller, _has_wrapped_results=True))
+    box = MagicMock()
+    return SimpleNamespace(window=window, scroller=scroller, box=box)
+
+
+def test_fit_results_height__requests_the_height_for_width(mocker: MockerFixture) -> None:
+    run_when_idle = mocker.patch("ulauncher.ui.ulauncher_window.scheduling.run_when_idle")
+    setup = _make_window(max_content_height=600, current_min=46)
+    setup.box.get_preferred_height_for_width.return_value = (180, 180)
+
+    UlauncherWindow._fit_results_height(setup.window, setup.box, cast("Any", SimpleNamespace(width=500)))
+
+    setup.box.get_preferred_height_for_width.assert_called_once_with(500)
+    setup.scroller.set_min_content_height.assert_called_once_with(180)
+    run_when_idle.assert_called_once()
+
+
+def test_fit_results_height__clamps_to_max_content_height(mocker: MockerFixture) -> None:
+    mocker.patch("ulauncher.ui.ulauncher_window.scheduling.run_when_idle")
+    setup = _make_window(max_content_height=600, current_min=46)
+    setup.box.get_preferred_height_for_width.return_value = (2000, 2000)
+
+    UlauncherWindow._fit_results_height(setup.window, setup.box, cast("Any", SimpleNamespace(width=500)))
+
+    setup.scroller.set_min_content_height.assert_called_once_with(600)
+
+
+def test_fit_results_height__noop_when_height_is_unchanged(mocker: MockerFixture) -> None:
+    run_when_idle = mocker.patch("ulauncher.ui.ulauncher_window.scheduling.run_when_idle")
+    setup = _make_window(max_content_height=600, current_min=180)
+    setup.box.get_preferred_height_for_width.return_value = (180, 180)
+
+    UlauncherWindow._fit_results_height(setup.window, setup.box, cast("Any", SimpleNamespace(width=500)))
+
+    setup.scroller.set_min_content_height.assert_not_called()
+    run_when_idle.assert_not_called()  # no resize requeued: would loop on every allocation
+
+
+def test_fit_results_height__inactive_without_wrapped_results(mocker: MockerFixture) -> None:
+    run_when_idle = mocker.patch("ulauncher.ui.ulauncher_window.scheduling.run_when_idle")
+    setup = _make_window(max_content_height=600, current_min=180)
+    setup.window._has_wrapped_results = False
+
+    UlauncherWindow._fit_results_height(setup.window, setup.box, cast("Any", SimpleNamespace(width=500)))
+
+    # stock sizing is restored so a previous wrapped query cannot ratchet the height
+    setup.scroller.set_min_content_height.assert_called_once_with(-1)
+    setup.box.get_preferred_height_for_width.assert_not_called()
+    run_when_idle.assert_not_called()
+
+
+def test_fit_results_height__skips_early_allocation_passes(mocker: MockerFixture) -> None:
+    run_when_idle = mocker.patch("ulauncher.ui.ulauncher_window.scheduling.run_when_idle")
+    setup = _make_window(max_content_height=600, current_min=46)
+
+    UlauncherWindow._fit_results_height(setup.window, setup.box, cast("Any", SimpleNamespace(width=0)))
+
+    setup.scroller.set_min_content_height.assert_not_called()
+    run_when_idle.assert_not_called()
+
+
+def test_fit_results_height__tolerates_one_pixel_oscillation(mocker: MockerFixture) -> None:
+    run_when_idle = mocker.patch("ulauncher.ui.ulauncher_window.scheduling.run_when_idle")
+    setup = _make_window(max_content_height=600, current_min=180)
+    setup.box.get_preferred_height_for_width.return_value = (181, 181)
+
+    UlauncherWindow._fit_results_height(setup.window, setup.box, cast("Any", SimpleNamespace(width=500)))
+
+    setup.scroller.set_min_content_height.assert_not_called()
+    run_when_idle.assert_not_called()

--- a/tests/ui/test_ulauncher_window.py
+++ b/tests/ui/test_ulauncher_window.py
@@ -1,84 +1,57 @@
+from __future__ import annotations
+
 from types import SimpleNamespace
 from typing import Any, cast
 from unittest.mock import MagicMock
 
+import pytest
 from pytest_mock import MockerFixture
 
 from ulauncher.ui.ulauncher_window import UlauncherWindow
 
 
-def _make_window(max_content_height: int, current_min: int) -> SimpleNamespace:
-    scroller = MagicMock()
-    scroller.get_property.return_value = max_content_height
-    scroller.get_min_content_height.return_value = current_min
-    # GTK widgets cannot be built without a display; the method only touches the scroller
-    window = cast("Any", SimpleNamespace(results_scroller=scroller, _has_wrapped_results=True))
-    box = MagicMock()
-    return SimpleNamespace(window=window, scroller=scroller, box=box)
+class TestUlauncherWindow:
+    @pytest.mark.parametrize(
+        ("has_wrapped", "width", "current_min", "needed", "measured_width", "expected_min", "expects_resize"),
+        [
+            pytest.param(True, 500, 46, 180, 500, 180, True, id="requests_the_height_for_width"),
+            pytest.param(True, 500, 46, 2000, 500, 600, True, id="clamps_to_max_content_height"),
+            pytest.param(True, 500, 180, 180, 500, None, False, id="noop_when_height_is_unchanged"),
+            pytest.param(True, 500, 180, 181, 500, None, False, id="tolerates_one_pixel_oscillation"),
+            pytest.param(True, 0, 46, 180, None, None, False, id="skips_early_allocation_passes"),
+            pytest.param(False, 500, 180, 180, None, -1, False, id="restores_stock_sizing_without_wrapped_results"),
+        ],
+    )
+    def test_fit_results_height(
+        self,
+        mocker: MockerFixture,
+        has_wrapped: bool,
+        width: int,
+        current_min: int,
+        needed: int,
+        measured_width: int | None,
+        expected_min: int | None,
+        expects_resize: bool,
+    ) -> None:
+        run_when_idle = mocker.patch("ulauncher.ui.ulauncher_window.scheduling.run_when_idle")
+        scroller = MagicMock()
+        scroller.get_property.return_value = 600  # max-content-height
+        scroller.get_min_content_height.return_value = current_min
+        box = MagicMock()
+        box.get_preferred_height_for_width.return_value = (needed, needed)
+        # GTK widgets cannot be built without a display; the method only touches the scroller
+        window = cast("Any", SimpleNamespace(results_scroller=scroller, _has_wrapped_results=has_wrapped))
 
+        UlauncherWindow._fit_results_height(window, box, cast("Any", SimpleNamespace(width=width)))
 
-def test_fit_results_height__requests_the_height_for_width(mocker: MockerFixture) -> None:
-    run_when_idle = mocker.patch("ulauncher.ui.ulauncher_window.scheduling.run_when_idle")
-    setup = _make_window(max_content_height=600, current_min=46)
-    setup.box.get_preferred_height_for_width.return_value = (180, 180)
+        if measured_width is None:
+            box.get_preferred_height_for_width.assert_not_called()
+        else:
+            box.get_preferred_height_for_width.assert_called_once_with(measured_width)
 
-    UlauncherWindow._fit_results_height(setup.window, setup.box, cast("Any", SimpleNamespace(width=500)))
+        if expected_min is None:
+            scroller.set_min_content_height.assert_not_called()
+        else:
+            scroller.set_min_content_height.assert_called_once_with(expected_min)
 
-    setup.box.get_preferred_height_for_width.assert_called_once_with(500)
-    setup.scroller.set_min_content_height.assert_called_once_with(180)
-    run_when_idle.assert_called_once()
-
-
-def test_fit_results_height__clamps_to_max_content_height(mocker: MockerFixture) -> None:
-    mocker.patch("ulauncher.ui.ulauncher_window.scheduling.run_when_idle")
-    setup = _make_window(max_content_height=600, current_min=46)
-    setup.box.get_preferred_height_for_width.return_value = (2000, 2000)
-
-    UlauncherWindow._fit_results_height(setup.window, setup.box, cast("Any", SimpleNamespace(width=500)))
-
-    setup.scroller.set_min_content_height.assert_called_once_with(600)
-
-
-def test_fit_results_height__noop_when_height_is_unchanged(mocker: MockerFixture) -> None:
-    run_when_idle = mocker.patch("ulauncher.ui.ulauncher_window.scheduling.run_when_idle")
-    setup = _make_window(max_content_height=600, current_min=180)
-    setup.box.get_preferred_height_for_width.return_value = (180, 180)
-
-    UlauncherWindow._fit_results_height(setup.window, setup.box, cast("Any", SimpleNamespace(width=500)))
-
-    setup.scroller.set_min_content_height.assert_not_called()
-    run_when_idle.assert_not_called()  # no resize requeued: would loop on every allocation
-
-
-def test_fit_results_height__inactive_without_wrapped_results(mocker: MockerFixture) -> None:
-    run_when_idle = mocker.patch("ulauncher.ui.ulauncher_window.scheduling.run_when_idle")
-    setup = _make_window(max_content_height=600, current_min=180)
-    setup.window._has_wrapped_results = False
-
-    UlauncherWindow._fit_results_height(setup.window, setup.box, cast("Any", SimpleNamespace(width=500)))
-
-    # stock sizing is restored so a previous wrapped query cannot ratchet the height
-    setup.scroller.set_min_content_height.assert_called_once_with(-1)
-    setup.box.get_preferred_height_for_width.assert_not_called()
-    run_when_idle.assert_not_called()
-
-
-def test_fit_results_height__skips_early_allocation_passes(mocker: MockerFixture) -> None:
-    run_when_idle = mocker.patch("ulauncher.ui.ulauncher_window.scheduling.run_when_idle")
-    setup = _make_window(max_content_height=600, current_min=46)
-
-    UlauncherWindow._fit_results_height(setup.window, setup.box, cast("Any", SimpleNamespace(width=0)))
-
-    setup.scroller.set_min_content_height.assert_not_called()
-    run_when_idle.assert_not_called()
-
-
-def test_fit_results_height__tolerates_one_pixel_oscillation(mocker: MockerFixture) -> None:
-    run_when_idle = mocker.patch("ulauncher.ui.ulauncher_window.scheduling.run_when_idle")
-    setup = _make_window(max_content_height=600, current_min=180)
-    setup.box.get_preferred_height_for_width.return_value = (181, 181)
-
-    UlauncherWindow._fit_results_height(setup.window, setup.box, cast("Any", SimpleNamespace(width=500)))
-
-    setup.scroller.set_min_content_height.assert_not_called()
-    run_when_idle.assert_not_called()
+        assert run_when_idle.called is expects_resize

--- a/tests/ui/test_ulauncher_window.py
+++ b/tests/ui/test_ulauncher_window.py
@@ -19,7 +19,7 @@ class TestUlauncherWindow:
             pytest.param(True, 500, 180, 180, 500, None, False, id="noop_when_height_is_unchanged"),
             pytest.param(True, 500, 180, 181, 500, None, False, id="tolerates_one_pixel_oscillation"),
             pytest.param(True, 0, 46, 180, None, None, False, id="skips_early_allocation_passes"),
-            pytest.param(False, 500, 180, 180, None, -1, False, id="restores_stock_sizing_without_wrapped_results"),
+            pytest.param(False, 500, 180, 180, None, None, False, id="noop_without_wrapped_results"),
         ],
     )
     def test_fit_results_height(

--- a/ulauncher/internals/result.py
+++ b/ulauncher/internals/result.py
@@ -22,6 +22,7 @@ class Result(BaseDataClass):
     """
 
     compact = False  #: If True, the result will be displayed in a single line without a title
+    wrap = False  #: If True, name and description wrap over multiple lines instead of being ellipsized
     highlightable = False  #: If True, a substring matching the query will be highlighted
     searchable = False
     name = ""  #: The name of the result item
@@ -34,10 +35,11 @@ class Result(BaseDataClass):
     on_enter: effects.EffectMessage | list[Result] | None = None
     on_alt_enter: effects.EffectMessage | list[Result] | None = None
 
-    def __init__(
+    def __init__(  # noqa: PLR0913
         self,
         *,
         compact: bool | None = None,
+        wrap: bool | None = None,
         highlightable: bool | None = None,
         searchable: bool | None = None,
         name: str | None = None,
@@ -54,6 +56,8 @@ class Result(BaseDataClass):
         init_kwargs: dict[str, Any] = {}
         if compact is not None:
             init_kwargs["compact"] = compact
+        if wrap is not None:
+            init_kwargs["wrap"] = wrap
         if highlightable is not None:
             init_kwargs["highlightable"] = highlightable
         if searchable is not None:

--- a/ulauncher/ui/result_widget.py
+++ b/ulauncher/ui/result_widget.py
@@ -88,12 +88,18 @@ class ResultWidget(Gtk.EventBox):
         item_container.set_property("margin-bottom", margin_y)
 
         if result.description and not result.compact:
-            descr_label = Gtk.Label(hexpand=True, max_width_chars=1, xalign=0, ellipsize=Pango.EllipsizeMode.MIDDLE)
+            descr_label = self._make_text_label()
             descr_label.get_style_context().add_class("item-descr")
             descr_label.get_style_context().add_class("item-text")
             descr_label.set_text(unescape(result.description))
             self.text_container.pack_start(descr_label, False, True, 0)
         self.highlight_name()
+
+    def _make_text_label(self, text: str = "") -> Gtk.Label:
+        if self.result.wrap:
+            return Gtk.Label(label=text, hexpand=True, xalign=0, wrap=True, wrap_mode=Pango.WrapMode.WORD_CHAR)
+        # max_width_chars=1 lets the label shrink below its natural size so ellipsizing kicks in
+        return Gtk.Label(label=text, hexpand=True, max_width_chars=1, xalign=0, ellipsize=Pango.EllipsizeMode.MIDDLE)
 
     def set_index(self, index: int) -> None:
         """
@@ -124,6 +130,10 @@ class ResultWidget(Gtk.EventBox):
             viewport.set_vadjustment(Gtk.Adjustment(bottom - viewport_height, 0, 2**32, 1, 10, 0))
 
     def highlight_name(self) -> None:
+        if self.result.wrap:
+            # highlighting splits the name into labels that cannot reflow as one paragraph
+            self.title_box.pack_start(self._make_text_label(self.result.name), True, True, 0)
+            return
         highlightable_input = self.result.get_highlightable_input(str(self.query))
         if highlightable_input and (self.result.searchable or self.result.highlightable):
             labels = []

--- a/ulauncher/ui/result_widget.py
+++ b/ulauncher/ui/result_widget.py
@@ -132,12 +132,11 @@ class ResultWidget(Gtk.EventBox):
     def highlight_name(self) -> None:
         if self.result.wrap:
             # highlighting splits the name into labels that cannot reflow as one paragraph
-            self.title_box.pack_start(self._make_text_label(self.result.name), True, True, 0)
-            return
-        highlightable_input = self.result.get_highlightable_input(str(self.query))
-        if highlightable_input and (self.result.searchable or self.result.highlightable):
+            labels = [self._make_text_label(self.result.name)]
+        elif (highlightable_input := self.result.get_highlightable_input(str(self.query))) and (
+            self.result.searchable or self.result.highlightable
+        ):
             labels = []
-
             for label_text, is_highlight in highlight_text(highlightable_input, self.result.name):
                 ellipsize_min = ELLIPSIZE_MIN_LENGTH if not is_highlight else ELLIPSIZE_FORCE_AT_LENGTH
                 ellipsize = Pango.EllipsizeMode.MIDDLE if len(label_text) > ellipsize_min else Pango.EllipsizeMode.NONE
@@ -148,8 +147,10 @@ class ResultWidget(Gtk.EventBox):
         else:
             labels = [Gtk.Label(label=self.result.name, ellipsize=Pango.EllipsizeMode.MIDDLE)]
 
+        # a wrapped label must fill the row so it has a width to reflow against
+        expand = self.result.wrap
         for label in labels:
-            self.title_box.pack_start(label, False, False, 0)
+            self.title_box.pack_start(label, expand, expand, 0)
 
     def on_click(self, _widget: Gtk.Widget, event: Gdk.EventButton | None = None) -> None:
         alt = bool(event and event.button != 1)  # right click

--- a/ulauncher/ui/ulauncher_window.py
+++ b/ulauncher/ui/ulauncher_window.py
@@ -33,6 +33,7 @@ def emit_show_results(results: Iterable[Result]) -> None:
 
 class UlauncherWindow(Gtk.ApplicationWindow):
     _css_provider: Gtk.CssProvider | None = None
+    _has_wrapped_results = False
     _results_nav: ItemNavigation | None = None
     is_dragging = False
     layer_shell_enabled = False
@@ -139,6 +140,7 @@ class UlauncherWindow(Gtk.ApplicationWindow):
             shadow_type=Gtk.ShadowType.IN,
         )
         self.results = Gtk.Box(orientation=Gtk.Orientation.VERTICAL)
+        self.results.connect("size-allocate", self._fit_results_height)
         self.results_scroller.add(self.results)
 
         self.theme_root.pack_start(drag_listener, False, True, 0)
@@ -424,6 +426,25 @@ class UlauncherWindow(Gtk.ApplicationWindow):
     def reload_query(self) -> None:
         self.core.set_query(self.query_str, emit_show_results)
 
+    def _fit_results_height(self, box: Gtk.Box, allocation: Gdk.Rectangle) -> None:
+        """GtkScrolledWindow measures its natural height without height-for-width,
+        clipping wrapped (Result.wrap) labels — request the real height instead."""
+        current = self.results_scroller.get_min_content_height()
+        if not self._has_wrapped_results:
+            if current != -1:
+                self.results_scroller.set_min_content_height(-1)  # restore stock sizing
+            return
+        if allocation.width <= 0:
+            return  # early allocation pass, no usable width yet
+        max_height = self.results_scroller.get_property("max-content-height")
+        needed = box.get_preferred_height_for_width(allocation.width)[1]
+        if max_height > 0:
+            needed = min(needed, max_height)
+        if abs(needed - current) > 1:  # tolerance: a scrollbar can shift the width by ~1px
+            self.results_scroller.set_min_content_height(needed)
+            # the in-progress allocation pass ignores the new request
+            scheduling.run_when_idle(self.results_scroller.queue_resize)
+
     def show_results(self, results: Iterable[Result]) -> None:
         self._results_nav = None
         self.results.foreach(lambda w: w.destroy())
@@ -431,6 +452,8 @@ class UlauncherWindow(Gtk.ApplicationWindow):
         jump_keys = self.settings.get_jump_keys()
         limit = len(jump_keys) or 25
         result_list = list(results)[:limit]
+        # stock sizing works for single-line results; only wrapped ones need _fit_results_height
+        self._has_wrapped_results = any(result.wrap for result in result_list)
 
         if result_list:
             from ulauncher.ui.result_widget import ResultWidget

--- a/ulauncher/ui/ulauncher_window.py
+++ b/ulauncher/ui/ulauncher_window.py
@@ -431,13 +431,13 @@ class UlauncherWindow(Gtk.ApplicationWindow):
         clipping wrapped (Result.wrap) labels - request the real height instead."""
         if not self._has_wrapped_results or allocation.width <= 0:
             return  # nothing to fit, or an early allocation pass with no usable width yet
-        current = self.results_scroller.get_min_content_height()
+        current_height = self.results_scroller.get_min_content_height()
         max_height = self.results_scroller.get_property("max-content-height")
-        needed = box.get_preferred_height_for_width(allocation.width)[1]
+        needed_height = box.get_preferred_height_for_width(allocation.width)[1]
         if max_height > 0:
-            needed = min(needed, max_height)
-        if abs(needed - current) > 1:  # tolerance: a scrollbar can shift the width by ~1px
-            self.results_scroller.set_min_content_height(needed)
+            needed_height = min(needed_height, max_height)
+        if abs(needed_height - current_height) > 1:  # tolerance: a scrollbar can shift the width by ~1px
+            self.results_scroller.set_min_content_height(needed_height)
             # the in-progress allocation pass ignores the new request
             scheduling.run_when_idle(self.results_scroller.queue_resize)
 

--- a/ulauncher/ui/ulauncher_window.py
+++ b/ulauncher/ui/ulauncher_window.py
@@ -428,14 +428,10 @@ class UlauncherWindow(Gtk.ApplicationWindow):
 
     def _fit_results_height(self, box: Gtk.Box, allocation: Gdk.Rectangle) -> None:
         """GtkScrolledWindow measures its natural height without height-for-width,
-        clipping wrapped (Result.wrap) labels — request the real height instead."""
+        clipping wrapped (Result.wrap) labels - request the real height instead."""
+        if not self._has_wrapped_results or allocation.width <= 0:
+            return  # nothing to fit, or an early allocation pass with no usable width yet
         current = self.results_scroller.get_min_content_height()
-        if not self._has_wrapped_results:
-            if current != -1:
-                self.results_scroller.set_min_content_height(-1)  # restore stock sizing
-            return
-        if allocation.width <= 0:
-            return  # early allocation pass, no usable width yet
         max_height = self.results_scroller.get_property("max-content-height")
         needed = box.get_preferred_height_for_width(allocation.width)[1]
         if max_height > 0:
@@ -454,6 +450,8 @@ class UlauncherWindow(Gtk.ApplicationWindow):
         result_list = list(results)[:limit]
         # stock sizing works for single-line results; only wrapped ones need _fit_results_height
         self._has_wrapped_results = any(result.wrap for result in result_list)
+        if not self._has_wrapped_results:
+            self.results_scroller.set_min_content_height(-1)  # restore stock sizing
 
         if result_list:
             from ulauncher.ui.result_widget import ResultWidget


### PR DESCRIPTION
## Motivation

Result texts are always ellipsized to a single line. That fits app/file results, but AI/LLM extensions (ChatGPT, Gemini, Ollama, Mistral…) display multi-sentence answers, and file/clipboard extensions display long content — today they must split text into many fake single-line results (~90 chars each), which breaks selection, copy and readability.

## Design

- New opt-in `Result.wrap` property (default `False`): name and description wrap over multiple lines (`Pango.WrapMode.WORD_CHAR`) instead of being ellipsized.
- `GtkScrolledWindow` measures its natural height without height-for-width, so wrapped labels would stay clipped to ~one line until a reallocation. A small `_fit_results_height` handler requests the real (height-for-width) height on the scroller — only active when the current results contain a wrapped one; stock sizing is restored otherwise. Guards: zero-width allocation passes are skipped, and a ±1px tolerance avoids scrollbar-induced relayout loops.
- Highlighting is skipped for wrapped results — it splits the name across multiple labels in a horizontal box, which cannot reflow as one paragraph.
- **Backward/forward compatible**: `wrap=False` keeps rendering pixel-identical; `BaseDataClass` carries unknown properties, so a `wrap=True` result sent to an older app degrades to today's single ellipsized line. No manifest or API version change.

## Notes

- Complements (but does not depend on) #1743 — together they make LLM answers stream in and read naturally. Follows up on discussion #1736.
- Tested end-to-end on GNOME Wayland with a real extension rendering full LLM answers ([demo branch](https://github.com/PhilMeyr/ulauncher-mistral/tree/feat/streaming-demo)).
- Tests cover the wrap labels (wrap on, ellipsize off), unchanged defaults, the highlight interaction, and the scroller fitting (clamp, no-op guard, inactive-without-wrap reset, zero-width and 1px-oscillation guards).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds opt-in multi-line rendering via `Result.wrap`. Long answers and file/clipboard content now wrap instead of being cut to one line; defaults stay the same.

- **New Features**
  - Add `Result.wrap` (default false) to wrap name/description.
  - Skip query highlighting when wrapped; unify title label packing so wrapped titles reflow cleanly.
  - Fit scroller height only when any wrapped results are shown; reset min height in `show_results`, clamp to max height, and tolerate ±1px oscillation.
  - Back/forward compatible; no API/version changes.
  - Tests cover wrapping defaults and highlight suppression (no `item-highlight` class), plus scroller-fit cases and guards.

<sup>Written for commit 70ffb13d0a94790b18b61ca944e9ee852eef8c66. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Ulauncher/Ulauncher/pull/1744?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

