### PR TITLE
fix(cli): flush D-Bus trigger events before the CLI exits

### DIFF
--- a/tests/utils/test_dbus.py
+++ b/tests/utils/test_dbus.py
@@ -1,0 +1,43 @@
+from unittest.mock import MagicMock, call
+
+import pytest
+from pytest_mock import MockerFixture
+
+from ulauncher.utils import dbus
+
+
+@pytest.fixture
+def gio(mocker: MockerFixture) -> MagicMock:
+    return mocker.patch("ulauncher.utils.dbus.Gio")
+
+
+@pytest.fixture
+def action_group(mocker: MockerFixture) -> MagicMock:
+    return mocker.patch("ulauncher.utils.dbus.get_ulauncher_dbus_action_group").return_value
+
+
+class TestDbusTriggerEvent:
+    def test_flushes_the_bus_after_activating_the_action(
+        self, gio: MagicMock, action_group: MagicMock, mocker: MockerFixture
+    ) -> None:
+        mocker.patch("ulauncher.utils.dbus.check_app_running", return_value=True)
+        bus = gio.bus_get_sync.return_value
+
+        # flush must follow activate so the queued message is on the socket before the process exits
+        parent = MagicMock()
+        parent.attach_mock(action_group.activate_action, "activate")
+        parent.attach_mock(bus.flush_sync, "flush")
+
+        dbus.dbus_trigger_event("extensions:stop_preview")
+
+        assert parent.mock_calls == [call.activate("trigger-event", mocker.ANY), call.flush(None)]
+
+    def test_does_nothing_when_app_is_not_running(
+        self, gio: MagicMock, action_group: MagicMock, mocker: MockerFixture
+    ) -> None:
+        mocker.patch("ulauncher.utils.dbus.check_app_running", return_value=False)
+
+        dbus.dbus_trigger_event("extensions:stop_preview")
+
+        action_group.activate_action.assert_not_called()
+        gio.bus_get_sync.return_value.flush_sync.assert_not_called()

--- a/ulauncher/utils/dbus.py
+++ b/ulauncher/utils/dbus.py
@@ -75,3 +75,6 @@ def dbus_trigger_event(name: str, *args: Any) -> None:
 
     json_message = json.dumps({"name": name, "args": list(args)})
     get_ulauncher_dbus_action_group(bus).activate_action("trigger-event", GLib.Variant.new_string(json_message))
+    # activate_action only queues the message; flush it so it reaches the bus before the short-lived
+    # CLI process exits and drops the still-pending write.
+    bus.flush_sync(None)

--- a/ulauncher/utils/dbus.py
+++ b/ulauncher/utils/dbus.py
@@ -77,4 +77,7 @@ def dbus_trigger_event(name: str, *args: Any) -> None:
     get_ulauncher_dbus_action_group(bus).activate_action("trigger-event", GLib.Variant.new_string(json_message))
     # activate_action only queues the message; flush it so it reaches the bus before the short-lived
     # CLI process exits and drops the still-pending write.
-    bus.flush_sync(None)
+    try:
+        bus.flush_sync(None)
+    except GLib.Error as e:
+        logger.warning("DBus flush failed: %s", e)


### PR DESCRIPTION
dbus_trigger_event only queued the message on the shared session-bus connection; the actual socket write is done asynchronously by the GDBus worker thread. A short-lived CLI command (preview stop, install/upgrade reload, uninstall stop) could exit before that flush ran, silently dropping the message. Most visibly, Ctrl+C on a preview could fail to deliver stop_preview, leaving the extension running under the dev path.

Flush the connection after activating the action so the message reaches the bus before the process tears down.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Flush D-Bus trigger events before the CLI exits to prevent dropped messages in short-lived commands. Fixes lost `stop_preview` events (e.g., on Ctrl+C) that could leave extensions running.

- **Bug Fixes**
  - Call `bus.flush_sync(None)` after activating `trigger-event` in `dbus_trigger_event`; catch `GLib.Error` and log a warning to avoid CLI crashes.
  - Add tests to verify flush happens after activate and that no-op occurs when the app isn’t running.

<sup>Written for commit 44be3db0fab2226f8b5addd2af8247422314a4f9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Ulauncher/Ulauncher/pull/1750?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

