### PR TITLE
fix(ext): show loading placeholder for transitioning extensions instead of erroring

### DIFF
--- a/tests/modes/extensions/test_extension_mode.py
+++ b/tests/modes/extensions/test_extension_mode.py
@@ -8,6 +8,7 @@ from pytest_mock import MockerFixture
 
 from ulauncher.api.shared.event import EventType
 from ulauncher.internals.query import Query
+from ulauncher.internals.result import Result
 from ulauncher.modes.extensions import extension_registry
 from ulauncher.modes.extensions.extension_controller import ExtensionController
 from ulauncher.modes.extensions.extension_controller import events as controller_events
@@ -108,7 +109,7 @@ def test_handle_query__loading_timeout_shows_empty(mocker: MockerFixture) -> Non
     assert mode._loading_timer is None
 
 
-def test_handle_query__unknown_keyword_shows_empty(mocker: MockerFixture) -> None:
+def test_handle_query__unknown_keyword_shows_message(mocker: MockerFixture) -> None:
     mode = _make_mode()
     mocker.patch.object(extension_registry, "iterate", return_value=iter([]))
     mocker.patch.object(extension_registry, "get", return_value=None)
@@ -116,12 +117,16 @@ def test_handle_query__unknown_keyword_shows_empty(mocker: MockerFixture) -> Non
 
     mode.handle_query(Query("kw", "arg"), callback)
 
-    callback.assert_called_once_with([])
+    callback.assert_called_once()
+    (results,) = callback.call_args.args
+    assert [r.name for r in results] == ["Extension not available"]
 
 
-def test_errored__while_loading_shows_empty_immediately() -> None:
+def test_errored__while_loading_shows_failure(mocker: MockerFixture) -> None:
     mode = _make_mode()
     mode._active_ext = _make_active_ext("test.ext")
+    failure = Result(name="failed")
+    mocker.patch.object(mode, "_loading_failed_result", return_value=failure)
     timer = MagicMock()
     mode._loading_timer = timer
     callback = MagicMock()
@@ -129,7 +134,7 @@ def test_errored__while_loading_shows_empty_immediately() -> None:
 
     mode.errored("test.ext")
 
-    callback.assert_called_once_with([])
+    callback.assert_called_once_with([failure])
     timer.cancel.assert_called_once()
     assert mode._loading_timer is None
 

--- a/tests/modes/extensions/test_extension_mode.py
+++ b/tests/modes/extensions/test_extension_mode.py
@@ -1,12 +1,29 @@
+from __future__ import annotations
+
 from types import SimpleNamespace
+from typing import TYPE_CHECKING
 from unittest.mock import MagicMock, PropertyMock
 
 from pytest_mock import MockerFixture
 
 from ulauncher.api.shared.event import EventType
+from ulauncher.internals.query import Query
 from ulauncher.modes.extensions import extension_registry
 from ulauncher.modes.extensions.extension_controller import ExtensionController
 from ulauncher.modes.extensions.extension_controller import events as controller_events
+
+if TYPE_CHECKING:
+    from ulauncher.modes.extensions.extension_mode import ExtensionMode
+
+
+def _make_mode() -> ExtensionMode:
+    # Imported lazily so collection doesn't register ExtensionMode's event listeners globally,
+    # which would otherwise fire (unbound) when other test modules emit extension events.
+    from ulauncher.modes.extensions import extension_mode
+
+    mode = object.__new__(extension_mode.ExtensionMode)
+    mode._trigger_cache = {}
+    return mode
 
 
 def test_save_user_preferences__emits_old_preferences(mocker: MockerFixture) -> None:
@@ -55,3 +72,79 @@ def test_update_preferences__uses_emitted_old_preferences(mocker: MockerFixture)
     ext.send_message.assert_called_once_with(
         {"type": EventType.UPDATE_PREFERENCES, "args": ["city", "Berlin", "Stockholm"]}
     )
