### PR TITLE
refactor(extension): typed ipc messages

### DIFF
--- a/tests/api/client/test_client.py
+++ b/tests/api/client/test_client.py
@@ -27,8 +27,8 @@ class TestClient:
             return Client(extension)
 
     def test_on_message__trigger_event__is_called(self, client: Client, extension: MagicMock) -> None:
-        client.on_message({"hello": "world"})
-        extension.trigger_event.assert_called_with({"hello": "world"})
+        client.on_message([{"hello": "world"}, 42])
+        extension.trigger_event.assert_called_with({"hello": "world"}, 42)
 
     def test_unload(self, client: Client, extension: MagicMock) -> None:
         client.mainloop = MagicMock()

--- a/tests/modes/extensions/test_extension_mode.py
+++ b/tests/modes/extensions/test_extension_mode.py
@@ -71,7 +71,7 @@ def test_update_preferences__uses_emitted_old_preferences(mocker: MockerFixture)
     )
 
     ext.send_message.assert_called_once_with(
-        {"type": EventType.UPDATE_PREFERENCES, "args": ["city", "Berlin", "Stockholm"]}
+        {"type": EventType.UPDATE_PREFERENCES, "args": ("city", "Berlin", "Stockholm")}
     )
 
 

--- a/ulauncher/api/client/Client.py
+++ b/ulauncher/api/client/Client.py
@@ -56,12 +56,17 @@ class Client:
         self.mainloop.run()
         logger.debug("GLib mainloop stopped")
 
-    def on_message(self, event: dict[str, Any]) -> None:
+    def on_message(self, message: list[Any]) -> None:
         """
         Parses message from Ulauncher and triggers extension event
         """
-        logger.debug("Incoming event: %s", event)
-        self.extension.trigger_event(event)
+        logger.debug("Incoming message: %s", message)
+        try:
+            event, request_id = message
+        except (TypeError, ValueError):
+            logger.warning("Ignoring malformed message: %s", message)
+            return
+        self.extension.trigger_event(event, request_id)
 
     def unload(self) -> None:
         # trigger unload event and release mainloop so that the process will exit after the event is handled

--- a/ulauncher/api/extension.py
+++ b/ulauncher/api/extension.py
@@ -13,7 +13,7 @@ from ulauncher.api.client.Client import Client
 from ulauncher.api.client.EventListener import EventListener
 from ulauncher.api.shared.action.ExtensionCustomAction import custom_data_store
 from ulauncher.api.shared.event import BaseEvent, EventType, KeywordQueryEvent, PreferencesUpdateEvent, events
-from ulauncher.internals import effect_utils, effects
+from ulauncher.internals import effect_utils, effects, ipc
 from ulauncher.internals.result import Result
 from ulauncher.utils import scheduling
 from ulauncher.utils.logging_color_formatter import ColoredFormatter
@@ -193,7 +193,7 @@ class Extension:
                 # Add the result_id to the dict representation so Ulauncher can send it back
                 result["__result_id__"] = result_id
 
-        response = {"effect": effect_msg}
+        response: ipc.Response = {"effect": effect_msg}
         if "keep_app_open" in event:
             # Only used for EventType.LEGACY_ACTIVATE_CUSTOM
             response["keep_app_open"] = event["keep_app_open"]

--- a/ulauncher/api/extension.py
+++ b/ulauncher/api/extension.py
@@ -109,22 +109,22 @@ class Extension:
 
         return None
 
-    def trigger_event(self, event: dict[str, Any]) -> None:
+    def trigger_event(self, event: dict[str, Any], request_id: int | None = None) -> None:
         """Trigger an event. If it's an input trigger it will be debounced"""
         if event.get("type") != EventType.INPUT_TRIGGER:
-            self._do_trigger_event(event)
+            self._do_trigger_event(event, request_id)
             return
 
         def trigger_debounced() -> None:
             self._input_debounce_timer = None
-            self._do_trigger_event(event)
+            self._do_trigger_event(event, request_id)
 
         if self._input_debounce_timer:
             self._input_debounce_timer.cancel()
 
         self._input_debounce_timer = scheduling.timer(self._input_debounce_delay, trigger_debounced)
 
