### PR TITLE
feat: rename and invert option to auto-resume interrupted sessions

### DIFF
--- a/ulauncher/ui/preferences/views/preferences.py
+++ b/ulauncher/ui/preferences/views/preferences.py
@@ -188,7 +188,7 @@ class PreferencesView(BaseView):
         # Auto resume
         auto_resume_switch = Gtk.Switch(active=self.settings.auto_resume)
         auto_resume_switch.connect("notify::active", self._on_auto_resume_toggled)
-        auto_resume_desc = "If you close Ulauncher with an unfinished query, restore it on the next session."
+        auto_resume_desc = "If you close Ulauncher without running the query, restore it on the next session."
         self._add_setting_row(general_box, "Auto-resume unfinished sessions", auto_resume_switch, auto_resume_desc)
 
         # Close on focus out

--- a/ulauncher/ui/preferences/views/preferences.py
+++ b/ulauncher/ui/preferences/views/preferences.py
@@ -185,11 +185,11 @@ class PreferencesView(BaseView):
         screen_desc = "Decide which monitor presents Ulauncher when you press the hotkey."
         self._add_setting_row(general_box, "Screen to show on", screen_combo, screen_desc)
 
-        # Start with blank query
-        clear_query_switch = Gtk.Switch(active=self.settings.clear_previous_query)
-        clear_query_switch.connect("notify::active", self._on_clear_query_toggled)
-        clear_desc = "Clear the previous search so each invocation starts from an empty input field."
-        self._add_setting_row(general_box, "Start each session with a blank query", clear_query_switch, clear_desc)
+        # Auto resume
+        auto_resume_switch = Gtk.Switch(active=self.settings.auto_resume)
+        auto_resume_switch.connect("notify::active", self._on_auto_resume_toggled)
+        auto_resume_desc = "If you close Ulauncher with an unfinished query, restore it on the next session."
+        self._add_setting_row(general_box, "Auto-resume unfinished sessions", auto_resume_switch, auto_resume_desc)
 
         # Close on focus out
         close_focus_switch = Gtk.Switch(active=self.settings.close_on_focus_out)
@@ -315,8 +315,8 @@ class PreferencesView(BaseView):
         if screen:
             self.settings.save({"render_on_screen": screen})
 
-    def _on_clear_query_toggled(self, switch: Gtk.Switch, _: Any) -> None:
-        self.settings.save({"clear_previous_query": switch.get_active()})
+    def _on_auto_resume_toggled(self, switch: Gtk.Switch, _: Any) -> None:
+        self.settings.save({"auto_resume": switch.get_active()})
 
     def _on_close_focus_toggled(self, switch: Gtk.Switch, _: Any) -> None:
         self.settings.save({"close_on_focus_out": switch.get_active()})

--- a/ulauncher/ui/ulauncher_window.py
+++ b/ulauncher/ui/ulauncher_window.py
@@ -392,7 +392,7 @@ class UlauncherWindow(Gtk.ApplicationWindow):
 
     def close(self, save_query: bool = False) -> None:
         logger.info("Closing Ulauncher window")
-        if not save_query or self.settings.clear_previous_query:
+        if not save_query or not self.settings.auto_resume:
             events.emit("app:set_query", "", update_input=False)
         if self.settings.grab_mouse_pointer:
             self.toggle_grab_pointer_device(False)

--- a/ulauncher/utils/settings.py
+++ b/ulauncher/utils/settings.py
@@ -10,8 +10,8 @@ _settings_file = f"{paths.CONFIG}/settings.json"
 
 class Settings(JsonConf):
     arrow_key_aliases = "hjkl"
+    auto_resume = False
     base_width = 750
-    clear_previous_query = True
     close_on_focus_out = True
     disable_desktop_filters = False
     enable_application_mode = True
@@ -36,6 +36,9 @@ class Settings(JsonConf):
             normalized = "show_tray_icon"
         elif normalized == "daemonless":
             normalized = "keep_alive"
+            value = not value
+        elif normalized == "clear_previous_query":
+            normalized = "auto_resume"
             value = not value
         super().__setitem__(normalized, value)
 


### PR DESCRIPTION
I don't like negative options "Don't do X", and while it can be argued to be a feature to run Ulauncher without pre-filling the last query, I think this phrasing makes a lot more sense.

Before:
<img width="1530" height="142" alt="image" src="https://github.com/user-attachments/assets/8d6b7a89-6e88-4742-b6c4-9b99abf91021" />


After:
<img width="1530" height="142" alt="image" src="https://github.com/user-attachments/assets/645ac5ae-58a6-4250-96a8-d204073e25a1" />

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Renamed the “Start each session with a blank query” setting to “Auto-resume unfinished sessions” and inverted its logic for clearer behavior. Default behavior is unchanged.

- **Refactors**
  - UI: replaced “Start each session with a blank query” with “Auto-resume unfinished sessions” and updated help text.
  - Settings: renamed `clear_previous_query` to `auto_resume` (inverted semantics, default remains equivalent).
  - Logic: updated window close behavior to respect `auto_resume`.
  - Compatibility: added mapping so old `clear_previous_query` writes are redirected to `auto_resume` with inverted value.

<sup>Written for commit 7907cdefa1b35554c1835590c98c4a04f5f2cedd. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Ulauncher/Ulauncher/pull/1751?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

