### PR TITLE
feat(file_browser): add "Open with..." action

### DIFF
--- a/ulauncher/gi.py
+++ b/ulauncher/gi.py
@@ -151,6 +151,9 @@ class DesktopAppInfo:
     def get_icon(self) -> Gio.Icon | None:
         return self._app_info.get_icon()
 
+    def launch_uris(self, uris: list[str] | None = None) -> bool:
+        return self._app_info.launch_uris(uris, None)
+
     # Borked unbound methods that we have to call via the class to work consistently
     def get_boolean(self, name: str) -> bool:
         return DesktopAppInfo._raw.get_boolean(self._app_info, name)

--- a/ulauncher/modes/file_browser/file_browser_mode.py
+++ b/ulauncher/modes/file_browser/file_browser_mode.py
@@ -110,8 +110,10 @@ class FileBrowserMode(Mode):
         elif action_id == "open_with_app":
             from ulauncher.modes.file_browser.open_with import open_path_with_app
 
-            open_path_with_app(result.app_id, result.path)
-            callback(effects.close_window())
+            if open_path_with_app(result.app_id, result.path):
+                callback(effects.close_window())
+            else:
+                callback(effects.do_nothing())
         elif action_id == "open":
             callback(effects.open(result.path))
         elif action_id == "open_parent":

--- a/ulauncher/modes/file_browser/file_browser_mode.py
+++ b/ulauncher/modes/file_browser/file_browser_mode.py
@@ -103,6 +103,15 @@ class FileBrowserMode(Mode):
     ) -> None:
         if action_id == "go_to":
             callback(effects.set_query(join(fold_user_path(result.path), "")))
+        elif action_id == "open_with":
+            from ulauncher.modes.file_browser.open_with import get_open_with_results
+
+            callback(get_open_with_results(result.path))
+        elif action_id == "open_with_app":
+            from ulauncher.modes.file_browser.open_with import open_path_with_app
+
+            open_path_with_app(result.app_id, result.path)
+            callback(effects.close_window())
         elif action_id == "open":
             callback(effects.open(result.path))
         elif action_id == "open_parent":

--- a/ulauncher/modes/file_browser/open_with.py
+++ b/ulauncher/modes/file_browser/open_with.py
@@ -49,13 +49,14 @@ def get_open_with_results(path: str) -> list[Result]:
     return results
 
 
-def open_path_with_app(app_id: str, path: str) -> None:
+def open_path_with_app(app_id: str, path: str) -> bool:
     app_info = GioUnix.DesktopAppInfo.new(app_id)
     if not app_info:
         logger.error("Could not load app %s to open %s", app_id, path)
-        return
+        return False
     uri = Gio.File.new_for_path(path).get_uri()
     try:
-        app_info.launch_uris([uri])
+        return app_info.launch_uris([uri])
     except GLib.Error:
         logger.exception("Could not open %s with app %s", uri, app_id)
+        return False

--- a/ulauncher/modes/file_browser/open_with.py
+++ b/ulauncher/modes/file_browser/open_with.py
@@ -1,0 +1,61 @@
+from __future__ import annotations
+
+import logging
+
+from ulauncher.gi import Gio, GioUnix, GLib
+from ulauncher.internals.result import Result
+
+logger = logging.getLogger(__name__)
+
+
+class OpenWithAppResult(Result):
+    compact = True
+    path = ""
+    app_id = ""
+    actions = {"open_with_app": {"name": "Open with this application", "icon": "system-run"}}
+
+
+def _get_content_type(path: str) -> str:
+    gfile = Gio.File.new_for_path(path)
+    try:
+        file_info = gfile.query_info("standard::content-type", Gio.FileQueryInfoFlags.NONE, None)
+        if content_type := file_info.get_content_type():
+            return content_type
+    except GLib.Error:
+        pass
+    content_type, _ = Gio.content_type_guess(path, None)
+    return content_type
+
+
+def get_open_with_results(path: str) -> list[Result]:
+    """Build a result for each application that can open the file at the given path."""
+    results: list[Result] = []
+    for app_info in Gio.AppInfo.get_recommended_for_type(_get_content_type(path)):
+        app_id = app_info.get_id()
+        if not app_id:
+            continue
+        desktop_app = GioUnix.DesktopAppInfo.new(app_id)
+        results.append(
+            OpenWithAppResult(
+                name=app_info.get_display_name(),
+                icon=(desktop_app.get_string("Icon") if desktop_app else None) or "",
+                path=path,
+                app_id=app_id,
+            )
+        )
+    if not results:
+        unsupported_msg = "No application is registered to handle this file type"
+        return [Result(name=unsupported_msg, compact=True, icon="dialog-information")]
+    return results
+
+
+def open_path_with_app(app_id: str, path: str) -> None:
+    app_info = GioUnix.DesktopAppInfo.new(app_id)
+    if not app_info:
+        logger.error("Could not load app %s to open %s", app_id, path)
+        return
+    uri = Gio.File.new_for_path(path).get_uri()
+    try:
+        app_info.launch_uris([uri])
+    except GLib.Error:
+        logger.exception("Could not open %s with app %s", uri, app_id)

