### PR TITLE
refactor: add PreviewExtension class to replace verbose ext mode code

### DIFF
--- a/ulauncher/cli/commands/preview.py
+++ b/ulauncher/cli/commands/preview.py
@@ -140,5 +140,5 @@ def run(args: CLIArguments) -> int:
     _wait_for_interrupt(ext_id)
 
     logger.info("Stopping '%s'...", ext_id)
-    dbus_trigger_event("extensions:stop_preview", f"{ext_id}.preview", ext_id)
+    dbus_trigger_event("extensions:stop_preview")
     return 0

--- a/ulauncher/cli/commands/preview.py
+++ b/ulauncher/cli/commands/preview.py
@@ -7,10 +7,13 @@ from pathlib import Path
 
 from ulauncher import app_id, paths
 from ulauncher.cli import CLIArguments
+from ulauncher.gi import GLib
 from ulauncher.modes.extensions import ext_exceptions, extension_finder
 from ulauncher.modes.extensions.extension_controller import DEBUGPY_HOST, DEBUGPY_PORT
+from ulauncher.modes.extensions.extension_dependencies import ExtensionDependencies
 from ulauncher.modes.extensions.extension_manifest import ExtensionManifest
 from ulauncher.modes.extensions.extension_remote import parse_extension_url
+from ulauncher.utils import scheduling
 from ulauncher.utils.dbus import check_app_running, dbus_trigger_event
 
 logger = logging.getLogger(__name__)
@@ -82,14 +85,6 @@ def _resolve_ext_id(path: Path) -> str | None:
         return None
 
 
