### PR TITLE
refactor(effects): RenderResults effect

### DIFF
--- a/tests/internals/test_effect_utils.py
+++ b/tests/internals/test_effect_utils.py
@@ -8,7 +8,7 @@ class TestShouldClose:
 
     def test_result_list_keeps_window_open(self) -> None:
         """Result list should should keep the window open."""
-        assert not effect_utils.should_close([])
+        assert not effect_utils.should_close(effects.render_results([]))
 
     def test_set_query_keeps_window_open(self) -> None:
         """SET_QUERY effect should keep the window open."""

--- a/tests/modes/calc/test_calc_mode.py
+++ b/tests/modes/calc/test_calc_mode.py
@@ -16,7 +16,12 @@ from ulauncher.modes.calc.calc_result import CalcErrorResult
 def get_results(mode: CalcMode, query: Query) -> list[Result]:
     """Helper to collect results from callback-based handle_query."""
     results: list[Result] = []
-    mode.handle_query(query, lambda msg: results.extend(msg) if isinstance(msg, list) else None)
+
+    def collect(msg: object) -> None:
+        if isinstance(msg, dict) and msg["type"] == EffectType.RENDER_RESULTS:
+            results.extend(msg["results"])
+
+    mode.handle_query(query, collect)
     return results
 
 

--- a/tests/modes/extensions/test_extension_mode.py
+++ b/tests/modes/extensions/test_extension_mode.py
@@ -7,6 +7,7 @@ from unittest.mock import MagicMock, PropertyMock
 from pytest_mock import MockerFixture
 
 from ulauncher.api.shared.event import EventType
+from ulauncher.internals import effects
 from ulauncher.internals.query import Query
 from ulauncher.internals.result import Result
 from ulauncher.modes.extensions import extension_registry
@@ -105,7 +106,7 @@ def test_handle_query__loading_timeout_shows_empty(mocker: MockerFixture) -> Non
     mode.handle_query(Query("kw", "arg"), callback)
     timer.call_args.args[1]()  # fire the captured loading-timeout callback
 
-    callback.assert_called_once_with([])
+    callback.assert_called_once_with(effects.render_results([]))
     assert mode._loading_timer is None
 
 
@@ -118,8 +119,8 @@ def test_handle_query__unknown_keyword_shows_message(mocker: MockerFixture) -> N
     mode.handle_query(Query("kw", "arg"), callback)
 
     callback.assert_called_once()
-    (results,) = callback.call_args.args
-    assert [r.name for r in results] == ["Extension not available"]
+    (effect,) = callback.call_args.args
+    assert [r.name for r in effect["results"]] == ["Extension not available"]
 
 
 def test_errored__while_loading_shows_failure(mocker: MockerFixture) -> None:
@@ -134,7 +135,7 @@ def test_errored__while_loading_shows_failure(mocker: MockerFixture) -> None:
 
     mode.errored("test.ext")
 
-    callback.assert_called_once_with([failure])
+    callback.assert_called_once_with(effects.render_results([failure]))
     timer.cancel.assert_called_once()
     assert mode._loading_timer is None
 

--- a/tests/modes/file_browser/test_file_browser_mode.py
+++ b/tests/modes/file_browser/test_file_browser_mode.py
@@ -6,6 +6,7 @@ from unittest.mock import MagicMock
 import pytest
 from pytest_mock import MockerFixture
 
+from ulauncher.internals.effects import EffectType
 from ulauncher.internals.query import Query
 from ulauncher.internals.result import Result
 from ulauncher.modes.file_browser.file_browser_mode import FileBrowserMode
@@ -14,7 +15,12 @@ from ulauncher.modes.file_browser.file_browser_mode import FileBrowserMode
 def get_results(mode: FileBrowserMode, query: Query) -> list[Result]:
     """Helper to collect results from callback-based handle_query."""
     results: list[Result] = []
-    mode.handle_query(query, lambda msg: results.extend(msg) if isinstance(msg, list) else None)
+
+    def collect(msg: object) -> None:
+        if isinstance(msg, dict) and msg["type"] == EffectType.RENDER_RESULTS:
+            results.extend(msg["results"])
+
+    mode.handle_query(query, collect)
     return results
 
 

