### PR TITLE
fix(ext): initialize modes at startup for a persistent service

### DIFF
--- a/ulauncher/ui/app.py
+++ b/ulauncher/ui/app.py
@@ -11,6 +11,7 @@ from gi.repository import Gdk, Gtk
 
 import ulauncher
 from ulauncher import app_id, first_run
+from ulauncher.core import UlauncherCore
 from ulauncher.gi import Gio, GLib
 from ulauncher.internals.result import Result
 from ulauncher.ui.ulauncher_window import UlauncherWindow
@@ -32,6 +33,8 @@ class UlauncherApp(Gtk.Application):
     # Whether the app should keep running with no windows open. Set in setup() from the
     # systemd unit state (or keep_alive fallback) and kept in sync by toggle_hold().
     _persistent: bool = False
+    # App-scoped query/mode controller, shared by every launcher window.
+    core: UlauncherCore
     # pyrefly: ignore[bad-assignment] https://github.com/facebook/pyrefly/issues/2227
     windows: WeakValueDictionary[Literal["main", "preferences"], Gtk.ApplicationWindow] = WeakValueDictionary()
     _tray_icon: ulauncher.ui.helpers.tray_icon.TrayIcon | None = None  # pyrefly: ignore[implicit-import]
@@ -93,12 +96,21 @@ class UlauncherApp(Gtk.Application):
 
     def setup(self) -> None:
         settings = Settings.load()
+        self.core = UlauncherCore()
         # Always hold on app start (conditionally release after closing window)
         self.hold()
         self._persistent = settings.is_persistent()
         if self._persistent:
             # Sync additional hold with user settings
             self.hold()
+
+            # Warm the modes so extension handlers register and enabled extensions start.
+            # Skip if a window exists - it needs to control when this runs for startup performance reasons.
+            def _warm_triggers() -> None:
+                if "main" not in self.windows:
+                    self.core.load_triggers()
+
+            scheduling.run_when_idle(_warm_triggers)
 
         if settings.show_tray_icon and self._persistent:
             self.toggle_tray_icon(True)
@@ -153,7 +165,7 @@ class UlauncherApp(Gtk.Application):
             del self.windows["main"]
 
         if "main" not in self.windows:
-            main_window = UlauncherWindow(application=self)
+            main_window = UlauncherWindow(core=self.core, application=self)
             main_window.connect("destroy", self._on_window_destroyed, "main")
             self.windows["main"] = main_window
 

--- a/ulauncher/ui/ulauncher_window.py
+++ b/ulauncher/ui/ulauncher_window.py
@@ -39,10 +39,10 @@ class UlauncherWindow(Gtk.ApplicationWindow):
     settings: Settings
     core: UlauncherCore
 
-    def __init__(self, **kwargs: Any) -> None:  # noqa: PLR0915
+    def __init__(self, core: UlauncherCore, **kwargs: Any) -> None:  # noqa: PLR0915
         logger.info("Opening Ulauncher window")
+        self.core = core
         self.settings = Settings.load(force=True)
-        self.core = UlauncherCore()
         width_request = int(self.settings.base_width)
         height_request = -1
 


### PR DESCRIPTION
Ensures that the core triggers and modes are always loaded when the app starts.

Previously it wasn't loaded until the first window paint event. Now it will load either on the window paint event or if there is no window.

This fixes a bug with the `preview` command not working unless you have opened the window once in the app session.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Initialize modes and extension handlers at app startup for persistent runs. Fixes dropped CLI events before any window is shown and keeps the first paint fast.

- **Bug Fixes**
  - Warm modes via `core.load_triggers()` when persistent and no window, so extension CLI (e.g., `ulauncher preview`, install/uninstall/upgrade) works before opening a window.
  - Skip background warm-up if a window exists to avoid adding ~110ms to cold starts; the window initializes modes itself.

- **Refactors**
  - Make `UlauncherCore` app-scoped and pass it into `UlauncherWindow`; stop creating a new core per window.

<sup>Written for commit 7cfc1e4ab0a2a89ad21e5db292eb25c03a43026a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Ulauncher/Ulauncher/pull/1748?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

