### PR TITLE
refactor(extension): type the extension-to-core IPC messages

### DIFF
--- a/tests/api/client/test_client.py
+++ b/tests/api/client/test_client.py
@@ -27,7 +27,7 @@ class TestClient:
             return Client(extension)
 
     def test_on_message__trigger_event__is_called(self, client: Client, extension: MagicMock) -> None:
-        client.on_message([{"hello": "world"}, 42])
+        client.on_message(({"hello": "world"}, 42))
         extension.trigger_event.assert_called_with({"hello": "world"}, 42)
 
     def test_unload(self, client: Client, extension: MagicMock) -> None:

--- a/ulauncher/api/client/Client.py
+++ b/ulauncher/api/client/Client.py
@@ -2,12 +2,15 @@ from __future__ import annotations  # noqa: N999
 
 import logging
 import os
-from typing import Any
+from typing import TYPE_CHECKING
 
 import ulauncher.api
 from ulauncher.api.shared.event import EventType
 from ulauncher.gi import GLib
 from ulauncher.utils.socket_msg_controller import SocketMsgController, summarize_ipc_args
+
+if TYPE_CHECKING:
+    from ulauncher.internals import ipc
 
 logger = logging.getLogger(__name__)
 
@@ -56,7 +59,7 @@ class Client:
         self.mainloop.run()
         logger.debug("GLib mainloop stopped")
 
-    def on_message(self, message: list[Any]) -> None:
+    def on_message(self, message: ipc.EventEnvelope) -> None:
         """
         Parses message from Ulauncher and triggers extension event
         """
@@ -74,7 +77,7 @@ class Client:
         if self.mainloop.is_running():
             self.mainloop.quit()
 
-    def send(self, name: str, *args: Any) -> None:
-        """Send a message with name and argument(s) to the app"""
-        logger.debug("Send %s message with arguments %s", name, summarize_ipc_args(args))
-        self.msg_controller.send([name, *args])
+    def send(self, message: ipc.ExtensionMessage) -> None:
+        """Send a message to the app"""
+        logger.debug("Send message %s", summarize_ipc_args([message]))
+        self.msg_controller.send(message)

--- a/ulauncher/api/extension.py
+++ b/ulauncher/api/extension.py
@@ -197,7 +197,7 @@ class Extension:
         if "keep_app_open" in event:
             # Only used for EventType.LEGACY_ACTIVATE_CUSTOM
             response["keep_app_open"] = event["keep_app_open"]
-        self._client.send("response", request_id, response)
+        self._client.send({"name": "response", "request_id": request_id, "response": response})
         return False
 
     def run(self) -> None:
@@ -215,7 +215,7 @@ class Extension:
             msg = f'Clipboard text "{text}" is invalid. It must be a string'
             raise TypeError(msg)
 
-        self._client.send("clipboard_store", text)
+        self._client.send({"name": "clipboard_store", "text": text})
 
     def notify(self, body: str = "", notification_id: str | None = None) -> None:
         """
@@ -231,7 +231,7 @@ class Extension:
             msg = f'Notification ID "{notification_id}" is invalid. It must be a string or None'
             raise TypeError(msg)
 
-        self._client.send("notify", body, notification_id)
+        self._client.send({"name": "notify", "body": body, "notification_id": notification_id})
 
     def on_input(self, _query_str: str, _trigger_id: str) -> Iterable[Result]:
         return []

--- a/ulauncher/internals/ipc.py
+++ b/ulauncher/internals/ipc.py
@@ -13,7 +13,7 @@ message holds a list there, not a tuple.
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any, Literal, TypedDict, Union
+from typing import TYPE_CHECKING, Any, Dict, Literal, Optional, Tuple, TypedDict, Union
 
 if TYPE_CHECKING:
     from typing_extensions import NotRequired
@@ -70,6 +70,11 @@ Notification = Union[UpdatePreferencesEvent, LegacyPreferencesLoadEvent, UnloadE
 
 Event = Union[Request, Notification]
 
+# Transport envelope wrapping an event Ulauncher sends to an extension, paired with the request_id
+# correlating its response (None for notifications, which expect no reply). Typed as a tuple for
+# fixed arity; on the wire it is a JSON array, so a parsed message holds a list here.
+EventEnvelope = Tuple[Dict[str, Any], Optional[int]]
+
 
 class Response(TypedDict):
     """A response an extension sends for a Request.
