### PR TITLE
fix(apps): guard against malformed Exec crashing app launch

### DIFF
--- a/ulauncher/modes/apps/launch_app.py
+++ b/ulauncher/modes/apps/launch_app.py
@@ -72,15 +72,19 @@ def launch_app(desktop_entry_name: str, action_name: str | None = None) -> bool:
         if try_raise_app(app_wm_id):
             return True
 
-    if is_dbus:  # an action with DBus activation already returned above
-        # https://wiki.gnome.org/HowDoI/DBusApplicationLaunching
-        cmd = ["gapplication", "launch", app_id]
-    elif use_custom_terminal:
-        cmd = [*shlex.split(settings.terminal_command), app_exec]
-    elif is_terminal:  # a terminal action without a preferred terminal already returned above
-        cmd = ["gtk-launch", app_id]
-    else:
-        cmd = shlex.split(app_exec)
+    try:
+        if is_dbus:  # an action with DBus activation already returned above
+            # https://wiki.gnome.org/HowDoI/DBusApplicationLaunching
+            cmd = ["gapplication", "launch", app_id]
+        elif use_custom_terminal:
+            cmd = [*shlex.split(settings.terminal_command), app_exec]
+        elif is_terminal:  # a terminal action without a preferred terminal already returned above
+            cmd = ["gtk-launch", app_id]
+        else:
+            cmd = shlex.split(app_exec)
+    except ValueError:
+        logger.exception("Could not parse command for app %s: %r", app_id, app_exec)
+        return False
 
     logger.info("Run %s (%s) Exec %s", f"action {action_name}" if action_name else "application", app_id, cmd)
     launch_detached(cmd, app.get_string("Path"))

--- a/ulauncher/modes/apps/launch_app.py
+++ b/ulauncher/modes/apps/launch_app.py
@@ -72,19 +72,20 @@ def launch_app(desktop_entry_name: str, action_name: str | None = None) -> bool:
         if try_raise_app(app_wm_id):
             return True
 
-    try:
-        if is_dbus:  # an action with DBus activation already returned above
-            # https://wiki.gnome.org/HowDoI/DBusApplicationLaunching
-            cmd = ["gapplication", "launch", app_id]
-        elif use_custom_terminal:
-            cmd = [*shlex.split(settings.terminal_command), app_exec]
-        elif is_terminal:  # a terminal action without a preferred terminal already returned above
-            cmd = ["gtk-launch", app_id]
-        else:
-            cmd = shlex.split(app_exec)
-    except ValueError:
-        logger.exception("Could not parse command for app %s: %r", app_id, app_exec)
-        return False
+    if is_dbus:  # an action with DBus activation already returned above
+        # https://wiki.gnome.org/HowDoI/DBusApplicationLaunching
+        cmd = ["gapplication", "launch", app_id]
+    elif is_terminal and not use_custom_terminal:
+        cmd = ["gtk-launch", app_id]
+    else:
+        shell_string = settings.terminal_command if use_custom_terminal else app_exec
+        try:
+            cmd = shlex.split(shell_string)
+            if use_custom_terminal:
+                cmd = [*cmd, app_exec]
+        except ValueError:
+            logger.exception("Could not parse command for app %s: %r", app_id, shell_string)
+            return False
 
     logger.info("Run %s (%s) Exec %s", f"action {action_name}" if action_name else "application", app_id, cmd)
     launch_detached(cmd, app.get_string("Path"))


### PR DESCRIPTION
shlex.split() raises ValueError on malformed shell strings such as unclosed quotes. Both the desktop entry Exec and the user-configurable terminal command feed into it, so an invalid value crashed activation instead of failing gracefully. Catch ValueError and return False.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevent app launch crashes from malformed `Exec` or custom terminal commands by safely splitting shell strings and catching `shlex.split()` errors. On parse failure we log and return False, and we simplify the branch so terminal actions use `gtk-launch` unless a custom terminal is set.

<sup>Written for commit ffcba699cf5d025eda2585360065718fd5e0a63e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Ulauncher/Ulauncher/pull/1756?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

