### PR TITLE
fix(ext-prefs): dialog destroy must run in main glib thread

### DIFF
--- a/ulauncher/ui/preferences/utils/ext_handlers.py
+++ b/ulauncher/ui/preferences/utils/ext_handlers.py
@@ -161,10 +161,12 @@ class ExtensionHandlers:
                     GLib.idle_add(update_ui)
 
                 except (ext_exceptions.ExtensionError, OSError, asyncio.CancelledError):
-                    progress_dialog.destroy()
-                    GLib.idle_add(
-                        self.dialog_launcher.show_error, "Failed to remove extension", "Remove operation failed"
-                    )
+
+                    def show_error() -> None:
+                        progress_dialog.destroy()
+                        self.dialog_launcher.show_error("Failed to remove extension", "Remove operation failed")
+
+                    GLib.idle_add(show_error)
 
             thread = threading.Thread(target=remove_async)
             thread.daemon = True


### PR DESCRIPTION
remove_async runs in a background thread, so its except branch executes off the main thread. It called progress_dialog.destroy() directly there, while only the error dialog was marshaled to the main loop via GLib.idle_add.

All GTK operations must run in the main thread, so destroying the dialog from the worker thread is unsafe and can crash. This was the only handler doing so; install_extension and update_extension already wrap destroy() in their idle callbacks.

Move destroy() into the show_error callback scheduled via GLib.idle_add, matching the other handlers.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Ensure the progress dialog is destroyed on the main GLib thread when extension removal fails, preventing GTK crashes. The destroy() call now runs inside a GLib.idle_add callback with show_error, matching the install/update handlers.

<sup>Written for commit e5e52dc50ba4881bf9d9c299d12eae4be587fea1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Ulauncher/Ulauncher/pull/1745?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