--- a/tests/modes/shortcuts/test_shortcut_mode.py
+++ b/tests/modes/shortcuts/test_shortcut_mode.py
@@ -6,6 +6,7 @@ from unittest.mock import MagicMock
 import pytest
 from pytest_mock import MockerFixture
 
+from ulauncher.internals.effects import EffectType
 from ulauncher.internals.query import Query
 from ulauncher.internals.result import Result
 from ulauncher.modes.shortcuts.results import ShortcutResult, ShortcutStaticTrigger
@@ -16,7 +17,12 @@ from ulauncher.modes.shortcuts.shortcuts import Shortcut
 def get_results(mode: ShortcutMode, query: Query) -> list[Result]:
     """Helper to collect results from callback-based handle_query."""
     results: list[Result] = []
-    mode.handle_query(query, lambda msg: results.extend(msg) if isinstance(msg, list) else None)
+
+    def collect(msg: object) -> None:
+        if isinstance(msg, dict) and msg["type"] == EffectType.RENDER_RESULTS:
+            results.extend(msg["results"])
+
+    mode.handle_query(query, collect)
     return results
 
 

--- a/ulauncher/api/extension.py
+++ b/ulauncher/api/extension.py
@@ -7,7 +7,7 @@ import os
 import signal
 import threading
 from collections import defaultdict
-from typing import Any, Callable, Iterable
+from typing import Any, Callable, Iterable, cast
 
 from ulauncher.api.client.Client import Client
 from ulauncher.api.client.EventListener import EventListener
@@ -97,7 +97,7 @@ class Extension:
         elif event_type == EventType.RESULT_ACTIVATION:
             # Restore actual Result instance from cache using the result_id
             action_id, result_id = args
-            if result_id and (result := self._result_cache.get(result_id)):
+            if (result := self._result_cache.get(result_id)) is not None:
                 args = [action_id, result]
             else:
                 err_msg = f"Result with id {result_id} not found"
@@ -177,20 +177,16 @@ class Extension:
         self,
         request_id: int,
         event: dict[str, Any],
-        effect_msg: effects.EffectMessage | list[Result],
+        effect_msg: effects.EffectMessage,
         input_request_id: int | None,
     ) -> bool:
         if input_request_id is not None and input_request_id != self._input_request_id:
             return False
 
-        # Cache Result objects before sending them, keyed by their Python object ID
-        if isinstance(effect_msg, list):
-            self._result_cache.clear()
-            for result in effect_msg:
-                result_id = id(result)
-                self._result_cache[result_id] = result
-                # Add the result_id to the dict representation so Ulauncher can send it back
-                result["__result_id__"] = result_id
+        # Cache the rendered results by list index so an activation can map its result_id back to the
+        # actual Result instance, without mutating the result objects the extension handed us.
+        if effect_msg["type"] == effects.EffectType.RENDER_RESULTS:
+            self._result_cache = dict(enumerate(cast("effects.RenderResults", effect_msg)["results"]))
 
         response: ipc.Response = {"effect": effect_msg}
         if "keep_app_open" in event:

--- a/ulauncher/api/shared/action/ActionList.py
+++ b/ulauncher/api/shared/action/ActionList.py
@@ -1,14 +1,9 @@
 from __future__ import annotations  # noqa: N999
 
-from typing import TYPE_CHECKING
-
 from ulauncher.internals import effects
 
-if TYPE_CHECKING:
-    from ulauncher.internals.result import Result
 