--- a/ulauncher/modes/file_browser/results.py
+++ b/ulauncher/modes/file_browser/results.py
@@ -10,12 +10,14 @@ _Actions = Dict[str, Dict[Literal["name", "icon"], str]]
 
 _FILE_ACTIONS: _Actions = {
     "open": {"name": "Open file", "icon": "document-open"},
+    "open_with": {"name": "Open with...", "icon": "system-run"},
     "open_parent": {"name": "Open containing folder", "icon": "folder-open"},
     "copy_path": {"name": "Copy path", "icon": "edit-copy"},
 }
 _FOLDER_ACTIONS: _Actions = {
     "go_to": {"name": "Open", "icon": "folder-open"},
     "open": {"name": "Open in file manager", "icon": "system-file-manager"},
+    "open_with": {"name": "Open with...", "icon": "system-run"},
     "copy_path": {"name": "Copy path", "icon": "edit-copy"},
 }
 


### PR DESCRIPTION
Files and folders now offer an "Open with..." action that lists the applications able to open the path (via Gio.AppInfo.get_recommended_for_type) as a result list, and launches the chosen application with the file.

It is reachable from the action list (alt+enter) and leaves the default enter action unchanged.

For folders the chooser lists the available file managers and directory apps; terminals do not register as directory handlers so they are not included.

<img width="1494" height="502" alt="Screenshot From 2026-06-15 17-23-13" src="https://github.com/user-attachments/assets/74009356-5726-4c6f-b15b-6f6012804a26" />

<img width="1494" height="502" alt="Screenshot From 2026-06-15 17-23-21" src="https://github.com/user-attachments/assets/88f8f49d-c51b-4f15-8fa2-a63f52a4ebac" />

<img width="1494" height="670" alt="Screenshot From 2026-06-15 17-25-23" src="https://github.com/user-attachments/assets/95d469bb-9961-4155-aeaf-6ad8967187de" />


<!--
Thank you for submitting a PR to Ulauncher!

Please read our contribution instructions if you haven't:
https://github.com/Ulauncher/Ulauncher#code-contribution

* Explain the changes in this PR and link to related issue(s) if applicable
* When applicable, please update the documentation according to your changes.
* Ensure that the PR doesn't break existing tests, and please add your own if applicable.

A git action will verify your PR, but you can also test locally with `make check`

-->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add an “Open with…” action to the File Browser so you can choose a specific app to open a file or folder. Available from the action list (Alt+Enter); Enter behavior is unchanged.

- **New Features**
  - Builds a chooser from `Gio.AppInfo.get_recommended_for_type` using the file’s detected content type.
  - Launches the selected app via `GioUnix.DesktopAppInfo.launch_uris` and closes the launcher.
  - For folders, only shows file managers and directory apps; terminals aren’t shown.
  - Shows an info message when no handlers are registered.

<sup>Written for commit 0fad1aa18decd0bcaad3ea806acb411ea2bfe1db. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Ulauncher/Ulauncher/pull/1754?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