+
+
+def test_handle_query__transitioning_extension_waits(mocker: MockerFixture) -> None:
+    from ulauncher.modes.extensions import extension_mode
+
+    mode = _make_mode()
+    mode._trigger_cache = {"kw": ("trigger1", "test.ext")}
+    ext = SimpleNamespace(id="test.ext", is_running=False)
+    mocker.patch.object(extension_registry, "get", return_value=ext)
+    timer = mocker.patch.object(extension_mode.scheduling, "timer", return_value=MagicMock())
+    callback = MagicMock()
+
+    mode.handle_query(Query("kw", "arg"), callback)
+
+    callback.assert_not_called()
+    timer.assert_called_once()
+    assert mode.active_ext is ext
+
+
+def test_handle_query__loading_timeout_shows_empty(mocker: MockerFixture) -> None:
+    from ulauncher.modes.extensions import extension_mode
+
+    mode = _make_mode()
+    mode._trigger_cache = {"kw": ("trigger1", "test.ext")}
+    ext = SimpleNamespace(id="test.ext", is_running=False)
+    mocker.patch.object(extension_registry, "get", return_value=ext)
+    timer = mocker.patch.object(extension_mode.scheduling, "timer", return_value=MagicMock())
+    callback = MagicMock()
+
+    mode.handle_query(Query("kw", "arg"), callback)
+    timer.call_args.args[1]()  # fire the captured loading-timeout callback
+
+    callback.assert_called_once_with([])
+    assert mode._loading_timer is None
+
+
+def test_handle_query__unknown_keyword_shows_empty(mocker: MockerFixture) -> None:
+    mode = _make_mode()
+    mocker.patch.object(extension_registry, "iterate", return_value=iter([]))
+    mocker.patch.object(extension_registry, "get", return_value=None)
+    callback = MagicMock()
+
+    mode.handle_query(Query("kw", "arg"), callback)
+
+    callback.assert_called_once_with([])
+
+
+def _make_active_ext(ext_id: str) -> ExtensionController:
+    ext = object.__new__(ExtensionController)
+    ext.id = ext_id
+    return ext
+
+
+def test_started__reruns_query_for_active_extension(mocker: MockerFixture) -> None:
+    from ulauncher.modes.extensions import extension_mode
+
+    mode = _make_mode()
+    mode._active_ext = _make_active_ext("test.ext")
+    mocker.patch.object(extension_mode.scheduling, "run_when_idle", side_effect=lambda func: func())
+    emit = mocker.patch.object(extension_mode.events, "emit")
+
+    mode.started("test.ext")
+
+    emit.assert_called_once_with("app:reload_query")
+
+
+def test_started__ignores_other_extensions(mocker: MockerFixture) -> None:
+    from ulauncher.modes.extensions import extension_mode
+
+    mode = _make_mode()
+    mode._active_ext = _make_active_ext("test.ext")
+    run_when_idle = mocker.patch.object(extension_mode.scheduling, "run_when_idle")
+
+    mode.started("other.ext")
+
+    run_when_idle.assert_not_called()

--- a/tests/modes/extensions/test_extension_mode.py
+++ b/tests/modes/extensions/test_extension_mode.py
@@ -119,6 +119,48 @@ def test_handle_query__unknown_keyword_shows_empty(mocker: MockerFixture) -> Non
     callback.assert_called_once_with([])
 
 