-
-def ActionList(effect_list: list[effects.EffectMessage | list[Result]]) -> effects.LegacyRunMany:  # noqa: N802
+def ActionList(effect_list: list[effects.EffectMessage]) -> effects.LegacyRunMany:  # noqa: N802
     """
     ActionList is deprecated but maintained for backward compatibility.
 

--- a/ulauncher/api/shared/action/RenderResultListAction.py
+++ b/ulauncher/api/shared/action/RenderResultListAction.py
@@ -1,9 +1,3 @@
-from __future__ import annotations  # noqa: N999
+from ulauncher.internals.effects import render_results as RenderResultListAction  # noqa: N812, N999
 
-from ulauncher.internals.result import Result
-
-# @todo: Add deprecation warning
-
-
-def RenderResultListAction(results: list[Result]) -> list[Result]:  # noqa: N802
-    return results
+__all__ = ["RenderResultListAction"]

--- a/ulauncher/api/shared/action/__init__.py
+++ b/ulauncher/api/shared/action/__init__.py
@@ -1,0 +1,1 @@
+# @todo: Add deprecation warnings for all actions

--- a/ulauncher/core.py
+++ b/ulauncher/core.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import itertools
 import logging
 from collections import defaultdict
-from typing import Callable, Iterable
+from typing import Callable, Iterable, cast
 from weakref import WeakKeyDictionary
 
 from ulauncher.internals import effect_utils, effects
@@ -212,7 +212,7 @@ class UlauncherCore:
 
     def _mode_callback(
         self, valid_mode: Mode | None, callback: Callable[[Iterable[Result]], None]
-    ) -> Callable[[effects.EffectMessage | list[Result]], None]:
+    ) -> Callable[[effects.EffectMessage], None]:
         """
         Callback to handle results and effects from modes.
 