-def _wait_for_interrupt(ext_id: str) -> None:
-    # Block SIGINT so sigwait() can dequeue it atomically without racing
-    # with Python's default KeyboardInterrupt handler.
-    signal.pthread_sigmask(signal.SIG_BLOCK, [signal.SIGINT])
-    logger.info("Press Ctrl+C to stop previewing extension '%s'...", ext_id)
-    signal.sigwait([signal.SIGINT])
-
-
 def run(args: CLIArguments) -> int:
     """
     Run an extension in preview mode (without installing it).
@@ -110,35 +105,55 @@ def run(args: CLIArguments) -> int:
     if not _validate_manifest(path):
         return 1
 
-    if (path / "requirements.txt").is_file():
-        logger.warning(
-            "The extension has a requirements.txt file. "
-            "Its dependencies will be installed in the '.dependencies' folder inside the extension path."
-        )
-
-    ext_id = _resolve_ext_id(path)
-    if ext_id is None:
+    resolved_id = _resolve_ext_id(path)
+    if resolved_id is None:
         return 1
+    ext_id: str = resolved_id
     logger.info("Extension ID: %s", ext_id)
 
-    dbus_trigger_event("extensions:preview_ext", ext_id, str(path), args.with_debugger)
+    loop = GLib.MainLoop()
+    exit_code = 0
 
-    logger.info(
-        "Extension '%s' started.\nSee extension's output along with the Ulauncher's in %s",
-        ext_id,
-        paths.LOG_FILE,
-    )
-
-    if args.with_debugger:
+    def start_preview() -> None:
+        dbus_trigger_event("extensions:preview_ext", ext_id, str(path), args.with_debugger)
         logger.info(
-            "Connect your debugger to: %s:%d\n"
-            "See https://github.com/Ulauncher/Ulauncher/wiki/How-to-debug-an-extension for instructions.",
-            DEBUGPY_HOST,
-            DEBUGPY_PORT,
+            "Previewing extension '%s'.\nSee its output along with Ulauncher's in %s",
+            ext_id,
+            paths.LOG_FILE,
         )
+        if args.with_debugger:
+            logger.info(
+                "Connect your debugger to: %s:%d\n"
+                "See https://github.com/Ulauncher/Ulauncher/wiki/How-to-debug-an-extension for instructions.",
+                DEBUGPY_HOST,
+                DEBUGPY_PORT,
+            )
+        logger.info("Press Ctrl+C to stop previewing extension '%s'...", ext_id)
 
-    _wait_for_interrupt(ext_id)
+    def on_deps_error(error: Exception) -> None:
+        nonlocal exit_code
+        logger.error("Error: Failed to install extension dependencies: %s", error)
+        exit_code = 1
+        loop.quit()
 
-    logger.info("Stopping '%s'...", ext_id)
-    dbus_trigger_event("extensions:stop_preview")
-    return 0
+    def begin() -> bool:
+        # Runs under the loop so a synchronous install callback can quit it without racing loop.run().
+        if (path / "requirements.txt").is_file():
+            logger.info("Installing extension dependencies in the '.dependencies' folder...")
+            ExtensionDependencies(ext_id, str(path)).install(lambda _stdout: start_preview(), on_deps_error)
+        else:
+            start_preview()
+        return False
+
+    def on_interrupt() -> bool:
+        logger.info("Stopping '%s'...", ext_id)
+        dbus_trigger_event("extensions:stop_preview")
+        loop.quit()
+        return False
+
+    # The dependency install is callback-based and must finish before the app launches the extension,
+    # so the CLI drives it (and Ctrl+C) on its own GLib loop.
+    GLib.unix_signal_add(GLib.PRIORITY_DEFAULT, signal.SIGINT, on_interrupt)
+    scheduling.run_when_idle(begin)
+    loop.run()
+    return exit_code

--- a/ulauncher/cli/commands/preview.py
+++ b/ulauncher/cli/commands/preview.py
@@ -136,14 +136,13 @@ def run(args: CLIArguments) -> int:
         exit_code = 1
         loop.quit()
 
-    def begin() -> bool:
+    def begin() -> None:
         # Runs under the loop so a synchronous install callback can quit it without racing loop.run().
         if (path / "requirements.txt").is_file():
             logger.info("Installing extension dependencies in the '.dependencies' folder...")
             ExtensionDependencies(ext_id, str(path)).install(lambda _stdout: start_preview(), on_deps_error)
         else:
             start_preview()
-        return False
 
     def on_interrupt() -> bool:
         logger.info("Stopping '%s'...", ext_id)

--- a/ulauncher/modes/extensions/extension_controller.py
+++ b/ulauncher/modes/extensions/extension_controller.py
@@ -144,10 +144,14 @@ class ExtensionController:
     state: ExtensionState
     is_manageable: bool
     _state_path: Path
+    _manifest: ExtensionManifest | None
+    _manifest_path: str
 
     def __init__(self, ext_id: str, path: str) -> None:
         self.id = ext_id
         self.path = path
+        self._manifest = None
+        self._manifest_path = ""
         self.is_manageable = extension_finder.is_manageable(path)
         _state_path = f"{paths.EXTENSIONS_STATE}/{self.id}.json"
         self._state_path = Path(_state_path)
@@ -205,7 +209,12 @@ class ExtensionController:
 
     @property
     def manifest(self) -> ExtensionManifest:
-        return ExtensionManifest.load(self.source_path)
+        # Reload only when the source path changes (e.g. entering or leaving preview); the
+        # preferences list reads this for every extension on every refresh.
+        if self._manifest is None or self._manifest_path != self.source_path:
+            self._manifest_path = self.source_path
+            self._manifest = ExtensionManifest.load(self._manifest_path)
+        return self._manifest
 
     @property
     def is_enabled(self) -> bool:

--- a/ulauncher/modes/extensions/extension_controller.py
+++ b/ulauncher/modes/extensions/extension_controller.py
@@ -144,14 +144,10 @@ class ExtensionController:
     state: ExtensionState
     is_manageable: bool
     _state_path: Path
-    _manifest: ExtensionManifest | None
-    _manifest_path: str
 
     def __init__(self, ext_id: str, path: str) -> None:
         self.id = ext_id
         self.path = path
-        self._manifest = None
-        self._manifest_path = ""
         self.is_manageable = extension_finder.is_manageable(path)
         _state_path = f"{paths.EXTENSIONS_STATE}/{self.id}.json"
         self._state_path = Path(_state_path)
@@ -209,12 +205,7 @@ class ExtensionController:
 
     @property
     def manifest(self) -> ExtensionManifest:
-        # Reload only when the source path changes (e.g. entering or leaving preview); the
-        # preferences list reads this for every extension on every refresh.
-        if self._manifest is None or self._manifest_path != self.source_path:
-            self._manifest_path = self.source_path
-            self._manifest = ExtensionManifest.load(self._manifest_path)
-        return self._manifest
+        return ExtensionManifest.load(self.source_path)
 
     @property
     def is_enabled(self) -> bool:

--- a/ulauncher/modes/extensions/extension_controller.py
+++ b/ulauncher/modes/extensions/extension_controller.py
@@ -68,6 +68,31 @@ stopped_listeners: dict[str, list[Callable[[], None]]] = defaultdict(list)
 events = EventBus()
 
 
+class PreviewExtension:
+    """The single extension currently being previewed from a dev path via the CLI, if any.
+
+    Only one runs at a time (the debugger binds a fixed port). While active, the controller whose id
+    matches launches from `path` (with `with_debugger`) instead of its installed location.
+    """
+
+    ext_id: str | None = None
+    path: str = ""
+    with_debugger: bool = False
+
+    def set(self, ext_id: str, path: str, with_debugger: bool) -> None:
+        self.ext_id = ext_id
+        self.path = path
+        self.with_debugger = with_debugger
+
+    def clear(self) -> None:
+        self.ext_id = None
+        self.path = ""
+        self.with_debugger = False
+
+
+preview = PreviewExtension()
+
+
 def _run_gio_blocking(start: Callable[[Callable[[Any], None], Callable[[Exception], None]], None]) -> Any:
     """Drive a callback-based Gio operation to completion synchronously on the calling thread.
 
