### PR TITLE
refactor(file_browser): merge FolderResult into FileResult

### DIFF
--- a/ulauncher/modes/file_browser/file_browser_mode.py
+++ b/ulauncher/modes/file_browser/file_browser_mode.py
@@ -2,14 +2,14 @@ from __future__ import annotations
 
 import logging
 import os
-from os.path import dirname, expandvars, isdir, join
+from os.path import dirname, expandvars, join
 from pathlib import Path
 from typing import Callable
 
 from ulauncher.internals import effects
 from ulauncher.internals.query import Query
 from ulauncher.internals.result import Result
-from ulauncher.modes.file_browser.results import FileResult, FolderResult
+from ulauncher.modes.file_browser.results import FileResult
 from ulauncher.modes.mode import Mode
 from ulauncher.utils.eventbus import EventBus
 from ulauncher.utils.fold_user_path import fold_user_path
@@ -65,7 +65,7 @@ class FileBrowserMode(Mode):
                     file_names = self.list_files(str(path), sort_by_atime=True)
                     for name in self.filter_dot_files(file_names)[: self.LIMIT]:
                         file_path = join(closest_parent, name)
-                        results.append(FolderResult(file_path) if isdir(file_path) else FileResult(file_path))
+                        results.append(FileResult(file_path))
 
                 else:
                     file_names = self.list_files(closest_parent)
@@ -82,7 +82,7 @@ class FileBrowserMode(Mode):
                     ]
                     for name in filtered:
                         file_path = join(closest_parent, name)
-                        results.append(FolderResult(file_path) if isdir(file_path) else FileResult(file_path))
+                        results.append(FileResult(file_path))
 
         except (RuntimeError, OSError):
             results = []

--- a/ulauncher/modes/file_browser/get_icon_from_path.py
+++ b/ulauncher/modes/file_browser/get_icon_from_path.py
@@ -17,8 +17,8 @@ SPECIAL_DIRS = {
 }
 
 
-def get_icon_from_path(path: str) -> str:
-    if Path(path).is_dir():
+def get_icon_from_path(path: str, is_dir: bool) -> str:
+    if is_dir:
         return SPECIAL_DIRS.get(path) or "folder"
 
     if mime := mimetypes.guess_type(Path(path).name)[0]:

--- a/ulauncher/modes/file_browser/results.py
+++ b/ulauncher/modes/file_browser/results.py
@@ -1,35 +1,38 @@
 from __future__ import annotations
 
-from os.path import basename
+from os.path import basename, isdir
+from typing import Dict, Literal
 
 from ulauncher.internals.result import Result
 from ulauncher.modes.file_browser.get_icon_from_path import get_icon_from_path
+
+_Actions = Dict[str, Dict[Literal["name", "icon"], str]]
+
+_FILE_ACTIONS: _Actions = {
+    "open": {"name": "Open file", "icon": "document-open"},
+    "open_parent": {"name": "Open containing folder", "icon": "folder-open"},
+    "copy_path": {"name": "Copy path", "icon": "edit-copy"},
+}
+_FOLDER_ACTIONS: _Actions = {
+    "go_to": {"name": "Open", "icon": "folder-open"},
+    "open": {"name": "Open in file manager", "icon": "system-file-manager"},
+    "copy_path": {"name": "Copy path", "icon": "edit-copy"},
+}
 
 
 class FileResult(Result):
     compact = True
     highlightable = True
     path = ""
-    actions = {
-        "open": {"name": "Open file", "icon": "document-open"},
-        "open_parent": {"name": "Open containing folder", "icon": "folder-open"},
-        "copy_path": {"name": "Copy path", "icon": "edit-copy"},
-    }
 
     def __init__(self, path: str) -> None:
+        is_dir = isdir(path)
         super().__init__(
             path=path,
             name=basename(path),
-            icon=get_icon_from_path(path),
+            icon=get_icon_from_path(path, is_dir),
+            actions=_FOLDER_ACTIONS if is_dir else _FILE_ACTIONS,
         )
 
     def get_highlightable_input(self, query_str: str) -> str:
         return basename(query_str)
-
-
-class FolderResult(FileResult):
-    actions = {
-        "go_to": {"name": "Open", "icon": "folder-open"},
-        "open": {"name": "Open in file manager", "icon": "system-file-manager"},
-        "copy_path": {"name": "Copy path", "icon": "edit-copy"},
-    }


### PR DESCRIPTION
Refactors the file browser result classes by merging `FolderResult` into `FileResult`, using a runtime `isdir()` check to conditionally create the actions.

This is also reused for the icon, avoiding checking isdir twice.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Merged `FolderResult` into `FileResult`. `FileResult` now checks if a path is a directory once and uses that to set actions and pick the icon.

- **Refactors**
  - Single `FileResult` class with actions chosen via `_FILE_ACTIONS`/`_FOLDER_ACTIONS` based on `isdir(path)`.
  - `get_icon_from_path` now takes `(path, is_dir)` to reuse the directory check.
  - `file_browser_mode` always creates `FileResult(path)`; removed conditional `FolderResult`.
  - Removes duplicate `isdir` calls per item for a small I/O and perf win.

<sup>Written for commit 04a2d4e0e5c8c1fbeb5c36abf78aa09460040f90. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Ulauncher/Ulauncher/pull/1753?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