@@ -220,14 +220,14 @@ class UlauncherCore:
         callback: The callback function to handle results and effects.
         """
 
-        def _callback(effect_msg: effects.EffectMessage | list[Result]) -> None:
+        def _callback(effect_msg: effects.EffectMessage) -> None:
             if valid_mode not in (self._mode, None):
                 return
 
-            if isinstance(effect_msg, dict):
+            if effect_msg.get("type") == effects.EffectType.RENDER_RESULTS:
+                self._show_results(cast("effects.RenderResults", effect_msg)["results"], callback)
+            else:
                 effect_utils.handle(effect_msg)
-            elif isinstance(effect_msg, list):
-                self._show_results(effect_msg, callback)
 
         return _callback
 

--- a/ulauncher/internals/effect_utils.py
+++ b/ulauncher/internals/effect_utils.py
@@ -61,8 +61,11 @@ def handle(effect_msg: EffectMessage, prevent_close: bool = False) -> None:
         _events.emit("app:show_results", effect_msg.get("results"))
 
     elif event_type == EffectType.LEGACY_RUN_MANY and isinstance(data, list):
-        for effect in cast("list[EffectMessage]", data):
-            handle(effect, True)
+        for effect in data:
+            if isinstance(effect, dict):
+                handle(cast("EffectMessage", effect), True)
+            else:
+                _logger.warning("Invalid nested effect in LEGACY_RUN_MANY: %s", effect)
 
     elif not has_valid_type:
         _logger.warning("Unknown effect type: %s", event_type)

--- a/ulauncher/internals/effect_utils.py
+++ b/ulauncher/internals/effect_utils.py
@@ -28,12 +28,11 @@ def is_valid(effect_msg: Any) -> bool:
 
 def should_close(effect_msg: EffectMessage) -> bool:
     """Whether or not the effect should close the window."""
-    if isinstance(effect_msg, dict):
-        if effect_msg.get("type") in (EffectType.DO_NOTHING, EffectType.SET_QUERY, EffectType.RENDER_RESULTS):
-            return False
-        if effect_msg.get("type") == EffectType.LEGACY_RUN_MANY:
-            effect_list = cast("list[EffectMessage]", effect_msg.get("data", []))
-            return all(map(should_close, effect_list))
+    if effect_msg.get("type") in (EffectType.DO_NOTHING, EffectType.SET_QUERY, EffectType.RENDER_RESULTS):
+        return False
+    if effect_msg.get("type") == EffectType.LEGACY_RUN_MANY:
+        effect_list = cast("list[EffectMessage]", effect_msg.get("data", []))
+        return all(map(should_close, effect_list))
     return True
 
 

--- a/ulauncher/internals/effect_utils.py
+++ b/ulauncher/internals/effect_utils.py
@@ -61,11 +61,8 @@ def handle(effect_msg: EffectMessage, prevent_close: bool = False) -> None:
         _events.emit("app:show_results", effect_msg.get("results"))
 
     elif event_type == EffectType.LEGACY_RUN_MANY and isinstance(data, list):
-        for effect in data:
-            if isinstance(effect, dict):
-                handle(cast("EffectMessage", effect), True)
-            else:
-                _logger.warning("Invalid nested effect in LEGACY_RUN_MANY: %s", effect)
+        for effect in cast("list[EffectMessage]", data):
+            handle(effect, True)
 
     elif not has_valid_type:
         _logger.warning("Unknown effect type: %s", event_type)

--- a/ulauncher/internals/effect_utils.py
+++ b/ulauncher/internals/effect_utils.py
@@ -9,6 +9,7 @@ from ulauncher.internals.effects import (
     EffectType,
     close_window,
     do_nothing,
+    render_results,
     set_query,
 )
 from ulauncher.utils.eventbus import EventBus
@@ -25,15 +26,13 @@ def is_valid(effect_msg: Any) -> bool:
     return isinstance(effect_msg, dict) and effect_msg.get("type") in _VALID_EFFECT_TYPES
 
 
-def should_close(effect_msg: EffectMessage | list[Result]) -> bool:
+def should_close(effect_msg: EffectMessage) -> bool:
     """Whether or not the effect should close the window."""
-    if isinstance(effect_msg, list):
-        return False
     if isinstance(effect_msg, dict):
-        if effect_msg.get("type") in (EffectType.DO_NOTHING, EffectType.SET_QUERY):
+        if effect_msg.get("type") in (EffectType.DO_NOTHING, EffectType.SET_QUERY, EffectType.RENDER_RESULTS):
             return False
         if effect_msg.get("type") == EffectType.LEGACY_RUN_MANY:
-            effect_list = cast("list[EffectMessage | list[Result]]", effect_msg.get("data", []))
+            effect_list = cast("list[EffectMessage]", effect_msg.get("data", []))
             return all(map(should_close, effect_list))
     return True
 
@@ -59,12 +58,12 @@ def handle(effect_msg: EffectMessage, prevent_close: bool = False) -> None:
         from ulauncher.modes.shortcuts.run_script import run_script
 
         run_script(*data)
+    elif event_type == EffectType.RENDER_RESULTS and isinstance(effect_msg.get("results"), list):
+        _events.emit("app:show_results", effect_msg.get("results"))
+
     elif event_type == EffectType.LEGACY_RUN_MANY and isinstance(data, list):
-        for effect in cast("list[EffectMessage | list[Result]]", data):
-            if isinstance(effect, list):
-                _events.emit("app:show_results", effect)
-            else:
-                handle(effect, True)
+        for effect in cast("list[EffectMessage]", data):
+            handle(effect, True)
 
     elif not has_valid_type:
         _logger.warning("Unknown effect type: %s", event_type)
@@ -75,7 +74,7 @@ def handle(effect_msg: EffectMessage, prevent_close: bool = False) -> None:
         _events.emit("app:close_launcher")
 
 
-def convert_to_effect_message(input_data: EffectMessageInput | None) -> EffectMessage | list[Result]:
+def convert_to_effect_message(input_data: EffectMessageInput | None) -> EffectMessage:
     """Normalize input format that supports boolean and string to represent effects and iterable lists for results"""
     if isinstance(input_data, bool) or input_data is None:
         return do_nothing() if input_data else close_window()
@@ -86,4 +85,4 @@ def convert_to_effect_message(input_data: EffectMessageInput | None) -> EffectMe
             return cast("EffectMessage", input_data)  # TypedDict unions can't be narrowed by runtime checks
         err_msg = f"Invalid effect message dict: {input_data}"
         raise ValueError(err_msg)
-    return list(cast("Iterable[Result]", input_data))  # collect/flatten iterators to lists
+    return render_results(list(cast("Iterable[Result]", input_data)))  # collect/flatten iterators to lists

--- a/ulauncher/internals/effects.py
+++ b/ulauncher/internals/effects.py
@@ -11,6 +11,7 @@ class EffectType:
     DO_NOTHING: Final = "effect:do_nothing"
     CLOSE_WINDOW: Final = "effect:close_window"
     SET_QUERY: Final = "effect:set_query"
+    RENDER_RESULTS: Final = "effect:render_results"
     OPEN: Final = "effect:open"
     LEGACY_COPY: Final = "effect:legacy_copy"
     LEGACY_RUN_SCRIPT: Final = "effect:legacy_run_script"
@@ -29,6 +30,11 @@ class CloseWindow(TypedDict):
 class SetQuery(TypedDict):
     type: Literal["effect:set_query"]
     data: str
+
+
+class RenderResults(TypedDict):
+    type: Literal["effect:render_results"]
+    results: list[Result]
 
 
 class Open(TypedDict):
@@ -61,6 +67,7 @@ EffectMessage = Union[
     DoNothing,
     CloseWindow,
     SetQuery,
+    RenderResults,
     Open,
     LegacyCopy,
     LegacyRunScript,
@@ -85,6 +92,10 @@ def set_query(query: str) -> SetQuery:
         msg = f'Query argument "{query}" is invalid. It must be a string'
         raise TypeError(msg)
     return {"type": EffectType.SET_QUERY, "data": query}
+
+
+def render_results(results: list[Result]) -> RenderResults:
+    return {"type": EffectType.RENDER_RESULTS, "results": results}
 
 
 def open(item: str) -> Open:  # noqa: A001

--- a/ulauncher/internals/ipc.py
+++ b/ulauncher/internals/ipc.py
@@ -19,7 +19,6 @@ if TYPE_CHECKING:
     from typing_extensions import NotRequired
 
     from ulauncher.internals.effects import EffectMessage
-    from ulauncher.internals.result import Result
 
 
 class InputTriggerEvent(TypedDict):
@@ -84,7 +83,7 @@ class Response(TypedDict):
     """
 
     keep_app_open: NotRequired[bool]