@@ -117,16 +142,12 @@ class ExtensionController:
     id: str
     path: str
     state: ExtensionState
-    manifest: ExtensionManifest
     is_manageable: bool
-    is_preview: bool = False
-    shadowed_by_preview: bool = False
     _state_path: Path
 
     def __init__(self, ext_id: str, path: str) -> None:
         self.id = ext_id
         self.path = path
-        self.manifest = ExtensionManifest.load(path)
         self.is_manageable = extension_finder.is_manageable(path)
         _state_path = f"{paths.EXTENSIONS_STATE}/{self.id}.json"
         self._state_path = Path(_state_path)
@@ -173,8 +194,22 @@ class ExtensionController:
         return controller
 
     @property
+    def is_preview(self) -> bool:
+        return preview.ext_id == self.id
+
+    @property
+    def source_path(self) -> str:
+        """Where to load and launch the extension from: the dev path while it is being previewed,
+        otherwise `self.path`."""
+        return preview.path if self.is_preview else self.path
+
+    @property
+    def manifest(self) -> ExtensionManifest:
+        return ExtensionManifest.load(self.source_path)
+
+    @property
     def is_enabled(self) -> bool:
-        return self.state.is_enabled and not self.has_error
+        return self.is_preview or (self.state.is_enabled and not self.has_error)
 
     @property
     def has_error(self) -> bool:
@@ -214,7 +249,7 @@ class ExtensionController:
 
     def get_icon_value(self, icon: str | None = None) -> str:
         icon_value = icon or self.manifest.icon
-        expanded_path = join(self.path, icon_value)
+        expanded_path = join(self.source_path, icon_value)
         if isfile(expanded_path):
             return expanded_path
         return icon_value
@@ -294,14 +329,11 @@ class ExtensionController:
         await self.stop()
         return False
 
