### PR TITLE
feat(apps): add desktop entry actions to app results

### DIFF
--- a/ulauncher/gi.py
+++ b/ulauncher/gi.py
@@ -176,6 +176,15 @@ class DesktopAppInfo:
     def get_nodisplay(self) -> bool:
         return DesktopAppInfo._raw.get_nodisplay(self._app_info)
 
+    def list_actions(self) -> list[str]:
+        return DesktopAppInfo._raw.list_actions(self._app_info)
+
+    def get_action_name(self, action_name: str) -> str:
+        return DesktopAppInfo._raw.get_action_name(self._app_info, action_name)
+
+    def launch_action(self, action_name: str, launch_context: Gio.AppLaunchContext | None = None) -> None:
+        DesktopAppInfo._raw.launch_action(self._app_info, action_name, launch_context)
+
 
 # ─── Deferred setup functions ──────────────────────────────────────────────────
 

--- a/ulauncher/modes/apps/app_mode.py
+++ b/ulauncher/modes/apps/app_mode.py
@@ -9,7 +9,7 @@ from ulauncher.internals import effects
 from ulauncher.internals.query import Query
 from ulauncher.internals.result import Result
 from ulauncher.modes.apps.app_rankings import AppRankings
-from ulauncher.modes.apps.app_result import AppResult
+from ulauncher.modes.apps.app_result import ACTION_PREFIX, AppResult
 from ulauncher.modes.apps.launch_app import launch_app
 from ulauncher.modes.mode import Mode
 from ulauncher.utils.settings import Settings
@@ -56,14 +56,17 @@ class AppMode(Mode):
         _query: Query,
         callback: Callable[[effects.EffectMessage | list[Result]], None],
     ) -> None:
-        if action_id == "launch":
+        if action_id == "launch" or action_id.startswith(ACTION_PREFIX):
             if not isinstance(result, AppResult):
                 logger.error("Expected AppResult but got %s", type(result).__name__)
                 callback(effects.do_nothing())
                 return
             AppRankings.load().bump(result.app_id)
-            if not launch_app(result.app_id):
-                logger.error("Could not launch app %s", result.app_id)
+            if action_id == "launch":
+                if not launch_app(result.app_id):
+                    logger.error("Could not launch app %s", result.app_id)
+            elif not launch_app(result.app_id, action_name=action_id[len(ACTION_PREFIX) :]):
+                logger.error("Could not run action %s of app %s", action_id, result.app_id)
             callback(effects.close_window())
             return
         logger.error("Unexpected action '%s' for App mode result '%s'", action_id, result)

--- a/ulauncher/modes/apps/app_result.py
+++ b/ulauncher/modes/apps/app_result.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import contextlib
 import logging
 from os.path import basename
+from typing import Literal
 
 from ulauncher.gi import GioUnix
 from ulauncher.internals.result import Result
@@ -10,19 +11,25 @@ from ulauncher.modes.apps.app_rankings import AppRankings
 
 logger = logging.getLogger(__name__)
 
+ACTION_PREFIX = "action:"
+
 
 class AppResult(Result):
     searchable = True
     app_id = ""
     _executable = ""
-    actions = {"launch": {"name": "Launch application"}}
 
     def __init__(self, app_info: GioUnix.DesktopAppInfo) -> None:
+        actions: dict[str, dict[Literal["name", "icon"], str]] = {"launch": {"name": "Launch application"}}
+        for action_name in app_info.list_actions():
+            if display_name := app_info.get_action_name(action_name):
+                actions[f"{ACTION_PREFIX}{action_name}"] = {"name": display_name}
         super().__init__(
             name=app_info.get_display_name(),
             icon=app_info.get_string("Icon") or "",
             description=app_info.get_description() or app_info.get_generic_name() or "",
             keywords=app_info.get_keywords(),
+            actions=actions,
             app_id=app_info.get_id(),
             # TryExec is what we actually want (name of/path to exec), but it's often not specified
             # get_executable uses Exec, which is always specified, but it will return the actual executable.

--- a/ulauncher/modes/apps/launch_app.py
+++ b/ulauncher/modes/apps/launch_app.py
@@ -1,11 +1,12 @@
 from __future__ import annotations
 
 import logging
+import os
 import re
 import shlex
 from pathlib import Path
 
-from ulauncher.gi import GioUnix
+from ulauncher.gi import Gio, GioUnix, GLib
 from ulauncher.modes.apps.try_raise_app import try_raise_app
 from ulauncher.utils.launch_detached import launch_detached
 from ulauncher.utils.settings import Settings
@@ -13,46 +14,74 @@ from ulauncher.utils.settings import Settings
 logger = logging.getLogger(__name__)
 
 
-def launch_app(desktop_entry_name: str) -> bool:
-    app_id = Path(desktop_entry_name).stem if desktop_entry_name.endswith(".desktop") else desktop_entry_name
-    settings = Settings.load()
+def _get_action_exec(action_name: str, desktop_entry_path: str | None) -> str | None:
+    if not desktop_entry_path:
+        return None
+    keyfile = GLib.KeyFile()
+    try:
+        keyfile.load_from_file(desktop_entry_path, GLib.KeyFileFlags.NONE)
+        return keyfile.get_string(f"Desktop Action {action_name}", "Exec")
+    except GLib.Error:
+        return None
+
+
+def _get_exec(app: GioUnix.DesktopAppInfo, action_name: str | None = None) -> str | None:
+    """Return the launch command for the app, or one of its actions, with field codes resolved."""
+    desktop_entry_path = app.get_filename()
+    exec_line = _get_action_exec(action_name, desktop_entry_path) if action_name else app.get_commandline()
+    if not exec_line:
+        return None
+    if desktop_entry_path:
+        exec_line = exec_line.replace("%k", desktop_entry_path)
+    # strip field codes %f, %F, %u, %U, etc
+    return re.sub(r"\%[uUfFdDnNickvm]", "", exec_line).strip()
+
+
+def _load_app(desktop_entry_name: str) -> GioUnix.DesktopAppInfo | None:
     app = GioUnix.DesktopAppInfo.new(desktop_entry_name)
-    cmd: list[str] = []
     if not app:
         logger.error("Could not load app %s", desktop_entry_name)
+    return app
+
+
+def launch_app(desktop_entry_name: str, action_name: str | None = None) -> bool:
+    app_id = Path(desktop_entry_name).stem if desktop_entry_name.endswith(".desktop") else desktop_entry_name
+    settings = Settings.load()
+    app = _load_app(desktop_entry_name)
+    if not app:
         return False
 
-    app_exec = app.get_commandline()
+    is_dbus = app.get_boolean("DBusActivatable")
+    is_terminal = app.get_boolean("Terminal")
+    use_custom_terminal = is_terminal and bool(settings.terminal_command)
+    app_exec = _get_exec(app, action_name)
+
+    if action_name is not None and (is_dbus or not app_exec or (is_terminal and not use_custom_terminal)):
+        # for actions where we have no command to spawn, let Gio invoke the action
+        launch_context = Gio.AppLaunchContext()
+        if os.environ.get("GDK_BACKEND") != "wayland":
+            launch_context.unsetenv("GDK_BACKEND")
+        app.launch_action(action_name, launch_context)
+        return True
     if not app_exec:
         logger.error("Could not get Exec for app %s", app_id)
         return False
 
-    if desktop_entry_path := app.get_filename():
-        app_exec = app_exec.replace("%k", desktop_entry_path)
+    if action_name is None and (settings.raise_if_started or app.get_boolean("SingleMainWindow")):
+        app_wm_id = (app.get_string("StartupWMClass") or Path(app_exec).name).lower()
+        if try_raise_app(app_wm_id):
+            return True
 
-    # strip field codes %f, %F, %u, %U, etc
-    app_exec = re.sub(r"\%[uUfFdDnNickvm]", "", app_exec).strip()
-    app_wm_id = (app.get_string("StartupWMClass") or Path(app_exec).name).lower()
-    prefer_raise = settings.raise_if_started or app.get_boolean("SingleMainWindow")
-    if prefer_raise and app_exec and try_raise_app(app_wm_id):
-        return True
-
-    if app.get_boolean("DBusActivatable"):
+    if is_dbus:  # an action with DBus activation already returned above
         # https://wiki.gnome.org/HowDoI/DBusApplicationLaunching
         cmd = ["gapplication", "launch", app_id]
-    elif app_exec:
-        if app.get_boolean("Terminal"):
-            if terminal_exec := settings.terminal_command:
-                logger.info("Will run command in preferred terminal (%s)", terminal_exec)
-                cmd = [*shlex.split(terminal_exec), app_exec]
-            else:
-                cmd = ["gtk-launch", app_id]
-        else:
-            cmd = shlex.split(app_exec)
-
-    if not cmd:
-        logger.error("No command to run %s", app_id)
+    elif use_custom_terminal:
+        cmd = [*shlex.split(settings.terminal_command), app_exec]
+    elif is_terminal:  # a terminal action without a preferred terminal already returned above
+        cmd = ["gtk-launch", app_id]
     else:
-        logger.info("Run application %s (%s) Exec %s", app.get_name(), app_id, cmd)
-        launch_detached(cmd, app.get_string("Path"))
+        cmd = shlex.split(app_exec)
+
+    logger.info("Run %s (%s) Exec %s", f"action {action_name}" if action_name else "application", app_id, cmd)
+    launch_detached(cmd, app.get_string("Path"))
     return True


### PR DESCRIPTION
Apps that define actions in their desktop entry (e.g. Chrome's "New Incognito Window") now expose those actions in the result's action list (alt+enter), alongside the default launch action. Selecting one runs it in a simialr way as launching the app (making sure it works from or outside systemd.

All of these are accessible through pressing alt+enter

Some examples:

<img width="1554" height="484" alt="image" src="https://github.com/user-attachments/assets/1d081c98-0375-40b7-b9a0-a811cfa87772" />

<img width="1554" height="484" alt="image" src="https://github.com/user-attachments/assets/b9db56a7-1516-4514-9b0e-8c9e9e4dec75" />

<img width="1498" height="388" alt="image" src="https://github.com/user-attachments/assets/6fc88fa2-cd89-4171-986d-00e73a44ce56" />

<img width="1498" height="388" alt="image" src="https://github.com/user-attachments/assets/2f2533ff-781f-40bc-be37-e6f994cd4ba9" />

<img width="1498" height="388" alt="image" src="https://github.com/user-attachments/assets/7aceedfe-d832-4b68-9fdd-b7efb329e46c" />

<img width="1498" height="388" alt="image" src="https://github.com/user-attachments/assets/2bdddd30-cfad-479d-856e-b04da4ea0c82" />


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Expose desktop entry actions in app results and let users run them from the action list (Alt+Enter). Actions launch reliably across DBus, terminal, and non-systemd sessions.

- **New Features**
  - Show actions defined in `.desktop` files in the result’s action list with their display names; default action remains “Launch application”.
  - Running an action resolves its `Desktop Action ...` Exec, strips field codes, or uses `Gio.DesktopAppInfo.launch_action` when needed (e.g., `DBusActivatable` or terminal without a custom terminal).

- **Refactors**
  - Centralized launch logic to respect `Terminal=true`, user `terminal_command`, and fallback to `gtk-launch`; use `gapplication launch` for `DBusActivatable` apps.
  - Only attempt to raise existing windows on the default launch, not for specific actions; internal `action:` prefix wires actions through App mode to the launcher.

<sup>Written for commit a1f7844b2f0eb578cc8a74c70ff3acb9af267dd6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Ulauncher/Ulauncher/pull/1755?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