-    def _do_trigger_event(self, event: dict[str, Any]) -> None:
+    def _do_trigger_event(self, event: dict[str, Any], request_id: int | None = None) -> None:
         base_event = self.convert_to_baseevent(event)
         if not base_event:
             self.logger.warning("Dropping unknown event: %s", event)
@@ -141,9 +141,9 @@ class Extension:
         # Ignore deprecated/useless PreferencesEvent event and optional UnloadEvent
         if not listeners and event_type.__name__ not in ["PreferencesEvent", "UnloadEvent"]:
             self.logger.debug("No listener for event %s", event_type.__name__)
-            if "request_id" in event:
-                # Events with request_id need a response to be able to garbage collect their callbacks
-                self._send_response(event, effects.do_nothing(), input_request_id)
+            if request_id is not None:
+                # Requests need a response to be able to garbage collect their callbacks
+                self._send_response(request_id, event, effects.do_nothing(), input_request_id)
             return
 
         for listener, method_name in listeners:
@@ -154,10 +154,13 @@ class Extension:
             # Run in a separate thread to avoid blocking the message listener thread (client.py)
             # It's not possible to cancel threads without process isolation, so we run multiple simultaneous threads,
             # then discard the result for stale events
-            threading.Thread(target=self.run_event_listener, args=(event, method, args, input_request_id)).start()
+            threading.Thread(
+                target=self.run_event_listener, args=(request_id, event, method, args, input_request_id)
+            ).start()
 
     def run_event_listener(
         self,
+        request_id: int | None,
         event: dict[str, Any],
         method: Callable[..., effects.EffectMessageInput | None],
         args: tuple[Any],
@@ -166,13 +169,14 @@ class Extension:
         # For extensions using yield to generate results, the method call will take no time, while
         # the conversion step will actually be the slow part. So we need to check staleness after both.
         input_effect_msg = method(*args)
-        if "request_id" in event:
+        if request_id is not None:
             # Schedule the response on the main thread to avoid races on shared state
             effect_msg = effect_utils.convert_to_effect_message(input_effect_msg)
-            scheduling.run_when_idle(self._send_response, event, effect_msg, input_request_id)
+            scheduling.run_when_idle(self._send_response, request_id, event, effect_msg, input_request_id)
 
     def _send_response(
         self,
+        request_id: int,
         event: dict[str, Any],
         effect_msg: effects.EffectMessage | list[Result],
         input_request_id: int | None,
@@ -189,11 +193,11 @@ class Extension:
                 # Add the result_id to the dict representation so Ulauncher can send it back
                 result["__result_id__"] = result_id
 
-        response = {"effect": effect_msg, "request_id": event["request_id"]}
+        response = {"effect": effect_msg}
         if "keep_app_open" in event:
             # Only used for EventType.LEGACY_ACTIVATE_CUSTOM
             response["keep_app_open"] = event["keep_app_open"]
-        self._client.send("response", response)
+        self._client.send("response", request_id, response)
         return False
 
     def run(self) -> None:

--- a/ulauncher/internals/ipc.py
+++ b/ulauncher/internals/ipc.py
@@ -1,0 +1,77 @@
+"""Typed IPC messages exchanged between Ulauncher and an extension process.
+
+Both processes run the same Ulauncher code (the extension gets it via PYTHONPATH), so these
+types are the single source of truth for the wire format on both ends. They follow the
+discriminated-union style of `ulauncher.internals.effects`: each message is a TypedDict tagged
+by its `type`, and the unions below let the type checker narrow on it.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any, Literal, TypedDict, Union
+
+if TYPE_CHECKING:
+    from typing_extensions import NotRequired
+
+    from ulauncher.internals.effects import EffectMessage
+    from ulauncher.internals.result import Result
+
+
+class InputTriggerEvent(TypedDict):
+    type: Literal["event:input_trigger"]
+    args: list[Any]  # [argument, trigger_id]
+
+
+class LaunchTriggerEvent(TypedDict):
+    type: Literal["event:launch_trigger"]
+    args: list[Any]  # [trigger_id]
+
+
+class ResultActivationEvent(TypedDict):
+    type: Literal["event:result_activation"]
+    args: list[Any]  # [action_id, Result]
+
+
+class LegacyActivateCustomEvent(TypedDict):
+    type: Literal["event:legacy_activate_custom"]
+    ref: int
+    keep_app_open: bool
+
+
+class UpdatePreferencesEvent(TypedDict):
+    type: Literal["event:update_preferences"]
+    args: list[Any]  # [id, new_value, old_value]
+
+
+class LegacyPreferencesLoadEvent(TypedDict):
+    type: Literal["event:legacy_preferences_load"]
+    args: list[Any]  # [preferences]
+
+
+class UnloadEvent(TypedDict):
+    type: Literal["event:unload"]
+
+
+# Events that expect a reply routed back to the caller's callback.
+Request = Union[
+    InputTriggerEvent,
+    LaunchTriggerEvent,
+    ResultActivationEvent,
+    LegacyActivateCustomEvent,
+]
+
+# Fire-and-forget events with no reply.
+Notification = Union[UpdatePreferencesEvent, LegacyPreferencesLoadEvent, UnloadEvent]
+
+Event = Union[Request, Notification]
+
+
+class Response(TypedDict):
+    """A response an extension sends for a Request.
+
+    `keep_app_open` carries the originating action's close behavior back. The request_id that
+    correlates the response to its pending callback travels in the transport envelope, not here.
+    """
+
+    keep_app_open: NotRequired[bool]
+    effect: EffectMessage | list[Result]

--- a/ulauncher/internals/ipc.py
+++ b/ulauncher/internals/ipc.py
@@ -4,6 +4,11 @@ Both processes run the same Ulauncher code (the extension gets it via PYTHONPATH
 types are the single source of truth for the wire format on both ends. They follow the
 discriminated-union style of `ulauncher.internals.effects`: each message is a TypedDict tagged
 by its `type`, and the unions below let the type checker narrow on it.
+
+`args` fields are typed as fixed-length tuples so the type checker can verify their arity and
+the type at each position. They are consumed positionally by the receiver (see
+`api.extension.Extension.convert_to_baseevent`). On the wire they are JSON arrays, so a parsed
+message holds a list there, not a tuple.
 """
 
 from __future__ import annotations
@@ -19,17 +24,17 @@ if TYPE_CHECKING:
 
 class InputTriggerEvent(TypedDict):
     type: Literal["event:input_trigger"]
-    args: list[Any]  # [argument, trigger_id]
+    args: tuple[str | None, str]  # argument, trigger_id
 
 
 class LaunchTriggerEvent(TypedDict):
     type: Literal["event:launch_trigger"]
-    args: list[Any]  # [trigger_id]
+    args: tuple[str]  # trigger_id
 
 
 class ResultActivationEvent(TypedDict):
     type: Literal["event:result_activation"]
-    args: list[Any]  # [action_id, Result]
+    args: tuple[str, Result]  # action_id, result
 
 
 class LegacyActivateCustomEvent(TypedDict):
@@ -40,12 +45,12 @@ class LegacyActivateCustomEvent(TypedDict):
 
 class UpdatePreferencesEvent(TypedDict):
     type: Literal["event:update_preferences"]
-    args: list[Any]  # [id, new_value, old_value]
+    args: tuple[str, Any, Any]  # id, new_value, old_value
 
 
 class LegacyPreferencesLoadEvent(TypedDict):
     type: Literal["event:legacy_preferences_load"]
-    args: list[Any]  # [preferences]
+    args: tuple[dict[str, Any]]  # preferences
 
 
 class UnloadEvent(TypedDict):

--- a/ulauncher/modes/extensions/extension_controller.py
+++ b/ulauncher/modes/extensions/extension_controller.py
@@ -415,9 +415,9 @@ class ExtensionController:
 
             await asyncio.wait_for(stopped_future, timeout=5.0)
 
-    def send_message(self, message: dict[str, Any]) -> None:
+    def send_message(self, message: dict[str, Any], request_id: int | None = None) -> None:
         """
         Sends a JSON message to the extension if it is running.
         """
         if runtime := extension_runtimes.get(self.id):
-            runtime.send_message(message)
+            runtime.send_message(message, request_id)

--- a/ulauncher/modes/extensions/extension_controller.py
+++ b/ulauncher/modes/extensions/extension_controller.py
@@ -15,6 +15,7 @@ from typing import Any, Callable
 from ulauncher import cli, paths
 from ulauncher.data import BaseDataClass, JsonConf
 from ulauncher.gi import GLib
+from ulauncher.internals import ipc
 from ulauncher.modes.extensions import ext_exceptions, extension_finder
 from ulauncher.modes.extensions.extension_dependencies import ExtensionDependencies
 from ulauncher.modes.extensions.extension_manifest import (
@@ -415,7 +416,7 @@ class ExtensionController:
 
             await asyncio.wait_for(stopped_future, timeout=5.0)
 
-    def send_message(self, message: dict[str, Any], request_id: int | None = None) -> None:
+    def send_message(self, message: ipc.Event, request_id: int | None = None) -> None:
         """
         Sends a JSON message to the extension if it is running.
         """

--- a/ulauncher/modes/extensions/extension_mode.py
+++ b/ulauncher/modes/extensions/extension_mode.py
@@ -114,7 +114,7 @@ class ExtensionMode(Mode):
 
         event: ipc.InputTriggerEvent = {
             "type": EventType.INPUT_TRIGGER,
-            "args": [query.argument, trigger_cache_entry[0]],
+            "args": (query.argument, trigger_cache_entry[0]),
         }
         self.send_request(event, callback)
 
@@ -188,14 +188,14 @@ class ExtensionMode(Mode):
             self.active_ext = extension_registry.get(result.ext_id)
             launch_event: ipc.LaunchTriggerEvent = {
                 "type": EventType.LAUNCH_TRIGGER,
-                "args": [result.trigger_id],
+                "args": (result.trigger_id,),
             }
             self.send_request(launch_event, callback)
             return
         else:
             activation_event: ipc.ResultActivationEvent = {
                 "type": EventType.RESULT_ACTIVATION,
-                "args": [action_id, result],
+                "args": (action_id, result),
             }
             self.send_request(activation_event, callback)
             return
@@ -276,7 +276,7 @@ class ExtensionMode(Mode):
                 if pref and new_value != old_value:
                     event_data: ipc.UpdatePreferencesEvent = {
                         "type": EventType.UPDATE_PREFERENCES,
-                        "args": [p_id, new_value, old_value],
+                        "args": (p_id, new_value, old_value),
                     }
                     ext.send_message(event_data)
 

--- a/ulauncher/modes/extensions/extension_mode.py
+++ b/ulauncher/modes/extensions/extension_mode.py
@@ -32,7 +32,6 @@ LOADING_TIMEOUT = 10  # seconds to wait for a transitioning extension before giv
 
 
 class ExtensionResponse(TypedDict):
-    request_id: int
     keep_app_open: NotRequired[bool]
     effect: EffectMessage | list[dict[str, Any]]
 
@@ -282,7 +281,7 @@ class ExtensionMode(Mode):
     def send_request(self, event: dict[str, Any], callback: Callable[[EffectMessage | list[Result]], None]) -> None:
         """
         Send an event to the extension, expecting a response (passed to the callback).
-        The event is enriched with a request_id property, used to filter out stale responses.
+        A request_id is sent alongside the event, used to filter out stale responses.
 
         For one-off messages, use ext.send_message() directly instead.
         """
@@ -296,8 +295,7 @@ class ExtensionMode(Mode):
 
         self._request_id += 1
         self._pending_callback = callback
-        event["request_id"] = self._request_id
-        self.active_ext.send_message(event)
+        self.active_ext.send_message(event, self._request_id)
 
     @events.on
     def handle_message(self, ext_id: str, name: str, *args: Any) -> None:
@@ -306,7 +304,12 @@ class ExtensionMode(Mode):
             logger.warning("Received '%s' message without event payload from %s", name, ext_id)
             return
         if name == "response":
-            self.handle_response(ext_id, args[0])
+            try:
+                request_id, response = args
+            except ValueError:
+                logger.warning("response expects two arguments, got %s from %s", len(args), ext_id)
+            else:
+                self.handle_response(ext_id, request_id, response)
         elif name == "clipboard_store":
             # Extension API: only copies; the launcher stays open and the extension is
             # responsible for any subsequent UI changes.
@@ -330,14 +333,14 @@ class ExtensionMode(Mode):
         else:
             logger.warning("Received unknown message from %s: %s", ext_id, name)
 
-    def handle_response(self, ext_id: str, response: ExtensionResponse) -> None:
+    def handle_response(self, ext_id: str, request_id: int, response: ExtensionResponse) -> None:
         if not self.active_ext:
             logger.error("No active extension to handle response")
             return
         if self.active_ext.id != ext_id:
             logger.debug("Ignoring response from inactive extension %s", ext_id)
             return
-        if not self._pending_callback or response["request_id"] != self._request_id:
+        if not self._pending_callback or request_id != self._request_id:
             logger.debug("Ignoring outdated extension response")
             return
 

--- a/ulauncher/modes/extensions/extension_mode.py
+++ b/ulauncher/modes/extensions/extension_mode.py
@@ -4,11 +4,11 @@ import asyncio
 import html
 import logging
 from threading import Thread
-from typing import TYPE_CHECKING, Any, Callable, Iterator, Literal, TypedDict
+from typing import Any, Callable, Iterator, Literal, cast
 
 from ulauncher.api.shared.event import EventType
-from ulauncher.internals import effect_utils, effects
-from ulauncher.internals.effects import EffectMessage, EffectType
+from ulauncher.internals import effect_utils, effects, ipc
+from ulauncher.internals.effects import EffectMessage, EffectType, LegacyActivateCustom
 from ulauncher.internals.query import Query
 from ulauncher.internals.result import KeywordTrigger, Result
 from ulauncher.modes.extensions import extension_registry
@@ -22,18 +22,10 @@ from ulauncher.utils import scheduling
 from ulauncher.utils.eventbus import EventBus
 from ulauncher.utils.socket_msg_controller import summarize_ipc_args
 
-if TYPE_CHECKING:
-    from typing_extensions import NotRequired
-
 logger = logging.getLogger(__name__)
 events = EventBus("extensions")
 
 LOADING_TIMEOUT = 10  # seconds to wait for a transitioning extension before giving up
-
-
-class ExtensionResponse(TypedDict):
-    keep_app_open: NotRequired[bool]
-    effect: EffectMessage | list[dict[str, Any]]
 
 
 class ExtensionLaunchTrigger(Result):
@@ -120,10 +112,11 @@ class ExtensionMode(Mode):
             self._loading_timer = scheduling.timer(LOADING_TIMEOUT, self._finish_loading)
             return
 
-        self.send_request(
-            {"type": EventType.INPUT_TRIGGER, "args": [query.argument, trigger_cache_entry[0]]},
-            callback,
-        )
+        event: ipc.InputTriggerEvent = {
+            "type": EventType.INPUT_TRIGGER,
+            "args": [query.argument, trigger_cache_entry[0]],
+        }
+        self.send_request(event, callback)
 
     def _iter_enabled_triggers(self) -> Iterator[tuple[ExtensionController, str, ExtensionControllerTrigger]]:
         for ext in extension_registry.iterate():
@@ -193,22 +186,28 @@ class ExtensionMode(Mode):
             effect_msg = result.on_alt_enter
         elif action_id == "__launch__" and isinstance(result, ExtensionLaunchTrigger):
             self.active_ext = extension_registry.get(result.ext_id)
-            self.send_request(
-                {
-                    "type": EventType.LAUNCH_TRIGGER,
-                    "args": [result.trigger_id],
-                },
-                callback,
-            )
+            launch_event: ipc.LaunchTriggerEvent = {
+                "type": EventType.LAUNCH_TRIGGER,
+                "args": [result.trigger_id],
+            }
+            self.send_request(launch_event, callback)
             return
         else:
-            event_type = EventType.RESULT_ACTIVATION
-            event_args = [action_id, result]
-            self.send_request({"type": event_type, "args": event_args}, callback)
+            activation_event: ipc.ResultActivationEvent = {
+                "type": EventType.RESULT_ACTIVATION,
+                "args": [action_id, result],
+            }
+            self.send_request(activation_event, callback)
             return
 
         if isinstance(effect_msg, dict) and effect_msg.get("type") == EffectType.LEGACY_ACTIVATE_CUSTOM:
-            self.send_request({**effect_msg, "type": EventType.LEGACY_ACTIVATE_CUSTOM}, callback)
+            custom = cast("LegacyActivateCustom", effect_msg)
+            custom_event: ipc.LegacyActivateCustomEvent = {
+                "type": EventType.LEGACY_ACTIVATE_CUSTOM,
+                "ref": custom["ref"],
+                "keep_app_open": custom["keep_app_open"],
+            }
+            self.send_request(custom_event, callback)
             return
 
         callback(effect_msg)
@@ -275,10 +274,13 @@ class ExtensionMode(Mode):
                 pref = ext.preferences.get(p_id)
                 old_value = old_preferences.get(p_id, pref.value if pref else None)
                 if pref and new_value != old_value:
-                    event_data = {"type": EventType.UPDATE_PREFERENCES, "args": [p_id, new_value, old_value]}
+                    event_data: ipc.UpdatePreferencesEvent = {
+                        "type": EventType.UPDATE_PREFERENCES,
+                        "args": [p_id, new_value, old_value],
+                    }
                     ext.send_message(event_data)
 
-    def send_request(self, event: dict[str, Any], callback: Callable[[EffectMessage | list[Result]], None]) -> None:
+    def send_request(self, event: ipc.Request, callback: Callable[[EffectMessage | list[Result]], None]) -> None:
         """
         Send an event to the extension, expecting a response (passed to the callback).
         A request_id is sent alongside the event, used to filter out stale responses.
@@ -333,7 +335,7 @@ class ExtensionMode(Mode):
         else:
             logger.warning("Received unknown message from %s: %s", ext_id, name)
 
-    def handle_response(self, ext_id: str, request_id: int, response: ExtensionResponse) -> None:
+    def handle_response(self, ext_id: str, request_id: int, response: ipc.Response) -> None:
         if not self.active_ext:
             logger.error("No active extension to handle response")
             return

--- a/ulauncher/modes/extensions/extension_runtime.py
+++ b/ulauncher/modes/extensions/extension_runtime.py
@@ -112,9 +112,9 @@ class ExtensionRuntime:
     def read_stderr_line(self) -> None:
         self._error_stream.read_line_async(GLib.PRIORITY_DEFAULT, None, self.handle_stderr)
 
-    def send_message(self, message: dict[str, Any]) -> None:
-        self._msg_controller.send(message)
-        logger.debug("Sent message to %s: %s", self._ext_id, message)
+    def send_message(self, message: dict[str, Any], request_id: int | None = None) -> None:
+        self._msg_controller.send([message, request_id])
+        logger.debug("Sent message to %s: %s (request_id=%s)", self._ext_id, message, request_id)
 
     def handle_message(self, arg_list: Any) -> None:
         if not isinstance(arg_list, list):

--- a/ulauncher/modes/extensions/extension_runtime.py
+++ b/ulauncher/modes/extensions/extension_runtime.py
@@ -9,6 +9,7 @@ from typing import Any, Callable, Literal
 from weakref import WeakSet
 
 from ulauncher.gi import Gio, GLib
+from ulauncher.internals import ipc
 from ulauncher.utils import scheduling
 from ulauncher.utils.eventbus import EventBus
 from ulauncher.utils.socket_msg_controller import SocketMsgController
@@ -112,7 +113,7 @@ class ExtensionRuntime:
     def read_stderr_line(self) -> None:
         self._error_stream.read_line_async(GLib.PRIORITY_DEFAULT, None, self.handle_stderr)
 
-    def send_message(self, message: dict[str, Any], request_id: int | None = None) -> None:
+    def send_message(self, message: ipc.Event, request_id: int | None = None) -> None:
         self._msg_controller.send([message, request_id])
         logger.debug("Sent message to %s: %s (request_id=%s)", self._ext_id, message, request_id)
 

--- a/ulauncher/utils/socket_msg_controller.py
+++ b/ulauncher/utils/socket_msg_controller.py
@@ -13,7 +13,7 @@ _MAX_SCALAR_REPR = 120
 
 
 def _summarize_dict(a: dict[str, Any]) -> str:
-    fields = [f"{k}={a[k]!r}" for k in ("type", "request_id", "ext_id") if k in a]
+    fields = [f"{k}={a[k]!r}" for k in ("type", "ext_id") if k in a]
     fields.extend(f"{k}=[{len(v)} items]" for k, v in a.items() if isinstance(v, list))
     return "{" + ", ".join(fields) + "}"
 


### PR DESCRIPTION
Two related refactors to the extension IPC layer. No behavior change to the protocol semantics.

**1. Carry `request_id` in the transport envelope, not the payload** (bac77f66e)

Previously `send_request` mutated the correlation id into the outgoing event dict (`event["request_id"] = ...`) and the extension echoed it back inside the response dict. That tangled the correlation id into the event payload.

It now rides in the wire framing instead:

- App to extension: `[event, request_id]` (`request_id` is `None` for notifications).
- Extension reply: `["response", request_id, payload]`.

`request_id` threads through `trigger_event` / `_do_trigger_event` / `run_event_listener` / `_send_response` on the extension side, and `send_request` / `handle_message` / `handle_response` on the app side. It is never stored inside an event or response dict.

**2. Add typed IPC message definitions (`ulauncher/internals/ipc.py`)** (b6d15fad2 and d060b0278)

Every message exchanged between Ulauncher and an extension process is now a `TypedDict` tagged by its `type`, in the same discriminated-union style as `internals/effects.py`. The messages are split into two unions:

- `Request` - events that expect a reply (input trigger, launch trigger, result activation, legacy activate-custom).
- `Notification` - fire-and-forget events (preference updates, legacy preferences load, unload).

This replaces the loosely-typed `dict[str, Any]` payloads and the old local `ExtensionResponse` TypedDict. `send_request` now accepts only `ipc.Request`, so the type checker enforces that only reply-expecting events go through the request path.

The `args` fields are typed as fixed-length tuples so the checker verifies their arity and the type at each position. Tuples don't exist in JSON, so on the wire they are arrays and a parsed message holds a list there. There is no "typed list" in Python, so a tuple type is the only way to describe a fixed-shape, heterogeneous argument list. The module docstring documents this.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Moved extension IPC to carry `request_id` in the transport envelope and added typed IPC messages in `ulauncher/internals/ipc.py`. No behavior change; cleaner message shapes and type safety.

- **Refactors**
  - `request_id` is no longer in event/response payloads; app→ext sends `[event, request_id]` (`None` for notifications) and ext→app replies `["response", request_id, payload]`.
  - Added `ipc.Event`, `ipc.Request`, `ipc.Notification`, and `ipc.Response` TypedDicts; `args` are fixed-length tuples for arity/type checks; `send_request` now accepts only `ipc.Request`.
  - Updated call sites: `Client.on_message` parses `[event, request_id]` (ignores malformed envelopes); extension forwards `request_id` through listeners and replies via `self._client.send("response", request_id, response)`; `UPDATE_PREFERENCES` uses tuple args; responses are `(request_id, response)`; log summarizer no longer expects `request_id` in dicts.

<sup>Written for commit 59395d5bd6ce37cdd950e6745ed4e95ef0da931f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Ulauncher/Ulauncher/pull/1758?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