-    def start(self, with_debugger: bool = False) -> bool:
+    def start(self) -> bool:
         """
         Starts the extension in a subprocess
         Returns True if the extension was already running or successfully started, False otherwise.
         """
-        if self.shadowed_by_preview:
-            return False
-
         if self.is_running:
             return True  # if already started, count as successful
 
@@ -331,12 +363,12 @@ class ExtensionController:
 
         self.state.save(error_type="", error_message="")  # clear any previous error
 
-        ext_deps = ExtensionDependencies(self.id, self.path)
-        extension_main = f"{self.path}/main.py"
+        ext_deps = ExtensionDependencies(self.id, self.source_path)
+        extension_main = f"{self.source_path}/main.py"
         cmd = [sys.executable, extension_main]
 
-        # If debugger mode is enabled, prepend debugger command
-        if with_debugger:
+        # Preview extensions can opt into the remote debugger
+        if self.is_preview and preview.with_debugger:
             cmd = [
                 sys.executable,
                 "-m",

--- a/ulauncher/modes/extensions/extension_controller.py
+++ b/ulauncher/modes/extensions/extension_controller.py
@@ -222,7 +222,8 @@ class ExtensionController:
 
     @property
     def has_error(self) -> bool:
-        return bool(self.state.error_type)
+        # A preview must not surface the installed extension's persisted error; it reports as a preview.
+        return not self.is_preview and bool(self.state.error_type)
 
     @property
     def is_running(self) -> bool:

--- a/ulauncher/modes/extensions/extension_controller.py
+++ b/ulauncher/modes/extensions/extension_controller.py
@@ -356,7 +356,9 @@ class ExtensionController:
             if cause != "Stopped":
                 logger.error('Extension "%s" exited with an error: %s (%s)', self.id, error_msg, cause)
                 extension_runtimes.pop(self.id, None)
-                self.state.save(error_type=cause, error_message=error_msg)
+                # A failing preview must not disable the installed extension by persisting its error.
+                if not self.is_preview:
+                    self.state.save(error_type=cause, error_message=error_msg)
 
             events.emit("extensions:exited", self.id, cause)
 
@@ -370,7 +372,8 @@ class ExtensionController:
             exit_handler("Incompatible", str(err))
             return False
 
-        self.state.save(error_type="", error_message="")  # clear any previous error
+        if not self.is_preview:
+            self.state.save(error_type="", error_message="")  # clear any previous error
 
         ext_deps = ExtensionDependencies(self.id, self.source_path)
         extension_main = f"{self.source_path}/main.py"

--- a/ulauncher/modes/extensions/extension_mode.py
+++ b/ulauncher/modes/extensions/extension_mode.py
@@ -329,22 +329,10 @@ class ExtensionMode(Mode):
         preview.set(ext_id, path, with_debugger)
 
         # Register a controller so a not-yet-installed extension's triggers become available; an
-        # installed one already has one (now launching from the preview path).
+        # installed one already has one (now launching from the preview path). Restart it so a
+        # background-running installed instance relaunches from the dev path.
         extension_registry.get(ext_id) or extension_registry.load(ext_id, path)
-
-        from ulauncher.modes.extensions.extension_dependencies import ExtensionDependencies
-
-        def on_deps_installed(_stdout: str) -> None:
-            # Restart so a background-running installed instance relaunches from the dev path.
-            self.run_ext_batch_job([ext_id], ["stop", "start"])
-
-        def on_deps_error(error: Exception) -> None:
-            logger.error("[preview] Failed to install dependencies for '%s': %s", ext_id, error)
-            preview.clear()
-
-        deps = ExtensionDependencies(ext_id, path)
-        # deps.install must run on the GLib main loop so use idle_add since this can run from a worker thread.
-        scheduling.run_when_idle(lambda: deps.install(on_deps_installed, on_deps_error))
+        self.run_ext_batch_job([ext_id], ["stop", "start"])
 
     @events.on
     def stop_preview(self) -> None:

--- a/ulauncher/modes/extensions/extension_mode.py
+++ b/ulauncher/modes/extensions/extension_mode.py
@@ -332,7 +332,14 @@ class ExtensionMode(Mode):
         # installed one already has one (now launching from the preview path). Restart it so a
         # background-running installed instance relaunches from the dev path.
         extension_registry.get(ext_id) or extension_registry.load(ext_id, path)
-        self.run_ext_batch_job([ext_id], ["stop", "start"])
+
+        # Guard the restart against a stop_preview that races in during the stop: only relaunch if
+        # this preview is still the active one, otherwise stop_preview owns restoring the extension.
+        def start_if_still_previewing() -> None:
+            if preview.ext_id == ext_id:
+                self.run_ext_batch_job([ext_id], ["start"])
+
+        self.run_ext_batch_job([ext_id], ["stop"], callback=start_if_still_previewing)
 
     @events.on
     def stop_preview(self) -> None:

--- a/ulauncher/modes/extensions/extension_mode.py
+++ b/ulauncher/modes/extensions/extension_mode.py
@@ -12,7 +12,7 @@ from ulauncher.internals.effects import EffectMessage, EffectType
 from ulauncher.internals.query import Query
 from ulauncher.internals.result import KeywordTrigger, Result
 from ulauncher.modes.extensions import extension_registry
-from ulauncher.modes.extensions.extension_controller import ExtensionController
+from ulauncher.modes.extensions.extension_controller import ExtensionController, preview
 from ulauncher.modes.mode import Mode
 from ulauncher.utils import scheduling
 from ulauncher.utils.eventbus import EventBus
@@ -42,7 +42,6 @@ class ExtensionMode(Mode):
     _trigger_cache: dict[str, tuple[str, str]]  # keyword: (trigger_id, ext_id)
     _pending_callback: Callable[[EffectMessage | list[Result]], None] | None = None
     _request_id: int = 0
-    _pending_preview_id: str | None = None
 
     def __init__(self) -> None:
         self._trigger_cache = {}
@@ -320,101 +319,51 @@ class ExtensionMode(Mode):
 
     @events.on
     def preview_ext(self, ext_id: str, path: str, with_debugger: bool = False) -> None:
-        """Handle a preview extension request coming from the CLI (via D-Bus)."""
+        """Run an extension from a dev path WITHOUT installing it. Triggered from the CLI via D-Bus.
 
-        logger.info(
-            "[preview] Received preview request for ext_id=%s path=%s debugger=%s",
-            ext_id,
-            path,
-            with_debugger,
-        )
+        While the preview is active, the controller with this id launches from the dev path; its
+        dependencies are installed by the CLI before this is called.
+        """
 
-        def load_preview_extension(ext_id: str) -> None:
-            preview_ext_id = f"{ext_id}.preview"
-            if controller := extension_registry.load(preview_ext_id, path):
-                ext = controller  # bind a non-optional local for the closures below
-                ext.is_preview = True
+        logger.info("[preview] Previewing ext_id=%s path=%s debugger=%s", ext_id, path, with_debugger)
+        preview.set(ext_id, path, with_debugger)
 
-                # install python dependencies from requirements.txt, then launch
-                from ulauncher.modes.extensions.extension_dependencies import ExtensionDependencies
+        # Register a controller so a not-yet-installed extension's triggers become available; an
+        # installed one already has one (now launching from the preview path).
+        extension_registry.get(ext_id) or extension_registry.load(ext_id, path)
 
-                # _pending_preview_id is a single-instance cancellation token: stop_preview clears it
-                # to abort a start still queued behind the dep install. Preview is one-at-a-time by
-                # design (the debugger binds a fixed port), so concurrent previews are unsupported; a
-                # superseded start aborts on the mismatch checks below without restoring its original.
-                self._pending_preview_id = preview_ext_id
+        from ulauncher.modes.extensions.extension_dependencies import ExtensionDependencies
 
-                def restore_shadowed_original() -> None:
-                    if (original := extension_registry.get(ext_id)) and original.shadowed_by_preview:
-                        original.shadowed_by_preview = False
-                        self.run_ext_batch_job([ext_id], ["start"])
+        def on_deps_installed(_stdout: str) -> None:
+            # Restart so a background-running installed instance relaunches from the dev path.
+            self.run_ext_batch_job([ext_id], ["stop", "start"])
 
-                def on_deps_installed(_stdout: str) -> None:
-                    if self._pending_preview_id != preview_ext_id:
-                        return
-                    self._pending_preview_id = None
-                    if ext.start(with_debugger=with_debugger):
-                        logger.info("[preview] Preview extension '%s' started successfully", preview_ext_id)
-                    else:
-                        logger.error("[preview] Failed to start preview extension '%s'", preview_ext_id)
-                        restore_shadowed_original()
+        def on_deps_error(error: Exception) -> None:
+            logger.error("[preview] Failed to install dependencies for '%s': %s", ext_id, error)
+            preview.clear()
 
-                def on_deps_error(error: Exception) -> None:
-                    if self._pending_preview_id != preview_ext_id:
-                        return
-                    self._pending_preview_id = None
-                    logger.error("[preview] Failed to install dependencies for '%s': %s", preview_ext_id, error)
-                    restore_shadowed_original()
-
-                deps = ExtensionDependencies(ext.id, ext.path)
-                # use run_when_idle to ensure deps.install runs on the GLib main loop
-                scheduling.run_when_idle(lambda: deps.install(on_deps_installed, on_deps_error))
-
-        def on_stopped(ext_id: str) -> None:
-            logger.info("[preview] Extension '%s' stopped", ext_id)
-            if existing_controller := extension_registry.get(ext_id):  # reload to update is_running state
-                existing_controller.shadowed_by_preview = True
-            load_preview_extension(ext_id)
-
-        existing_controller = extension_registry.get(ext_id)
-        if existing_controller and existing_controller.is_running:
-            logger.info(
-                "[preview] Extension '%s' is currently running; stopping it before launching preview version",
-                ext_id,
-            )
-            self.run_ext_batch_job([ext_id], ["stop"], callback=lambda: on_stopped(ext_id))
-        else:
-            load_preview_extension(ext_id)
+        deps = ExtensionDependencies(ext_id, path)
+        # deps.install must run on the GLib main loop so use idle_add since this can run from a worker thread.
+        scheduling.run_when_idle(lambda: deps.install(on_deps_installed, on_deps_error))
 
     @events.on
-    def stop_preview(self, preview_ext_id: str, original_ext_id: str) -> None:
-        """Handle stopping a preview extension and restoring the previous version if any."""
+    def stop_preview(self) -> None:
+        """Stop the active preview and restore the installed extension. Triggered from the CLI via D-Bus"""
 
-        logger.info(
-            "[preview] Received stop preview request for preview_ext_id=%s, original_ext_id=%s",
-            preview_ext_id,
-            original_ext_id,
-        )
+        # The CLI sends this on Ctrl+C even when preview_ext was never delivered (e.g. interrupted
+        # mid dependency-install), in which case there is no preview to stop or extension to restore.
+        ext_id = preview.ext_id
+        if not ext_id:
+            logger.debug("[preview] Ignoring stop_preview; no preview active")
+            return
 
-        # Cancel a start still deferred behind a dependency install (both run on the main loop).
-        if self._pending_preview_id == preview_ext_id:
-            self._pending_preview_id = None
+        logger.info("[preview] Stopping preview %s", ext_id)
+        preview.clear()
 
-        # Try to restart the original extension
-        def restart_original_extension(ext_id: str) -> None:
-            ext = extension_registry.get(ext_id)
-            if ext:
-                logger.info(
-                    "[preview] Re-enabling original extension '%s'",
-                    ext_id,
-                )
-                ext.shadowed_by_preview = False
-                restart_msg = f"[preview] Original extension '{ext_id}' re-enabled"
-                self.run_ext_batch_job([ext_id], ["start"], callback=lambda: logger.info(restart_msg))
+        def restore_original() -> None:
+            # Reload from the installed path, or drop the controller if the extension was never installed.
+            controller = extension_registry.load(ext_id)
+            if controller and controller.is_enabled:
+                self.run_ext_batch_job([ext_id], ["start"])
 
-        def stopped_handler(original_ext_id: str) -> None:
-            logger.info("[preview] Preview extension stopped. Restarting %s", original_ext_id)
-            restart_original_extension(original_ext_id)
-
-        # Stop the preview extension
-        self.run_ext_batch_job([preview_ext_id], ["stop"], lambda: stopped_handler(original_ext_id))
+        self.run_ext_batch_job([ext_id], ["stop"], callback=restore_original)

--- a/ulauncher/ui/preferences/views/extensions.py
+++ b/ulauncher/ui/preferences/views/extensions.py
@@ -80,12 +80,11 @@ class ExtensionsView(BaseView):
         extension_cache: dict[str, tuple[str, ext_utils.ExtStatus, str | None]] = {}
 
         for ext in extension_registry.iterate():
-            if not ext.shadowed_by_preview:
-                extension_cache[ext.id] = (
-                    ext.manifest.name,
-                    ext_utils.get_status_str(ext),
-                    ext.get_icon_value(),
-                )
+            extension_cache[ext.id] = (
+                ext.manifest.name,
+                ext_utils.get_status_str(ext),
+                ext.get_icon_value(),
+            )
 
         if extension_cache == self.extension_cache:
             return False


### PR DESCRIPTION
Fixes #1597 (it's actually better than the suggestion there).

Replace the `{ext_id}.preview` clone controller and the `shadowed_by_preview`/`is_preview` flags with a single `PreviewExtension` singleton. While a preview is active, the regular controller for that id reports `is_preview` and resolves its `source_path`/`manifest`/icon from the dev path instead of the installed location, so there is no second controller to shadow or restore.

This way, we can use the normal extension start and stop flow and it's less hacky.

The CLI now stops a preview with just the extension id, and the preferences list no longer needs to hide a shadowed original.

Move the requirements install out of the preview_ext D-Bus handler and into the `ulauncher preview` CLI command, which now drives the install (and Ctrl+C) on its own GLib main loop before triggering the preview. The handler can then start the extension directly instead of waiting on a callback-based install on the app side.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Refactors the extension preview flow to run under the installed extension ID via a single `PreviewExtension`. Previews load from the dev path, ignore installed errors, don’t persist preview failures, and the CLI installs deps and handles Ctrl+C.

- **Refactors**
  - Replace `{ext_id}.preview` and shadowing flags with a `PreviewExtension` singleton; controllers expose `is_preview` and load from `source_path` (dev path while previewing).
  - Start/stop: stop then restart the installed controller to run from the dev path; guarded so a racing stop won’t relaunch; remote debugger is enabled only for previews.
  - Preferences list shows the regular controller and status; no shadowed copy to hide.
  - `extensions:stop_preview` now stops the active preview without IDs and restores the installed extension.
  - Preview UI/status ignores any installed error state, and preview crashes are not persisted to the installed extension.

- **Migration**
  - `ulauncher preview` installs `requirements.txt` via `ExtensionDependencies` on its own `GLib` main loop, then triggers preview; Ctrl+C stops and restores via `extensions:stop_preview`.
  - If the extension is installed, preview restarts it to run from the dev path; if not installed, a controller is registered so triggers become available.

<sup>Written for commit b4e31c7f93097af4d1ee2d278020c2d5a532e448. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Ulauncher/Ulauncher/pull/1749?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