-    effect: EffectMessage | list[Result]
+    effect: EffectMessage
 
 
 class ResponseMessage(TypedDict):

--- a/ulauncher/internals/result.py
+++ b/ulauncher/internals/result.py
@@ -32,8 +32,8 @@ class Result(BaseDataClass):
         ""  #: An icon path relative to the extension root. If not set, the default icon of the extension will be used
     )
     actions: dict[str, dict[Literal["name", "icon"], str]] = {}  #: dict of actions with display names and icons
-    on_enter: effects.EffectMessage | list[Result] | None = None
-    on_alt_enter: effects.EffectMessage | list[Result] | None = None
+    on_enter: effects.EffectMessage | None = None
+    on_alt_enter: effects.EffectMessage | None = None
 
     def __init__(  # noqa: PLR0913
         self,

--- a/ulauncher/modes/apps/app_mode.py
+++ b/ulauncher/modes/apps/app_mode.py
@@ -18,9 +18,9 @@ logger = logging.getLogger(__name__)
 
 
 class AppMode(Mode):
-    def handle_query(self, _query: Query, callback: Callable[[effects.EffectMessage | list[Result]], None]) -> None:
+    def handle_query(self, _query: Query, callback: Callable[[effects.EffectMessage], None]) -> None:
         # App mode contributes search triggers but does not handle direct query-mode execution.
-        callback([])
+        callback(effects.render_results([]))
 
     def get_triggers(self) -> Iterator[AppResult]:
         settings = Settings.load()
@@ -54,7 +54,7 @@ class AppMode(Mode):
         action_id: str,
         result: Result,
         _query: Query,
-        callback: Callable[[effects.EffectMessage | list[Result]], None],
+        callback: Callable[[effects.EffectMessage], None],
     ) -> None:
         if action_id == "launch" or action_id.startswith(ACTION_PREFIX):
             if not isinstance(result, AppResult):

--- a/ulauncher/modes/calc/calc_mode.py
+++ b/ulauncher/modes/calc/calc_mode.py
@@ -165,7 +165,7 @@ class CalcMode(Mode):
     def matches_query_str(self, query_str: str) -> bool:
         return _is_enabled(normalize_expr(query_str))
 