+def test_errored__while_loading_shows_empty_immediately() -> None:
+    mode = _make_mode()
+    mode._active_ext = _make_active_ext("test.ext")
+    timer = MagicMock()
+    mode._loading_timer = timer
+    callback = MagicMock()
+    mode._pending_callback = callback
+
+    mode.errored("test.ext")
+
+    callback.assert_called_once_with([])
+    timer.cancel.assert_called_once()
+    assert mode._loading_timer is None
+
+
+def test_errored__while_not_loading_drops_pending_callback() -> None:
+    mode = _make_mode()
+    mode._active_ext = _make_active_ext("test.ext")
+    callback = MagicMock()
+    mode._pending_callback = callback
+
+    mode.errored("test.ext")
+
+    callback.assert_not_called()
+    assert mode._pending_callback is None
+
+
+def test_errored__ignores_other_extensions() -> None:
+    mode = _make_mode()
+    mode._active_ext = _make_active_ext("test.ext")
+    timer = MagicMock()
+    mode._loading_timer = timer
+    callback = MagicMock()
+    mode._pending_callback = callback
+
+    mode.errored("other.ext")
+
+    callback.assert_not_called()
+    timer.cancel.assert_not_called()
+    assert mode._loading_timer is timer
+
+
 def _make_active_ext(ext_id: str) -> ExtensionController:
     ext = object.__new__(ExtensionController)
     ext.id = ext_id

--- a/ulauncher/modes/extensions/extension_controller.py
+++ b/ulauncher/modes/extensions/extension_controller.py
@@ -404,6 +404,7 @@ class ExtensionController:
         except (OSError, GLib.Error) as err:
             exit_handler("FailedToStart", str(err))
             return False
+        events.emit("extensions:started", self.id)
         return self.is_running
 
     async def stop(self) -> None:

--- a/ulauncher/modes/extensions/extension_controller.py
+++ b/ulauncher/modes/extensions/extension_controller.py
@@ -352,7 +352,7 @@ class ExtensionController:
                 if not self.is_preview:
                     self.state.save(error_type=cause, error_message=error_msg)
 
-            events.emit("extensions:exited", self.id, cause)
+                events.emit("extensions:errored", self.id)
 
         try:
             self.manifest.validate()

--- a/ulauncher/modes/extensions/extension_mode.py
+++ b/ulauncher/modes/extensions/extension_mode.py
@@ -12,7 +12,11 @@ from ulauncher.internals.effects import EffectMessage, EffectType
 from ulauncher.internals.query import Query
 from ulauncher.internals.result import KeywordTrigger, Result
 from ulauncher.modes.extensions import extension_registry
-from ulauncher.modes.extensions.extension_controller import ExtensionController, preview
+from ulauncher.modes.extensions.extension_controller import (
+    ExtensionController,
+    ExtensionControllerTrigger,
+    preview,
+)
 from ulauncher.modes.mode import Mode
 from ulauncher.utils import scheduling
 from ulauncher.utils.eventbus import EventBus
@@ -20,6 +24,8 @@ from ulauncher.utils.socket_msg_controller import summarize_ipc_args
 
 logger = logging.getLogger(__name__)
 events = EventBus("extensions")
+
+LOADING_TIMEOUT = 10  # seconds to wait for a transitioning extension before giving up
 
 
 class ExtensionResponse(TypedDict, total=False):
@@ -41,6 +47,7 @@ class ExtensionMode(Mode):
     _active_ext: ExtensionController | None = None
     _trigger_cache: dict[str, tuple[str, str]]  # keyword: (trigger_id, ext_id)
     _pending_callback: Callable[[EffectMessage | list[Result]], None] | None = None
+    _loading_timer: scheduling.Context | None = None
     _request_id: int = 0
 
     def __init__(self) -> None:
@@ -66,6 +73,12 @@ class ExtensionMode(Mode):
             logger.debug("Active extension %s exited (%s), clearing pending callback", ext_id, cause)
             self._pending_callback = None
 
+    @events.on
+    def started(self, ext_id: str) -> None:
+        # start() runs in a worker thread, so re-evaluate the query on the main loop.
+        if self.active_ext and self.active_ext.id == ext_id:
+            scheduling.run_when_idle(lambda: events.emit("app:reload_query"))
+
     @property
     def active_ext(self) -> ExtensionController | None:
         return self._active_ext
@@ -77,44 +90,70 @@ class ExtensionMode(Mode):
             self._active_ext = ext
 
     def handle_query(self, query: Query, callback: Callable[[EffectMessage | list[Result]], None]) -> None:
+        self._clear_loading_timer()
         if not query.keyword:
             msg = f"Extensions currently only support queries with a keyword ('{query}' given)"
             raise RuntimeError(msg)
 
-        if trigger_cache_entry := self._trigger_cache.get(query.keyword, None):
-            trigger_id, ext_id = trigger_cache_entry
-            if ext := extension_registry.get(ext_id):
-                self.active_ext = ext
-                event = {
-                    "type": EventType.INPUT_TRIGGER,
-                    "ext_id": ext.id,
-                    "args": [query.argument, trigger_id],
-                }
+        self._ensure_trigger_cache()
+        trigger_cache_entry = self._trigger_cache.get(query.keyword, None)
+        ext = extension_registry.get(trigger_cache_entry[1]) if trigger_cache_entry else None
+        if not trigger_cache_entry or not ext:
+            # Core only routes a keyword here when its own cache claims this mode owns it, so a miss
+            # means the two caches disagree (e.g. the extension was removed since core last loaded).
+            logger.warning("Extension query '%s' did not match any enabled extension", query)
+            callback([])
+            return
 
-                self.send_request(event, callback)
-                return
+        self.active_ext = ext
+        if not ext.is_running:
+            # Transitioning (restart/preview/update/startup): wait for it to come up. Returning
+            # without a result lets core show "Loading..." after PLACEHOLDER_DELAY, and `started`
+            # re-runs the query once the extension is ready.
+            def loading_timed_out() -> None:
+                self._loading_timer = None
+                callback([])
 
-        msg = f"Query not valid for extension mode '{query}'"
-        raise RuntimeError(msg)
+            self._loading_timer = scheduling.timer(LOADING_TIMEOUT, loading_timed_out)
+            return
+
+        self.send_request(
+            {"type": EventType.INPUT_TRIGGER, "ext_id": ext.id, "args": [query.argument, trigger_cache_entry[0]]},
+            callback,
+        )
+
+    def _iter_enabled_triggers(self) -> Iterator[tuple[ExtensionController, str, ExtensionControllerTrigger]]:
+        for ext in extension_registry.iterate():
+            if not ext.is_enabled:
+                continue
+            for trigger_id, trigger in ext.triggers.items():
+                yield ext, trigger_id, trigger
+
+    def _ensure_trigger_cache(self) -> None:
+        if not self._trigger_cache:
+            for ext, trigger_id, trigger in self._iter_enabled_triggers():
+                if trigger.keyword:
+                    self._trigger_cache[trigger.keyword] = (trigger_id, ext.id)
+
+    def _clear_loading_timer(self) -> None:
+        if self._loading_timer:
+            self._loading_timer.cancel()
+            self._loading_timer = None
 
     def get_triggers(self) -> Iterator[Result]:
         self._trigger_cache.clear()
-        for ext in extension_registry.iterate():
-            if not ext.is_running:
-                continue
+        for ext, trigger_id, trigger in self._iter_enabled_triggers():
+            name = html.escape(trigger.name)
+            description = html.escape(trigger.description)
+            icon = ext.get_icon_value(trigger.icon)
 
-            for trigger_id, trigger in ext.triggers.items():
-                name = html.escape(trigger.name)
-                description = html.escape(trigger.description)
-                icon = ext.get_icon_value(trigger.icon)
-
-                if trigger.keyword:
-                    self._trigger_cache[trigger.keyword] = (trigger_id, ext.id)
-                    yield KeywordTrigger(name=name, description=description, icon=icon, keyword=trigger.keyword)
-                else:
-                    yield ExtensionLaunchTrigger(
-                        name=name, description=description, icon=icon, ext_id=ext.id, trigger_id=trigger_id
-                    )
+            if trigger.keyword:
+                self._trigger_cache[trigger.keyword] = (trigger_id, ext.id)
+                yield KeywordTrigger(name=name, description=description, icon=icon, keyword=trigger.keyword)
+            else:
+                yield ExtensionLaunchTrigger(
+                    name=name, description=description, icon=icon, ext_id=ext.id, trigger_id=trigger_id
+                )
 
     def get_placeholder_icon(self) -> str | None:
         if self.active_ext:

--- a/ulauncher/modes/extensions/extension_mode.py
+++ b/ulauncher/modes/extensions/extension_mode.py
@@ -68,9 +68,12 @@ class ExtensionMode(Mode):
         self._trigger_cache.clear()
 
     @events.on
-    def exited(self, ext_id: str, cause: str) -> None:
-        if self.active_ext and self.active_ext.id == ext_id:
-            logger.debug("Active extension %s exited (%s), clearing pending callback", ext_id, cause)
+    def errored(self, ext_id: str) -> None:
+        if not self.active_ext or self.active_ext.id != ext_id:
+            return
+        if self._loading_timer:
+            self._finish_loading()
+        else:
             self._pending_callback = None
 
     @events.on
@@ -109,12 +112,10 @@ class ExtensionMode(Mode):
         if not ext.is_running:
             # Transitioning (restart/preview/update/startup): wait for it to come up. Returning
             # without a result lets core show "Loading..." after PLACEHOLDER_DELAY, and `started`
-            # re-runs the query once the extension is ready.
-            def loading_timed_out() -> None:
-                self._loading_timer = None
-                callback([])
-
-            self._loading_timer = scheduling.timer(LOADING_TIMEOUT, loading_timed_out)
+            # re-runs the query once the extension is ready. The wait ends early if the extension
+            # exits with an error, otherwise after LOADING_TIMEOUT.
+            self._pending_callback = callback
+            self._loading_timer = scheduling.timer(LOADING_TIMEOUT, self._finish_loading)
             return
 
         self.send_request(
@@ -139,6 +140,13 @@ class ExtensionMode(Mode):
         if self._loading_timer:
             self._loading_timer.cancel()
             self._loading_timer = None
+
+    def _finish_loading(self) -> None:
+        """Resolve a pending loading wait with empty results (no-op if not waiting)."""
+        self._clear_loading_timer()
+        callback, self._pending_callback = self._pending_callback, None
+        if callback:
+            callback([])
 
     def get_triggers(self) -> Iterator[Result]:
         self._trigger_cache.clear()

--- a/ulauncher/modes/extensions/extension_mode.py
+++ b/ulauncher/modes/extensions/extension_mode.py
@@ -72,7 +72,7 @@ class ExtensionMode(Mode):
         if not self.active_ext or self.active_ext.id != ext_id:
             return
         if self._loading_timer:
-            self._finish_loading()
+            self._finish_loading([self._loading_failed_result()])
         else:
             self._pending_callback = None
 
@@ -105,15 +105,15 @@ class ExtensionMode(Mode):
             # Core only routes a keyword here when its own cache claims this mode owns it, so a miss
             # means the two caches disagree (e.g. the extension was removed since core last loaded).
             logger.warning("Extension query '%s' did not match any enabled extension", query)
-            callback([])
+            callback([Result(name="Extension not available")])
             return
 
         self.active_ext = ext
         if not ext.is_running:
             # Transitioning (restart/preview/update/startup): wait for it to come up. Returning
             # without a result lets core show "Loading..." after PLACEHOLDER_DELAY, and `started`
-            # re-runs the query once the extension is ready. The wait ends early if the extension
-            # exits with an error, otherwise after LOADING_TIMEOUT.
+            # re-runs the query once the extension is ready. The wait ends with a failure message if
+            # the extension exits with an error, otherwise empty after LOADING_TIMEOUT.
             self._pending_callback = callback
             self._loading_timer = scheduling.timer(LOADING_TIMEOUT, self._finish_loading)
             return
@@ -141,12 +141,21 @@ class ExtensionMode(Mode):
             self._loading_timer.cancel()
             self._loading_timer = None
 
-    def _finish_loading(self) -> None:
-        """Resolve a pending loading wait with empty results (no-op if not waiting)."""
+    def _finish_loading(self, results: list[Result] | None = None) -> None:
+        """Resolve a pending loading wait, defaulting to empty results (no-op if not waiting)."""
         self._clear_loading_timer()
         callback, self._pending_callback = self._pending_callback, None
         if callback:
-            callback([])
+            callback(results or [])
+
+    def _loading_failed_result(self) -> Result:
+        ext = self.active_ext
+        name = (ext.manifest.name if ext else "") or "Extension"
+        # A preview's error isn't persisted (it surfaces in the preview's own console), so the
+        # stored message is only meaningful for an installed extension that errored.
+        description = ext.state.error_message if ext and ext.has_error else ""
+        icon = ext.get_icon_value() if ext else None
+        return Result(name=f"{name} failed to start", description=description, icon=icon)
 
     def get_triggers(self) -> Iterator[Result]:
         self._trigger_cache.clear()

--- a/ulauncher/ui/app.py
+++ b/ulauncher/ui/app.py
@@ -59,6 +59,11 @@ class UlauncherApp(Gtk.Application):
         if update_input and (main_window := self.windows.get("main")) and isinstance(main_window, UlauncherWindow):
             main_window.set_input(self.query)
 
+    @events.on
+    def reload_query(self) -> None:
+        if (main_window := self.windows.get("main")) and isinstance(main_window, UlauncherWindow):
+            main_window.reload_query()
+
     def do_startup(self) -> None:
         Gtk.Application.do_startup(self)
         Gio.ActionMap.add_action_entries(

--- a/ulauncher/ui/ulauncher_window.py
+++ b/ulauncher/ui/ulauncher_window.py
@@ -421,6 +421,9 @@ class UlauncherWindow(Gtk.ApplicationWindow):
         self.prompt_input.set_text(query_str)
         self.prompt_input.set_position(-1)
 
+    def reload_query(self) -> None:
+        self.core.set_query(self.query_str, emit_show_results)
+
     def show_results(self, results: Iterable[Result]) -> None:
         self._results_nav = None
         self.results.foreach(lambda w: w.destroy())


### PR DESCRIPTION
Typing an extension keyword while its process was restarting (preview, reload, update or startup) routed the query to an extension that was momentarily not running, raising "Query not valid for extension mode" and leaving stale results on screen.

Build the keyword cache from enabled extensions rather than only running ones, so a keyword stays claimed across a restart, and rebuild it on demand in handle_query since the cache is cleared mid-restart. When the matched extension is enabled but not yet running, wait instead of raising: returning without a result lets the core render its "Loading..." placeholder, and a new extensions:started event re-evaluates the current query once the extension is ready. A 10s timeout caps the visible loading state, while a late start still recovers via the started event.

OOM- or externally-killed extensions keep their persisted error and are excluded from the cache, so they fall through to search rather than hang on "Loading...".

This makes the `ulauncher preview` command A LOT less flaky. You can open Ulauncher immediately after running it and it will match your keyword and wait for the preview extension to load and then send the query and show the response.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Show a "Loading..." placeholder when a keyword targets an extension that is starting or restarting. If the extension can’t serve the query, show a clear status message instead of a blank list.

- **Bug Fixes**
  - Build the keyword cache from enabled extensions (not just running) and rebuild it on demand in `handle_query` so keywords stay claimed mid‑restart.
  - If the matched extension isn’t running, wait instead of raising: start a 10s timeout, re-run the query on `extensions:started` via `app:reload_query` and `UlauncherWindow.reload_query`, and resolve early on `extensions:errored` with a "<name> failed to start" result that includes the persisted error.
  - If no enabled extension matches the keyword (e.g., it was removed), show "Extension not available" while keeping the keyword claimed.
  - Added tests for waiting behavior, timeout fallback, early error resolution, re-running on start, and status message rendering.

<sup>Written for commit e9e77cf23f026dc4f9a78aa3a7e9b54b6943da21. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Ulauncher/Ulauncher/pull/1752?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