@@ -80,3 +85,24 @@ class Response(TypedDict):
 
     keep_app_open: NotRequired[bool]
     effect: EffectMessage | list[Result]
+
+
+class ResponseMessage(TypedDict):
+    name: Literal["response"]
+    request_id: int
+    response: Response
+
+
+class ClipboardStoreMessage(TypedDict):
+    name: Literal["clipboard_store"]
+    text: str
+
+
+class NotifyMessage(TypedDict):
+    name: Literal["notify"]
+    body: str
+    notification_id: str | None
+
+
+# Messages an extension sends to Ulauncher, tagged by `name` so the receiver narrows on it.
+ExtensionMessage = Union[ResponseMessage, ClipboardStoreMessage, NotifyMessage]

--- a/ulauncher/modes/extensions/extension_mode.py
+++ b/ulauncher/modes/extensions/extension_mode.py
@@ -303,12 +303,21 @@ class ExtensionMode(Mode):
     def handle_message(self, ext_id: str, message: ipc.ExtensionMessage) -> None:
         logger.debug("Incoming message %s from %r", summarize_ipc_args([message]), ext_id)
         if message["name"] == "response":
+            if "request_id" not in message or "response" not in message:
+                logger.warning("Received malformed 'response' message from %s: %s", ext_id, message)
+                return
             self.handle_response(ext_id, message["request_id"], message["response"])
         elif message["name"] == "clipboard_store":
+            if "text" not in message:
+                logger.warning("Received malformed 'clipboard_store' message from %s: %s", ext_id, message)
+                return
             # Extension API: only copies; the launcher stays open and the extension is
             # responsible for any subsequent UI changes.
             events.emit("app:clipboard_store", message["text"])
         elif message["name"] == "notify":
+            if "body" not in message or "notification_id" not in message:
+                logger.warning("Received malformed 'notify' message from %s: %s", ext_id, message)
+                return
             ext = extension_registry.get(ext_id)
             if not ext:
                 logger.warning("Notification sent from an extension, '%s', which was not found", ext_id)

--- a/ulauncher/modes/extensions/extension_mode.py
+++ b/ulauncher/modes/extensions/extension_mode.py
@@ -303,7 +303,12 @@ class ExtensionMode(Mode):
     def handle_message(self, ext_id: str, message: ipc.ExtensionMessage) -> None:
         logger.debug("Incoming message %s from %r", summarize_ipc_args([message]), ext_id)
         if message["name"] == "response":
-            if "request_id" not in message or "response" not in message:
+            if (
+                "request_id" not in message
+                or "response" not in message
+                or not isinstance(message["response"], dict)
+                or "effect" not in message["response"]
+            ):
                 logger.warning("Received malformed 'response' message from %s: %s", ext_id, message)
                 return
             self.handle_response(ext_id, message["request_id"], message["response"])

--- a/ulauncher/modes/extensions/extension_mode.py
+++ b/ulauncher/modes/extensions/extension_mode.py
@@ -300,40 +300,27 @@ class ExtensionMode(Mode):
         self.active_ext.send_message(event, self._request_id)
 
     @events.on
-    def handle_message(self, ext_id: str, name: str, *args: Any) -> None:
-        logger.debug("Incoming %s message with arguments %s from %r", name, summarize_ipc_args(args), ext_id)
-        if not args:
-            logger.warning("Received '%s' message without event payload from %s", name, ext_id)
-            return
-        if name == "response":
-            try:
-                request_id, response = args
-            except ValueError:
-                logger.warning("response expects two arguments, got %s from %s", len(args), ext_id)
-            else:
-                self.handle_response(ext_id, request_id, response)
-        elif name == "clipboard_store":
+    def handle_message(self, ext_id: str, message: ipc.ExtensionMessage) -> None:
+        logger.debug("Incoming message %s from %r", summarize_ipc_args([message]), ext_id)
+        if message["name"] == "response":
+            self.handle_response(ext_id, message["request_id"], message["response"])
+        elif message["name"] == "clipboard_store":
             # Extension API: only copies; the launcher stays open and the extension is
             # responsible for any subsequent UI changes.
-            events.emit("app:clipboard_store", args[0])
-        elif name == "notify":
+            events.emit("app:clipboard_store", message["text"])
+        elif message["name"] == "notify":
             ext = extension_registry.get(ext_id)
             if not ext:
                 logger.warning("Notification sent from an extension, '%s', which was not found", ext_id)
                 return