-    def handle_query(self, query: Query, callback: Callable[[effects.EffectMessage | list[Result]], None]) -> None:
+    def handle_query(self, query: Query, callback: Callable[[effects.EffectMessage], None]) -> None:
         try:
             calc_result = str(eval_expr(query.argument or ""))
             result: Result = CalcResult(
@@ -177,14 +177,14 @@ class CalcMode(Mode):
             logger.warning("Calc mode error triggered while handling query: '%s'", query.argument)
             result = CalcErrorResult()
 
-        callback([result])
+        callback(effects.render_results([result]))
 
     def activate_result(
         self,
         action_id: str,
         result: Result,
         _query: Query,
-        callback: Callable[[effects.EffectMessage | list[Result]], None],
+        callback: Callable[[effects.EffectMessage], None],
     ) -> None:
         if action_id == "copy":
             if not isinstance(result, CalcResult):

--- a/ulauncher/modes/extensions/extension_mode.py
+++ b/ulauncher/modes/extensions/extension_mode.py
@@ -358,7 +358,11 @@ class ExtensionMode(Mode):
                 if not isinstance(result_dict, dict):
                     logger.warning("Skipping malformed result from extension %s at index %s", ext_id, result_id)
                     continue
-                result = Result(**result_dict)
+                try:
+                    result = Result(**result_dict)
+                except (KeyError, TypeError, ValueError) as e:
+                    logger.warning("Skipping malformed result from extension %s at index %s: %s", ext_id, result_id, e)
+                    continue
                 result.icon = self.active_ext.get_icon_value(result_dict.get("icon"))
                 # The extension keys its result cache by list index, so carry that index back as the
                 # result_id when the result is activated (see api.extension.Extension).

--- a/ulauncher/modes/extensions/extension_mode.py
+++ b/ulauncher/modes/extensions/extension_mode.py
@@ -40,7 +40,7 @@ class ExtensionMode(Mode):
 
     _active_ext: ExtensionController | None = None
     _trigger_cache: dict[str, tuple[str, str]]  # keyword: (trigger_id, ext_id)
-    _pending_callback: Callable[[EffectMessage | list[Result]], None] | None = None
+    _pending_callback: Callable[[EffectMessage], None] | None = None
     _loading_timer: scheduling.Context | None = None
     _request_id: int = 0
 
@@ -86,7 +86,7 @@ class ExtensionMode(Mode):
             self._pending_callback = None
             self._active_ext = ext
 
-    def handle_query(self, query: Query, callback: Callable[[EffectMessage | list[Result]], None]) -> None:
+    def handle_query(self, query: Query, callback: Callable[[EffectMessage], None]) -> None:
         self._clear_loading_timer()
         if not query.keyword:
             msg = f"Extensions currently only support queries with a keyword ('{query}' given)"
@@ -99,7 +99,7 @@ class ExtensionMode(Mode):
             # Core only routes a keyword here when its own cache claims this mode owns it, so a miss
             # means the two caches disagree (e.g. the extension was removed since core last loaded).
             logger.warning("Extension query '%s' did not match any enabled extension", query)
-            callback([Result(name="Extension not available")])
+            callback(effects.render_results([Result(name="Extension not available")]))
             return
 
         self.active_ext = ext
@@ -141,7 +141,7 @@ class ExtensionMode(Mode):
         self._clear_loading_timer()
         callback, self._pending_callback = self._pending_callback, None
         if callback:
-            callback(results or [])
+            callback(effects.render_results(results or []))
 
     def _loading_failed_result(self) -> Result:
         ext = self.active_ext
@@ -177,9 +177,9 @@ class ExtensionMode(Mode):
         action_id: str,
         result: Result,
         _query: Query,
-        callback: Callable[[EffectMessage | list[Result]], None],
+        callback: Callable[[EffectMessage], None],
     ) -> None:
-        effect_msg: EffectMessage | list[Result] = effects.close_window()
+        effect_msg: EffectMessage = effects.close_window()
         if action_id == "__legacy_on_enter__" and result.on_enter:
             effect_msg = result.on_enter
         elif action_id == "__legacy_on_alt_enter__" and result.on_alt_enter:
@@ -280,7 +280,7 @@ class ExtensionMode(Mode):
                     }
                     ext.send_message(event_data)
 
