### PR TITLE
fix(extensions): convert result dicts nested in legacy ActionList

### DIFF
--- a/ulauncher/modes/extensions/extension_mode.py
+++ b/ulauncher/modes/extensions/extension_mode.py
@@ -393,9 +393,9 @@ class ExtensionMode(Mode):
 
             # Convert legacy actions to the new actions dictionary format
             if not result.actions:
-                if "on_enter" in result:
+                if result.on_enter:
                     result.actions["__legacy_on_enter__"] = {"name": "Main action"}
-                if "on_alt_enter" in result:
+                if result.on_alt_enter:
                     result.actions["__legacy_on_alt_enter__"] = {"name": "Secondary action"}
 
             rendered.append(result)

--- a/ulauncher/modes/extensions/extension_mode.py
+++ b/ulauncher/modes/extensions/extension_mode.py
@@ -349,44 +349,56 @@ class ExtensionMode(Mode):
             return
 
         raw_effect_msg = response["effect"]
+        self._convert_result_dicts(ext_id, self.active_ext, cast("dict[str, Any]", raw_effect_msg))
         effect_msg: EffectMessage
 
-        if raw_effect_msg.get("type") == EffectType.RENDER_RESULTS:
-            rendered: list[Result] = []
-            raw_results = raw_effect_msg.get("results")
-            for result_id, result_dict in enumerate(raw_results if isinstance(raw_results, list) else []):
-                if not isinstance(result_dict, dict):
-                    logger.warning("Skipping malformed result from extension %s at index %s", ext_id, result_id)
-                    continue
-                try:
-                    result = Result(**result_dict)
-                except (KeyError, TypeError, ValueError) as e:
-                    logger.warning("Skipping malformed result from extension %s at index %s: %s", ext_id, result_id, e)
-                    continue
-                result.icon = self.active_ext.get_icon_value(result_dict.get("icon"))
-                # The extension keys its result cache by list index, so carry that index back as the
-                # result_id when the result is activated (see api.extension.Extension).
-                result["__result_id__"] = result_id
-
-                # Convert legacy actions to the new actions dictionary format
-                if not result.actions:
-                    if "on_enter" in result:
-                        result.actions["__legacy_on_enter__"] = {"name": "Main action"}
-                    if "on_alt_enter" in result:
-                        result.actions["__legacy_on_alt_enter__"] = {"name": "Secondary action"}
-
-                rendered.append(result)
-            effect_msg = effects.render_results(rendered)
-
-        elif not response.get("keep_app_open", True):
+        if raw_effect_msg.get("type") != EffectType.RENDER_RESULTS and not response.get("keep_app_open", True):
             effect_utils.handle(raw_effect_msg, prevent_close=True)
             effect_msg = effects.close_window()
-
         else:
             effect_msg = raw_effect_msg
 
         self._pending_callback(effect_msg)
         self._pending_callback = None
+
+    def _convert_result_dicts(self, ext_id: str, active_ext: ExtensionController, effect_msg: dict[str, Any]) -> None:
+        """Replace the raw result dicts in a RENDER_RESULTS effect with Result objects, in place.
+
+        Recurses into LEGACY_RUN_MANY so results nested in a legacy ActionList are converted too.
+        """
+        if effect_msg.get("type") == EffectType.LEGACY_RUN_MANY:
+            for nested in effect_msg.get("data") or []:
+                if isinstance(nested, dict):
+                    self._convert_result_dicts(ext_id, active_ext, nested)
+            return
+        if effect_msg.get("type") != EffectType.RENDER_RESULTS:
+            return
+
+        raw_results = effect_msg.get("results")
+        rendered: list[Result] = []
+        for result_id, result_dict in enumerate(raw_results if isinstance(raw_results, list) else []):
+            if not isinstance(result_dict, dict):
+                logger.warning("Skipping malformed result from extension %s at index %s", ext_id, result_id)
+                continue
+            try:
+                result = Result(**result_dict)
+            except (KeyError, TypeError, ValueError) as e:
+                logger.warning("Skipping malformed result from extension %s at index %s: %s", ext_id, result_id, e)
+                continue
+            result.icon = active_ext.get_icon_value(result_dict.get("icon"))
+            # The extension keys its result cache by list index, so carry that index back as the
+            # result_id when the result is activated (see api.extension.Extension).
+            result["__result_id__"] = result_id
+
+            # Convert legacy actions to the new actions dictionary format
+            if not result.actions:
+                if "on_enter" in result:
+                    result.actions["__legacy_on_enter__"] = {"name": "Main action"}
+                if "on_alt_enter" in result:
+                    result.actions["__legacy_on_alt_enter__"] = {"name": "Secondary action"}
+
+            rendered.append(result)
+        effect_msg["results"] = rendered
 
     @events.on
     def preview_ext(self, ext_id: str, path: str, with_debugger: bool = False) -> None:

--- a/ulauncher/modes/extensions/extension_mode.py
+++ b/ulauncher/modes/extensions/extension_mode.py
@@ -367,7 +367,8 @@ class ExtensionMode(Mode):
         Recurses into LEGACY_RUN_MANY so results nested in a legacy ActionList are converted too.
         """
         if effect_msg.get("type") == EffectType.LEGACY_RUN_MANY:
-            for nested in effect_msg.get("data") or []:
+            data = effect_msg.get("data")
+            for nested in data if isinstance(data, list) else []:
                 if isinstance(nested, dict):
                     self._convert_result_dicts(ext_id, active_ext, nested)
             return


### PR DESCRIPTION
In Ulauncher v6, extensions that return `ActionList([..., RenderResultListAction(...)])` (the only example of that is https://github.com/mikebarkmin/ulauncher-snippets/) were broken in several ways.

1. After the Result.wrap pr, it  crashed the launcher with `AttributeError: 'dict' object has no attribute 'wrap'` when rendering. This was only a symptom of this path missing the raw dict to Result conversion which was a bug before. Fixed by aab787e13
2. The placeholder timer wasn't cancelled. I pushed this to main already as 0009c640b because it was a small one liner fix that I think is the correct thing to do regardless of this bug

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a crash when legacy extensions wrap result rendering in a legacy ActionList. Nested result dicts are now converted to Result objects before rendering, so legacy results display correctly.

- **Bug Fixes**
  - Added a recursive `_convert_result_dicts` to descend into `LEGACY_RUN_MANY` and convert nested `RENDER_RESULTS` into `Result` instances in place.
  - Run the conversion on every response before effect handling; `keep_app_open` and close-window behavior is unchanged.

<sup>Written for commit 655738e9aebb2639751e418f8be7d9f87e5c0aa2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Ulauncher/Ulauncher/pull/1763?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