-            try:
-                body, notification_id = args
-            except ValueError:
-                logger.warning("notify expects two arguments, got %s from %s", len(args), ext_id)
-            else:
-                events.emit(
-                    "app:show_notification",
-                    f"ext-{ext.id}-{notification_id}",
-                    f"Message from {ext.manifest.name} extension",
-                    body,
-                )
+            events.emit(
+                "app:show_notification",
+                f"ext-{ext.id}-{message['notification_id']}",
+                f"Message from {ext.manifest.name} extension",
+                message["body"],
+            )
         else:
-            logger.warning("Received unknown message from %s: %s", ext_id, name)
+            logger.warning("Received unknown message from %s: %s", ext_id, message)
 
     def handle_response(self, ext_id: str, request_id: int, response: ipc.Response) -> None:
         if not self.active_ext:

--- a/ulauncher/modes/extensions/extension_runtime.py
+++ b/ulauncher/modes/extensions/extension_runtime.py
@@ -117,14 +117,11 @@ class ExtensionRuntime:
         self._msg_controller.send([message, request_id])
         logger.debug("Sent message to %s: %s (request_id=%s)", self._ext_id, message, request_id)
 
-    def handle_message(self, arg_list: Any) -> None:
-        if not isinstance(arg_list, list):
-            logger.warning("Extension %s sent invalid message format: %s", self._ext_id, arg_list)
+    def handle_message(self, message: Any) -> None:
+        if not isinstance(message, dict) or "name" not in message:
+            logger.warning("Extension %s sent invalid message format: %s", self._ext_id, message)
             return
-        if not arg_list:
-            logger.warning("Extension %s sent empty message", self._ext_id)
-            return
-        events.emit("extensions:handle_message", self._ext_id, *arg_list)
+        events.emit("extensions:handle_message", self._ext_id, message)
 
     def handle_stderr(self, error_stream: Gio.DataInputStream, result: Gio.AsyncResult) -> None:
         try:

--- a/ulauncher/utils/socket_msg_controller.py
+++ b/ulauncher/utils/socket_msg_controller.py
@@ -13,7 +13,7 @@ _MAX_SCALAR_REPR = 120
 
 
 def _summarize_dict(a: dict[str, Any]) -> str:
-    fields = [f"{k}={a[k]!r}" for k in ("type", "ext_id") if k in a]
+    fields = [f"{k}={a[k]!r}" for k in ("type", "name", "ext_id") if k in a]
     fields.extend(f"{k}=[{len(v)} items]" for k, v in a.items() if isinstance(v, list))
     return "{" + ", ".join(fields) + "}"
 


### PR DESCRIPTION
Replace the positional [name, *args] wire format for messages an extension sends to Ulauncher with a single discriminated-union dict tagged by `name` (ipc.ExtensionMessage). Branching on message["name"] narrows to the matching member, so ExtensionMode.handle_message reads each field with a concrete type instead of unpacking *args: Any.

Also name the inbound event transport envelope (ipc.EventEnvelope) and type the Client and runtime boundaries with these types. The eventbus and JSON wire stay Any, so this documents and locally type-checks the contract rather than enforcing it across the socket; the runtime guard in ExtensionRuntime.handle_message is kept for malformed extension messages.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Type the extension-to-core IPC by replacing positional arrays with a discriminated-union message dict and adding a typed event envelope. This makes message handling safer, clearer, and easier to extend.

- **Refactors**
  - Replace `[name, *args]` with `ipc.ExtensionMessage` (dict tagged by `name`).
  - Introduce `ipc.EventEnvelope = (event, request_id)` for incoming events; `Client.on_message` uses it.
  - `Client.send` now sends a message dict; update `Extension.notify`, `clipboard_store`, and response sending.
  - `extension_mode.handle_message` takes a single message, validates required fields, and emits events.
  - Keep runtime guard in `extension_runtime.handle_message` (expects a dict with `name`); forwards the message object.
  - Logging summarizer now includes `name`.

- **Migration**
  - No changes for extensions using the public `Extension` API.
  - If calling `Client.send` directly, pass a message dict (e.g., `{"name": "notify", ...}`) instead of `[name, *args]`.

<sup>Written for commit e46ed784dbcbcacc639798f602dd1669e146bd70. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Ulauncher/Ulauncher/pull/1759?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