-    def send_request(self, event: ipc.Request, callback: Callable[[EffectMessage | list[Result]], None]) -> None:
+    def send_request(self, event: ipc.Request, callback: Callable[[EffectMessage], None]) -> None:
         """
         Send an event to the extension, expecting a response (passed to the callback).
         A request_id is sent alongside the event, used to filter out stale responses.
@@ -308,6 +308,7 @@ class ExtensionMode(Mode):
                 or "response" not in message
                 or not isinstance(message["response"], dict)
                 or "effect" not in message["response"]
+                or not isinstance(message["response"]["effect"], dict)
             ):
                 logger.warning("Received malformed 'response' message from %s: %s", ext_id, message)
                 return
@@ -348,13 +349,17 @@ class ExtensionMode(Mode):
             return
 
         raw_effect_msg = response["effect"]
-        effect_msg: EffectMessage | list[Result]
+        effect_msg: EffectMessage
 
-        if isinstance(raw_effect_msg, list):
-            effect_msg = []
-            for result_dict in raw_effect_msg:
+        if raw_effect_msg.get("type") == EffectType.RENDER_RESULTS:
+            rendered: list[Result] = []
+            raw_results = raw_effect_msg.get("results")
+            for result_id, result_dict in enumerate(raw_results if isinstance(raw_results, list) else []):
                 result = Result(**result_dict)
                 result.icon = self.active_ext.get_icon_value(result_dict.get("icon"))
+                # The extension keys its result cache by list index, so carry that index back as the
+                # result_id when the result is activated (see api.extension.Extension).
+                result["__result_id__"] = result_id
 
                 # Convert legacy actions to the new actions dictionary format
                 if not result.actions:
@@ -363,7 +368,8 @@ class ExtensionMode(Mode):
                     if "on_alt_enter" in result:
                         result.actions["__legacy_on_alt_enter__"] = {"name": "Secondary action"}
 
-                effect_msg.append(result)
+                rendered.append(result)
+            effect_msg = effects.render_results(rendered)
 
         elif not response.get("keep_app_open", True):
             effect_utils.handle(raw_effect_msg, prevent_close=True)

--- a/ulauncher/modes/extensions/extension_mode.py
+++ b/ulauncher/modes/extensions/extension_mode.py
@@ -355,6 +355,9 @@ class ExtensionMode(Mode):
             rendered: list[Result] = []
             raw_results = raw_effect_msg.get("results")
             for result_id, result_dict in enumerate(raw_results if isinstance(raw_results, list) else []):
+                if not isinstance(result_dict, dict):
+                    logger.warning("Skipping malformed result from extension %s at index %s", ext_id, result_id)
+                    continue
                 result = Result(**result_dict)
                 result.icon = self.active_ext.get_icon_value(result_dict.get("icon"))
                 # The extension keys its result cache by list index, so carry that index back as the

--- a/ulauncher/modes/file_browser/file_browser_mode.py
+++ b/ulauncher/modes/file_browser/file_browser_mode.py
@@ -48,12 +48,12 @@ class FileBrowserMode(Mode):
     def filter_dot_files(self, file_list: list[str]) -> list[str]:
         return [f for f in file_list if not f.startswith(".")]
 
-    def handle_query(self, query: Query, callback: Callable[[effects.EffectMessage | list[Result]], None]) -> None:
+    def handle_query(self, query: Query, callback: Callable[[effects.EffectMessage], None]) -> None:
         results: list[Result] = []
         try:
             path_str = query.argument
             if not path_str:
-                callback([])
+                callback(effects.render_results([]))
                 return
             path = Path(expandvars(path_str.strip())).expanduser()
 
@@ -87,7 +87,7 @@ class FileBrowserMode(Mode):
         except (RuntimeError, OSError):
             results = []
 
-        callback(results)
+        callback(effects.render_results(results))
 
     def handle_backspace(self, query_str: str) -> Query | None:
         if "/" in query_str and len(query_str.strip().rstrip("/")) > 1:
@@ -99,14 +99,14 @@ class FileBrowserMode(Mode):
         action_id: str,
         result: Result,
         _query: Query,
-        callback: Callable[[effects.EffectMessage | list[Result]], None],
+        callback: Callable[[effects.EffectMessage], None],
     ) -> None:
         if action_id == "go_to":
             callback(effects.set_query(join(fold_user_path(result.path), "")))
         elif action_id == "open_with":
             from ulauncher.modes.file_browser.open_with import get_open_with_results
 
-            callback(get_open_with_results(result.path))
+            callback(effects.render_results(get_open_with_results(result.path)))
         elif action_id == "open_with_app":
             from ulauncher.modes.file_browser.open_with import open_path_with_app
 

--- a/ulauncher/modes/mode.py
+++ b/ulauncher/modes/mode.py
@@ -22,7 +22,7 @@ class Mode(ABC):
         return None
 
     @abstractmethod
-    def handle_query(self, _query: Query, callback: Callable[[EffectMessage | list[Result]], None]) -> None:
+    def handle_query(self, _query: Query, callback: Callable[[EffectMessage], None]) -> None:
         """
         Handle a query and provide the result list via callback.
         """
@@ -64,7 +64,7 @@ class Mode(ABC):
         action_id: str,
         result: Result,
         query: Query,
-        callback: Callable[[EffectMessage | list[Result]], None],
+        callback: Callable[[EffectMessage], None],
     ) -> None:
         """
         Called when a result is activated.

--- a/ulauncher/modes/shortcuts/shortcut_mode.py
+++ b/ulauncher/modes/shortcuts/shortcut_mode.py
@@ -45,14 +45,14 @@ class ShortcutMode(Mode):
 
         return None
 
-    def handle_query(self, query: Query, callback: Callable[[effects.EffectMessage | list[Result]], None]) -> None:
+    def handle_query(self, query: Query, callback: Callable[[effects.EffectMessage], None]) -> None:
         shortcut = self._get_active_shortcut(query)
         if not shortcut:
             msg = "Query doesn't match any shortcut"
             raise RuntimeError(msg)
 
         result: Result = convert_to_result(shortcut, query)
-        callback([result])
+        callback(effects.render_results([result]))
 
     def get_fallback_results(self, query_str: str) -> list[results.ShortcutResult]:
         query = Query(None, query_str)
@@ -71,7 +71,7 @@ class ShortcutMode(Mode):
         action_id: str,
         result: Result,
         query: Query,
-        callback: Callable[[effects.EffectMessage | list[Result]], None],
+        callback: Callable[[effects.EffectMessage], None],
     ) -> None:
         if action_id == "run_static":
             callback(run_shortcut(result.cmd))


### PR DESCRIPTION
We now have a bunch of `EffectMessage | list[Result]` types everywhere.  So wrapping `list[Result]` in an effect to get a more consistent type signature and simplifying how to handle the effect.

Interestingly, this reintroduces the exact same structure as the deprecated `RenderResultListAction`. I retired that because it wasn't practical to use.  Now we support both ways for extensions only, and will keep recommend yieldning and returning lists for brevity.

Every producer/consumer narrows on type == RENDER_RESULTS instead of isinstance(list). This is safe because we own/control both ends of the communication.

Also stops mutating the extension's Result objects to carry __result_id__. The extension now caches rendered results by list index and ships plain results; core stamps the positional index onto its own Result copies for activation routing. The result_id is purely positional, so the data stays a uniform list[Result] for both extension and built-in sources.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Normalize results into a tagged `EffectType.RENDER_RESULTS` effect across core, modes, and IPC, replacing the `list[Result]` special case and simplifying callbacks and closing logic. Extensions now cache results by index; core stamps positional `__result_id__` on its copies for activation routing without mutating extension data.

- **Refactors**
  - Added `effects.render_results`; `ipc.Response.effect` is now a single `EffectMessage`.
  - Producers/consumers render when `type == RENDER_RESULTS`; others go through `effect_utils.handle`.
  - `convert_to_effect_message` always returns an effect; iterables are wrapped via `render_results`.
  - `effect_utils.should_close` treats `RENDER_RESULTS`, `DO_NOTHING`, and `SET_QUERY` as non-closing; `LEGACY_RUN_MANY` delegates nested effects to `handle`.
  - `ActionList` now takes `list[EffectMessage]`; `RenderResultListAction` aliases `effects.render_results`; `Result.on_enter/alt` accept only `EffectMessage`.
  - Added deprecation TODO in `ulauncher.api.shared.action`.

- **Bug Fixes**
  - Skip and log non-dict and malformed entries in extension `RENDER_RESULTS` lists to prevent crashes.
  - Treat `result_id == 0` as valid during activation to fix first-item selection.

<sup>Written for commit ec9b4d5531cae2099a5861759bf0a9cb701ec88c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Ulauncher/Ulauncher/pull/1760?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

