### PR TITLE
feat: stream responses

### DIFF
--- a/docs/architecture/extension-ipc.md
+++ b/docs/architecture/extension-ipc.md
@@ -56,3 +56,17 @@ Extensions run in **separate processes** as the same user as Ulauncher (not sand
 4. Extension handles action → may send new results back
 
 All communication is asynchronous using GLib's event loop.
+
+## Streaming Results
+
+A handler that returns a list sends a single response. A handler that *yields* streams its
+results as several `response` messages sharing one request id, each carrying an `append`
+flag and a `final` flag. The type of each yielded value sets the `append` flag:
+
+- `yield result` (a single Result) -> appends it to the current list (`append: true`)
+- `yield [results]` (a list) -> replaces the current list (`append: false`)
+
+Only a yielded list triggers the replace; a single result always appends.
+
+Only the last batch is flagged `final`; Ulauncher keeps the request's callback alive until then.
+Stale batches (a newer query has superseded this one) are dropped on both ends.

--- a/tests/api/test_extension.py
+++ b/tests/api/test_extension.py
@@ -1,10 +1,16 @@
+from __future__ import annotations
+
 import logging
 import os
+from typing import Iterator
 from unittest.mock import patch
 
+import pytest
 from pytest_mock import MockerFixture
 
+from ulauncher.api import extension as extension_module
 from ulauncher.api.extension import Extension
+from ulauncher.internals.result import Result
 
 
 class TestExtension:
@@ -24,3 +30,72 @@ class TestExtension:
             Extension()
 
         assert basic_config.call_args_list[0].kwargs["level"] == logging.DEBUG
+
+
+def _batches(ext: Extension) -> list[tuple[bool, bool, list[str], list[int]]]:
+    """(append, final, result names, result ids) for each render the extension sent."""
+    batches = []
+    for call in ext._client.send.call_args_list:  # type: ignore[attr-defined]
+        effect = call.args[0]["response"]["effect"]
+        results = effect["results"]
+        names = [r["name"] for r in results]
+        ids = [r["__result_id__"] for r in results]
+        batches.append((effect["append"], effect["final"], names, ids))
+    return batches
+
+
+class TestStreamingResponses:
+    @pytest.fixture
+    def ext(self, mocker: MockerFixture) -> Extension:
+        mocker.patch("ulauncher.api.extension.Client")
+        mocker.patch("ulauncher.api.extension.signal.signal")
+        # run scheduled responses synchronously so we can assert on them inline
+        mocker.patch.object(extension_module.scheduling, "run_when_idle", side_effect=lambda fn, *a: fn(*a))
+        with patch.dict(os.environ, {"ULAUNCHER_EXTENSION_ID": "com.example.test"}):
+            return Extension()
+
+    def test_yielding_results_appends_with_continuous_ids(self, ext: Extension) -> None:
+        def gen() -> Iterator[Result]:
+            yield Result(name="a")
+            yield Result(name="b")
+
+        ext.run_event_listener(1, {}, gen, ())
+        assert _batches(ext) == [
+            (True, False, ["a"], [0]),
+            (True, False, ["b"], [1]),
+            (True, True, [], []),
+        ]
+
+    def test_yielding_lists_replaces_but_keeps_ids_unique(self, ext: Extension) -> None:
+        def gen() -> Iterator[list[Result]]:
+            yield [Result(name="a")]
+            yield [Result(name="a"), Result(name="b")]
+
+        ext.run_event_listener(1, {}, gen, ())
+        assert _batches(ext) == [
+            (False, False, ["a"], [0]),
+            (False, False, ["a", "b"], [1, 2]),
+            (True, True, [], []),
+        ]
+
+    def test_empty_generator_sends_final_empty_replace(self, ext: Extension) -> None:
+        def gen() -> Iterator[Result]:
+            return
+            yield  # makes this a generator
+
+        ext.run_event_listener(1, {}, gen, ())
+        assert _batches(ext) == [(False, True, [], [])]
+
+    def test_returned_list_is_a_single_final_response(self, ext: Extension) -> None:
+        ext.run_event_listener(1, {}, lambda: [Result(name="a")], ())
+        assert _batches(ext) == [(False, True, ["a"], [0])]
+
+    def test_stale_generator_stops_without_sending(self, ext: Extension) -> None:
+        ext._input_request_id = 5
+
+        def gen() -> Iterator[Result]:
+            yield Result(name="a")
+            yield Result(name="b")
+
+        ext.run_event_listener(1, {}, gen, (), input_request_id=4)  # superseded by 5
+        assert _batches(ext) == []

--- a/tests/internals/test_result_buffer.py
+++ b/tests/internals/test_result_buffer.py
@@ -1,0 +1,100 @@
+from __future__ import annotations
+
+from typing import Callable
+from unittest.mock import MagicMock
+
+import pytest
+from pytest_mock import MockerFixture
+
+from ulauncher.internals import effects, result_buffer
+from ulauncher.internals.result import Result
+from ulauncher.internals.result_buffer import ResultBuffer
+
+
+class TestResultBuffer:
+    @pytest.fixture
+    def buffer(self) -> ResultBuffer:
+        return ResultBuffer()
+
+    @pytest.fixture
+    def emit(self) -> MagicMock:
+        """Spy receiving (results, append) for each paint the buffer flushes."""
+        return MagicMock()
+
+    @pytest.fixture
+    def captured_flush(self, mocker: MockerFixture) -> list[Callable[[], None]]:
+        """Capture the throttle's scheduled flush instead of arming a real timer."""
+        captured: list[Callable[[], None]] = []
+        mocker.patch.object(
+            result_buffer.scheduling, "timer", side_effect=lambda _delay, func: (captured.append(func), MagicMock())[1]
+        )
+        return captured
+
+    def test_replace_final_renders_immediately(self, buffer: ResultBuffer, emit: MagicMock) -> None:
+        r = Result(name="a")
+        buffer.enqueue(effects.render_results([r], append=False, final=True), emit)
+        emit.assert_called_once_with([r], False)
+
+    def test_append_first_is_forced_to_replace(self, buffer: ResultBuffer, emit: MagicMock) -> None:
+        r = Result(name="a")
+        buffer.enqueue(effects.render_results([r], append=True, final=True), emit)
+        emit.assert_called_once_with([r], False)
+
+    def test_append_after_first_paint_appends(
+        self, buffer: ResultBuffer, emit: MagicMock, captured_flush: list[Callable[[], None]]
+    ) -> None:
+        first, second = Result(name="a"), Result(name="b")
+        buffer.enqueue(effects.render_results([first], append=False, final=False), emit)  # schedules a flush
+        captured_flush[0]()  # first paint
+        buffer.enqueue(effects.render_results([second], append=True, final=True), emit)
+        assert emit.call_args_list[0].args == ([first], False)
+        assert emit.call_args_list[1].args == ([second], True)
+
+    def test_replace_after_append_replaces(self, buffer: ResultBuffer, emit: MagicMock) -> None:
+        a, b, c = Result(name="a"), Result(name="b"), Result(name="c")
+        buffer.enqueue(effects.render_results([a], append=False, final=True), emit)  # first paint
+        buffer.enqueue(effects.render_results([b], append=True, final=True), emit)  # appends onto it
+        buffer.enqueue(effects.render_results([c], append=False, final=True), emit)  # replace must not leak a, b
+        assert emit.call_args_list[-1].args == ([c], False)
+
+    def test_replace_drafts_coalesce_to_latest(
+        self, buffer: ResultBuffer, emit: MagicMock, captured_flush: list[Callable[[], None]]
+    ) -> None:
+        base, draft2, draft3 = Result(name="base"), Result(name="2"), Result(name="3")
+        buffer.enqueue(effects.render_results([base], append=False, final=False), emit)  # schedules a flush
+        buffer.enqueue(effects.render_results([draft2], append=False, final=False), emit)  # coalesced into pending
+        buffer.enqueue(effects.render_results([draft3], append=False, final=False), emit)  # coalesced into pending
+        assert len(captured_flush) == 1
+        captured_flush[0]()
+        assert emit.call_args_list[-1].args == ([draft3], False)
+
+    def test_appends_batch_within_window(
+        self, buffer: ResultBuffer, emit: MagicMock, captured_flush: list[Callable[[], None]]
+    ) -> None:
+        base, a, b = Result(name="base"), Result(name="a"), Result(name="b")
+        buffer.enqueue(effects.render_results([base], append=False, final=False), emit)  # schedules a flush
+        captured_flush[0]()  # first paint
+        buffer.enqueue(effects.render_results([a], append=True, final=False), emit)  # schedules a flush
+        buffer.enqueue(effects.render_results([b], append=True, final=False), emit)  # batched into pending
+        captured_flush[1]()
+        assert emit.call_args_list[-1].args == ([a, b], True)
+
+    def test_append_onto_pending_replace_stays_replace(
+        self, buffer: ResultBuffer, emit: MagicMock, captured_flush: list[Callable[[], None]]
+    ) -> None:
+        base, draft, extra = Result(name="base"), Result(name="draft"), Result(name="extra")
+        buffer.enqueue(effects.render_results([base], append=False, final=False), emit)  # schedules a flush
+        buffer.enqueue(effects.render_results([draft], append=False, final=False), emit)  # un-flushed replace
+        buffer.enqueue(effects.render_results([extra], append=True, final=False), emit)  # piles onto it
+        captured_flush[0]()
+        assert emit.call_args_list[-1].args == ([draft, extra], False)
+
+    def test_reset_drops_pending_flush(
+        self, buffer: ResultBuffer, emit: MagicMock, captured_flush: list[Callable[[], None]]
+    ) -> None:
+        buffer.enqueue(effects.render_results([Result(name="base")], append=False, final=False), emit)  # schedules
+        buffer.enqueue(effects.render_results([Result(name="late")], append=True, final=False), emit)  # batched in
+        emit.reset_mock()
+        buffer.reset()
+        captured_flush[0]()  # a flush that fires after the query changed must do nothing
+        emit.assert_not_called()

--- a/tests/modes/extensions/test_extension_mode.py
+++ b/tests/modes/extensions/test_extension_mode.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from types import SimpleNamespace
 from typing import TYPE_CHECKING
-from unittest.mock import MagicMock, PropertyMock
+from unittest.mock import MagicMock, PropertyMock, call
 
 from pytest_mock import MockerFixture
 
@@ -196,3 +196,19 @@ def test_started__ignores_other_extensions(mocker: MockerFixture) -> None:
     mode.started("other.ext")
 
     run_when_idle.assert_not_called()
+
+
+def test_handle_response__streamed_batches_keep_callback_until_final() -> None:
+    mode = _make_mode()
+    callback = MagicMock()
+    mode._pending_callback = callback
+
+    non_final = effects.render_results([], append=True, final=False)
+    mode._handle_response({"effect": non_final})
+    assert mode._pending_callback is callback, "a non-final batch must keep the callback alive"
+
+    final = effects.render_results([], append=True, final=True)
+    mode._handle_response({"effect": final})
+    assert mode._pending_callback is None, "the final batch clears the callback"
+
+    assert callback.call_args_list == [call(non_final), call(final)]

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -1,0 +1,49 @@
+from __future__ import annotations
+
+from typing import Callable
+from unittest.mock import MagicMock, PropertyMock
+
+from pytest_mock import MockerFixture
+
+from ulauncher.core import UlauncherCore
+from ulauncher.internals import effects
+from ulauncher.internals.query import Query
+from ulauncher.internals.result import Result
+
+
+class TestStreamingResults:
+    """Core wires streamed RENDER_RESULTS through the buffer; ResultBuffer owns the batching
+    behavior itself (see tests/internals/test_result_buffer.py)."""
+
+    def test_streamed_render_stamps_query_and_pick(self, mocker: MockerFixture) -> None:
+        core = UlauncherCore()
+        core.query = Query(None, "foo")
+        mocker.patch.object(UlauncherCore, "last_query_result_pick", new_callable=PropertyMock, return_value="picked")
+        outer = MagicMock()
+        emit = core._mode_callback(None, outer)  # valid_mode=None skips the active-mode staleness guard
+
+        r = Result(name="a")
+        emit(effects.render_results([r], append=False, final=True))
+
+        update = outer.call_args.args[0]
+        assert update["results"] == [r]
+        assert update["append"] is False
+        assert str(update["query"]) == "foo"
+        assert update["selected_name"] == "picked"
+
+    def test_activating_drops_pending_stream_paint(self, mocker: MockerFixture) -> None:
+        # A throttled paint armed mid-stream must not fire over what an activation renders next.
+        core = UlauncherCore()
+        captured: list[Callable[[], None]] = []
+        mocker.patch(
+            "ulauncher.internals.result_buffer.scheduling.timer",
+            side_effect=lambda _d, fn: (captured.append(fn), MagicMock())[1],
+        )
+        render = MagicMock()
+        core._mode_callback(None, render)(effects.render_results([Result(name="a")], final=False))
+        assert captured  # a flush was scheduled
+        render.assert_not_called()  # but it hasn't painted yet
+
+        core.activate_result(Result(name="a"), MagicMock(), alt=True)
+        captured[0]()  # the stale flush fires after activation
+        render.assert_not_called()

--- a/tests/ui/test_results_view.py
+++ b/tests/ui/test_results_view.py
@@ -7,7 +7,17 @@ from unittest.mock import MagicMock
 import pytest
 from pytest_mock import MockerFixture
 
+from ulauncher.internals.query import Query
+from ulauncher.internals.result import Result
+from ulauncher.internals.results_update import ResultsUpdate, results_update
 from ulauncher.ui.results_view import ResultsView
+
+
+def _named_widget(name: str, *, searchable: bool = True) -> MagicMock:
+    widget = MagicMock()
+    widget.result.name = name
+    widget.result.searchable = searchable
+    return widget
 
 
 class TestResultsView:
@@ -112,3 +122,87 @@ class TestResultsViewNavigation:
         view.go_down()
         assert view.get_active_result() is None
         assert not view.has_results
+
+
+class TestResultsViewSelection:
+    """Selection logic used across streamed replace/append batches."""
+
+    @pytest.fixture
+    def view(self) -> ResultsView:
+        return ResultsView(cast("Any", MagicMock()), cast("Any", MagicMock()))
+
+    def test_select_marks_user_selected(self, view: ResultsView) -> None:
+        view._widgets = cast("Any", [_named_widget("a"), _named_widget("b")])
+        view.select(1)
+        assert view._index == 1
+        assert view._user_selected is True
+
+    def test_apply_selection_uses_default_name_without_marking_user_selected(self, view: ResultsView) -> None:
+        view._widgets = cast("Any", [_named_widget("a"), _named_widget("keep"), _named_widget("b")])
+        view._apply_selection("keep", None)
+        assert view._index == 1
+        assert view._user_selected is False
+
+    def test_apply_selection_preserves_user_pick(self, view: ResultsView) -> None:
+        view._widgets = cast("Any", [_named_widget("a"), _named_widget("keep"), _named_widget("b")])
+        view._user_selected = True
+        previous = cast("Any", MagicMock(name="prev"))
+        previous.name = "keep"
+        view._apply_selection(None, previous)
+        assert view._index == 1
+        assert view._user_selected
+
+    def test_apply_selection_falls_back_when_user_pick_gone(self, view: ResultsView) -> None:
+        view._widgets = cast("Any", [_named_widget("a"), _named_widget("b")])
+        view._user_selected = True
+        previous = cast("Any", MagicMock(name="prev"))
+        previous.name = "gone"
+        view._apply_selection("a", previous)
+        assert view._index == 0
+        assert not view._user_selected
+
+
+class TestResultsViewStreaming:
+    """End-to-end render of streamed replace/append batches (builds real result widgets)."""
+
+    @pytest.fixture(autouse=True)
+    def _no_scroll(self, mocker: MockerFixture) -> None:
+        mocker.patch("ulauncher.ui.result_widget.ResultWidget.scroll_to_focus")
+
+    @pytest.fixture
+    def view(self) -> ResultsView:
+        settings = MagicMock()
+        no_jump_keys: list[str] = []
+        settings.get_jump_keys.return_value = no_jump_keys
+        return ResultsView(settings, lambda *_: None)
+
+    @staticmethod
+    def _update(
+        names: list[str], query: str = "q", selected_name: str | None = None, append: bool = False
+    ) -> ResultsUpdate:
+        return results_update([Result(name=name) for name in names], Query(None, query), selected_name, append)
+
+    def test_replace_preserves_user_pick_within_same_query(self, view: ResultsView) -> None:
+        view.render(self._update(["a", "b", "c"]))
+        view.go_down()  # user picks "b"
+        # a later draft of the same query reorders the list; "b" is still present
+        view.render(self._update(["x", "a", "b", "c"]))
+        active = view.get_active_result()
+        assert active is not None
+        assert active.name == "b"
+
+    def test_append_grows_list_and_keeps_selection(self, view: ResultsView) -> None:
+        view.render(self._update(["a", "b"]))
+        view.go_down()  # "b"
+        view.render(self._update(["c", "d"], append=True))
+        assert len(view._widgets) == 4
+        active = view.get_active_result()
+        assert active is not None
+        assert active.name == "b"
+
+    def test_new_query_resets_user_selection(self, view: ResultsView) -> None:
+        view.render(self._update(["a", "b"], query="q1"))
+        view.go_down()
+        view.render(self._update(["a", "b"], query="q2"))
+        assert view._user_selected is False
+        assert view._index == 0

--- a/ulauncher/api/extension.py
+++ b/ulauncher/api/extension.py
@@ -7,7 +7,7 @@ import os
 import signal
 import threading
 from collections import defaultdict
-from typing import Any, Callable, Iterable
+from typing import Any, Callable, Iterable, cast
 
 from ulauncher.api.client.Client import Client
 from ulauncher.api.client.EventListener import EventListener
@@ -48,6 +48,7 @@ class Extension:
         self._input_debounce_timer: scheduling.Context | None = None
         self._input_debounce_delay = float(os.getenv("ULAUNCHER_INPUT_DEBOUNCE", "0.05"))
         self._result_cache: dict[int, Result] = {}
+        self._cache_request_id: int | None = None
         signal.signal(signal.SIGTERM, lambda *_: self._client.unload())
         with contextlib.suppress(Exception):
             # TODO: #1741 - migration path to remove trigger keywords from preferences
@@ -183,10 +184,8 @@ class Extension:
         if input_request_id is not None and input_request_id != self._input_request_id:
             return False
 
-        # Cache the rendered results by list index so an activation can map its result_id back to the
-        # actual Result instance, without mutating the result objects the extension handed us.
         if effect_msg["type"] == effects.EffectType.RENDER_RESULTS:
-            self._result_cache = dict(enumerate(effect_msg["results"]))
+            self._assign_result_ids(request_id, effect_msg)
 
         response: ipc.Response = {"effect": effect_msg}
         if "keep_app_open" in event:
@@ -194,6 +193,23 @@ class Extension:
             response["keep_app_open"] = event["keep_app_open"]
         self._client.send({"name": "response", "request_id": request_id, "response": response})
         return False
+
+    def _assign_result_ids(self, request_id: int, effect_msg: effects.RenderResults) -> None:
+        """Give each result a stable id, cache it for activation lookup, and stamp the id onto a wire
+        copy without mutating the result the extension handed us. Ids stay unique for the whole
+        request; only a new request starts a fresh id space.
+        """
+        # A replace batch must not reuse ids: the previous batch can still be on screen (its paint is
+        # throttled downstream), so an activation of a visible result would resolve to a new one.
+        if request_id != self._cache_request_id:
+            self._result_cache = {}
+            self._cache_request_id = request_id
+        wire_results: list[Result] = []
+        for result in effect_msg["results"]:
+            result_id = len(self._result_cache)
+            self._result_cache[result_id] = result
+            wire_results.append(cast("Result", {**result, "__result_id__": result_id}))
+        effect_msg["results"] = wire_results
 
     def run(self) -> None:
         """

--- a/ulauncher/api/extension.py
+++ b/ulauncher/api/extension.py
@@ -1,13 +1,14 @@
 from __future__ import annotations
 
 import contextlib
+import inspect
 import json
 import logging
 import os
 import signal
 import threading
 from collections import defaultdict
-from typing import Any, Callable, Iterable, cast
+from typing import Any, Callable, Iterable, Iterator, cast
 
 from ulauncher.api.client.Client import Client
 from ulauncher.api.client.EventListener import EventListener
@@ -163,16 +164,55 @@ class Extension:
         request_id: int | None,
         event: dict[str, Any],
         method: Callable[..., effects.EffectMessageInput | None],
-        args: tuple[Any],
+        args: tuple[Any, ...],
         input_request_id: int | None = None,
     ) -> None:
-        # For extensions using yield to generate results, the method call will take no time, while
-        # the conversion step will actually be the slow part. So we need to check staleness after both.
-        input_effect_msg = method(*args)
-        if request_id is not None:
+        result = method(*args)
+        if request_id is None:
+            return
+
+        # A generator streams its results in batches: `yield result` appends one, `yield [results]`
+        # replaces the list. Anything else (a returned list, effect, bool, ...) is a single response.
+        if inspect.isgenerator(result):
+            self._stream_response(request_id, event, result, input_request_id)
+        else:
             # Schedule the response on the main thread to avoid races on shared state
-            effect_msg = effect_utils.convert_to_effect_message(input_effect_msg)
+            effect_msg = effect_utils.convert_to_effect_message(result)
             scheduling.run_when_idle(self._send_response, request_id, event, effect_msg, input_request_id)
+
+    def _stream_response(
+        self,
+        request_id: int,
+        event: dict[str, Any],
+        generator: Iterator[Result | list[Result]],
+        input_request_id: int | None,
+    ) -> None:
+        """Send one render batch per yielded item, then a final empty batch to close the stream.
+
+        A yielded single result appends, while a yielded list replaces the rendered list.
+
+        After the yield, an empty closing (final=True) batch is sent separately. If nothing was streamed,
+        it clears any prior results (append=False).
+
+        A superseding input stops the loop with no closing batch, since that input renders its own; an
+        exception raised mid-stream propagates and likewise sends none. Ulauncher keeps the request's
+        callback alive until a closing batch or the next input, so partial results stay on screen.
+        """
+
+        def emit(effect_msg: effects.RenderResults) -> None:
+            # Schedule the response on the main thread to avoid races on shared state
+            scheduling.run_when_idle(self._send_response, request_id, event, effect_msg, input_request_id)
+
+        emitted = False
+        for item in generator:
+            if input_request_id is not None and input_request_id != self._input_request_id:
+                return
+            append = not isinstance(item, list)
+            results = [item] if append else list(item)
+            emit(effects.render_results(results, append=append, final=False))
+            emitted = True
+
+        emit(effects.render_results([], append=emitted, final=True))
 
     def _send_response(
         self,
@@ -244,7 +284,9 @@ class Extension:
 
         self._client.send({"name": "notify", "body": body, "notification_id": notification_id})
 
-    def on_input(self, _query_str: str, _trigger_id: str) -> Iterable[Result]:
+    def on_input(self, _query_str: str, _trigger_id: str) -> Iterable[Result | list[Result]]:
+        # Return a list of results, or yield to stream them: `yield result` appends one,
+        # `yield [results]` replaces the list (see _stream_response).
         return []
 
     def on_launch(self, trigger_id: str) -> None:

--- a/ulauncher/core.py
+++ b/ulauncher/core.py
@@ -10,6 +10,7 @@ from ulauncher.internals import effect_utils, effects
 from ulauncher.internals.query import Query
 from ulauncher.internals.query_history import QueryHistory
 from ulauncher.internals.result import ActionResult, KeywordTrigger, Result
+from ulauncher.internals.result_buffer import ResultBuffer
 from ulauncher.internals.results_update import ResultsUpdate, results_update
 from ulauncher.modes.mode import Mode
 from ulauncher.utils import scheduling
@@ -51,6 +52,9 @@ class UlauncherCore:
     _mode_map: WeakKeyDictionary[Result, Mode] = WeakKeyDictionary()
     query: Query = Query(None, "")
     _placeholder_timer: scheduling.Context | None = None
+
+    def __init__(self) -> None:
+        self._result_buffer = ResultBuffer()
 
     @property
     def last_query_result_pick(self) -> str | None:
@@ -98,6 +102,7 @@ class UlauncherCore:
         if not query_str:
             self._mode = None
             self.query = Query(None, "")
+            self._result_buffer.reset()
             self._show_results(self.get_home_results(), callback)
             return
 
@@ -142,6 +147,8 @@ class UlauncherCore:
                 yield app_result
 
     def _show_results(self, results: Iterable[Result], callback: ResultsCallback) -> None:
+        """Render a result list immediately, replacing the current one. For the non-streaming
+        paths (home, search, fallback, placeholder, action menu); does not touch stream state."""
         self._clear_placeholder_timer()
         callback(results_update(list(results), self.query, self.last_query_result_pick))
 
@@ -154,7 +161,12 @@ class UlauncherCore:
             self._placeholder_timer.cancel()
             self._placeholder_timer = None
 
+    def _emit_results(self, results: list[Result], append: bool, callback: ResultsCallback) -> None:
+        self._clear_placeholder_timer()
+        callback(results_update(results, self.query, self.last_query_result_pick, append))
+
     def handle_change(self, callback: ResultsCallback) -> None:
+        self._result_buffer.reset()
         self._clear_placeholder_timer()
 
         if self._mode:
@@ -189,6 +201,8 @@ class UlauncherCore:
         return False
 
     def activate_result(self, result: Result, callback: ResultsCallback, alt: bool = False) -> None:
+        # drop any pending buffer so it doesn't interfere with the activation results
+        self._result_buffer.reset()
         action_id: str | None = None
 
         if not alt:
@@ -240,7 +254,9 @@ class UlauncherCore:
 
             self._clear_placeholder_timer()
             if effect_msg["type"] == effects.EffectType.RENDER_RESULTS:
-                self._show_results(effect_msg["results"], callback)
+                self._result_buffer.enqueue(
+                    effect_msg, lambda results, append: self._emit_results(results, append, callback)
+                )
             elif effect_msg["type"] == effects.EffectType.LEGACY_RUN_MANY:
                 # effect_utils.handle has no callback to render with, so route any nested render
                 # here and let it process the rest (preserving its close behavior).

--- a/ulauncher/internals/effects.py
+++ b/ulauncher/internals/effects.py
@@ -81,8 +81,10 @@ EffectMessage = Union[
     LegacyActivateCustom,
 ]
 
-# Input format that we will convert to an EffectMessage
-EffectMessageInput = Union[EffectMessage, bool, str, Iterable["Result"]]
+# Input format that we will convert to an EffectMessage. A plain iterable of Results becomes one
+# render; a generator may also yield list[Result] batches to stream replace drafts (see
+# api.extension.Extension._stream_response).
+EffectMessageInput = Union[EffectMessage, bool, str, Iterable[Union["Result", "list[Result]"]]]
 
 
 def do_nothing() -> DoNothing:

--- a/ulauncher/internals/effects.py
+++ b/ulauncher/internals/effects.py
@@ -4,6 +4,8 @@ from typing import TYPE_CHECKING, Final, Iterable, Literal, TypedDict, Union
 
 # if type checking import Result
 if TYPE_CHECKING:
+    from typing_extensions import NotRequired
+
     from ulauncher.internals.result import Result
 
 
@@ -35,6 +37,10 @@ class SetQuery(TypedDict):
 class RenderResults(TypedDict):
     type: Literal["effect:render_results"]
     results: list[Result]
+    # True adds to the end of the current list, False (default) replaces the whole list.
+    append: NotRequired[bool]
+    # False while more batches are still coming for the same query.
+    final: NotRequired[bool]
 
 
 class Open(TypedDict):
@@ -94,8 +100,8 @@ def set_query(query: str) -> SetQuery:
     return {"type": EffectType.SET_QUERY, "query": query}
 
 
-def render_results(results: list[Result]) -> RenderResults:
-    return {"type": EffectType.RENDER_RESULTS, "results": results}
+def render_results(results: list[Result], append: bool = False, final: bool = True) -> RenderResults:
+    return {"type": EffectType.RENDER_RESULTS, "results": results, "append": append, "final": final}
 
 
 def open(item: str) -> Open:  # noqa: A001

--- a/ulauncher/internals/result_buffer.py
+++ b/ulauncher/internals/result_buffer.py
@@ -1,0 +1,65 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Callable
+
+from ulauncher.utils import scheduling
+
+if TYPE_CHECKING:
+    from ulauncher.internals import effects
+    from ulauncher.internals.result import Result
+
+RENDER_THROTTLE = 0.05  # delay in sec to coalesce streamed result batches
+
+EmitResults = Callable[["list[Result]", bool], None]
+
+
+class ResultBuffer:
+    """In-flight stream of result batches for a query, holding the buffered results, whether they
+    replace or append, and the throttle timer between paints."""
+
+    def __init__(self) -> None:
+        self._buffer: list[Result] | None = None
+        self._painted = False  # a batch has been painted, so there is a displayed list to append onto
+        self._is_appending = False
+        self._timer: scheduling.Context | None = None
+        self._emit: EmitResults | None = None
+
+    def reset(self) -> None:
+        """Drop buffered batches and any scheduled paint so the next query starts clean."""
+        if self._timer:
+            self._timer.cancel()
+            self._timer = None
+        self._buffer = None
+        self._painted = False
+        self._is_appending = False
+        self._emit = None
+
+    def enqueue(self, effect: effects.RenderResults, emit: EmitResults) -> None:
+        self._emit = emit
+        is_append = effect.get("append", False)
+        if is_append and self._buffer is not None:
+            self._buffer += effect["results"]
+        else:
+            self._buffer = list(effect["results"])
+            self._is_appending = is_append
+
+        if effect.get("final", True):
+            self._paint()
+        elif not self._timer:
+            self._timer = scheduling.timer(RENDER_THROTTLE, self._throttled_paint)
+
+    def _throttled_paint(self) -> None:
+        # the throttle timer fired; ignore it if reset() cancelled us in the meantime
+        if self._timer is not None:
+            self._paint()
+
+    def _paint(self) -> None:
+        if self._emit is None or self._buffer is None:
+            return
+
+        append = self._painted and self._is_appending
+        results = self._buffer
+        emit = self._emit
+        self.reset()
+        self._painted = True
+        emit(results, append)

--- a/ulauncher/internals/results_update.py
+++ b/ulauncher/internals/results_update.py
@@ -11,14 +11,22 @@ class ResultsUpdate(TypedDict):
     """A self-contained snapshot of what the results view should render.
 
     Carries everything the view needs so it never has to read back into core state:
-    the results, the query they were produced for, and which result to preselect.
+    the results, the query they were produced for, which result to preselect, and
+    whether to replace the current list or append to it (for streamed batches).
     """
 
     results: list[Result]
     query: Query
     # Name of the result to preselect, or None to fall back to the first.
     selected_name: str | None
+    # True adds to the end of the current list, False replaces the whole list.
+    append: bool
 
 
-def results_update(results: list[Result], query: Query, selected_name: str | None = None) -> ResultsUpdate:
-    return {"results": results, "query": query, "selected_name": selected_name}
+def results_update(
+    results: list[Result],
+    query: Query,
+    selected_name: str | None = None,
+    append: bool = False,
+) -> ResultsUpdate:
+    return {"results": results, "query": query, "selected_name": selected_name, "append": append}

--- a/ulauncher/modes/extensions/extension_mode.py
+++ b/ulauncher/modes/extensions/extension_mode.py
@@ -352,7 +352,10 @@ class ExtensionMode(Mode):
             effect_msg = effects.close_window()
 
         self._pending_callback(effect_msg)
-        self._pending_callback = None
+        # A streamed render keeps the callback alive across batches; everything else is terminal.
+        is_streaming_batch = effect_msg["type"] == EffectType.RENDER_RESULTS and not effect_msg.get("final", True)
+        if not is_streaming_batch:
+            self._pending_callback = None
 
     def _rehydrate_results(self, ext: ExtensionController, effect_msg: EffectMessage) -> EffectMessage:
         """Return the effect with raw result dicts in a RENDER_RESULTS effect replaced by Result objects.

--- a/ulauncher/modes/extensions/extension_mode.py
+++ b/ulauncher/modes/extensions/extension_mode.py
@@ -372,19 +372,22 @@ class ExtensionMode(Mode):
 
         raw_results = effect_msg.get("results")
         rendered: list[Result] = []
-        for result_id, result_dict in enumerate(raw_results):
+        for index, result_dict in enumerate(raw_results):
             if not isinstance(result_dict, dict):
-                logger.warning("Skipping malformed result from extension %s at index %s", ext.id, result_id)
+                logger.warning("Skipping malformed result from extension %s at index %s", ext.id, index)
                 continue
+            # The extension stamps each result with its cache id; carry it through so activation can
+            # map back to the actual Result instance (see api.extension.Extension). A result without
+            # one never entered that cache, so this positional fallback only keeps activation from
+            # crashing; it cannot resolve to the original Result, and across a streamed request the
+            # batch-local index may even repeat.
+            result_dict.setdefault("__result_id__", index)
             try:
                 result = Result(**result_dict)
             except (KeyError, TypeError, ValueError) as e:
-                logger.warning("Skipping malformed result from extension %s at index %s: %s", ext.id, result_id, e)
+                logger.warning("Skipping malformed result from extension %s at index %s: %s", ext.id, index, e)
                 continue
             result.icon = ext.get_icon_value(result_dict.get("icon"))
-            # The extension keys its result cache by list index, so carry that index back as the
-            # result_id when the result is activated (see api.extension.Extension).
-            result["__result_id__"] = result_id
 
             # Convert legacy actions to the new actions dictionary format
             if not result.actions:

--- a/ulauncher/ui/results_view.py
+++ b/ulauncher/ui/results_view.py
@@ -8,6 +8,7 @@ from gi.repository import Gdk, Gtk
 from ulauncher.utils import scheduling
 
 if TYPE_CHECKING:
+    from ulauncher.internals.query import Query
     from ulauncher.internals.result import Result
     from ulauncher.internals.results_update import ResultsUpdate
     from ulauncher.ui.result_widget import ResultWidget
@@ -21,6 +22,8 @@ class ResultsView(Gtk.ScrolledWindow):
 
     _has_wrapped_results = False
     _index = 0
+    _user_selected = False  # True once the user actively moved the selection (keyboard/mouse)
+    _query = ""
 
     def __init__(self, settings: Settings, apply_css: Callable[[Gtk.Widget], None]) -> None:
         super().__init__(
@@ -45,38 +48,23 @@ class ResultsView(Gtk.ScrolledWindow):
         self.set_property("max-content-height", height)
 
     def render(self, update: ResultsUpdate) -> None:
-        from ulauncher.ui.result_widget import ResultWidget
+        # A new query resets navigation; streamed batches of the same query keep the user's pick.
+        if str(update["query"]) != self._query:
+            self._query = str(update["query"])
+            self._user_selected = False
 
-        self._box.foreach(lambda w: w.destroy())
-        self._widgets = []
-        self._index = 0
+        if update["append"] and self._widgets:
+            self._append_results(update)
+        else:
+            self._replace_results(update)
 
-        jump_keys = self._settings.get_jump_keys()
-        limit = len(jump_keys) or 25
-        result_list = update["results"][:limit]
-        # stock sizing works for single-line results; only wrapped ones need _fit_results_height
-        self._has_wrapped_results = any(result.wrap for result in result_list)
-        if not self._has_wrapped_results:
-            self.set_min_content_height(-1)  # restore stock sizing
+    def get_active_result(self) -> Result | None:
+        selected = self._selected
+        return selected.result if selected else None
 
-        if not result_list:
-            # Hide the scroll container when there are no results since it normally takes up a
-            # minimum amount of space even if it is empty.
-            self.hide()
-            logger.debug("Hiding results container, no results found")
-            return
-
-        for index, result in enumerate(result_list):
-            widget = ResultWidget(result, index, update["query"], jump_keys)
-            self._widgets.append(widget)
-            self._box.add(widget)
-
-        self.select(self._index_for_name(update["selected_name"]))
-        self._box.set_margin_bottom(10)
-        self._box.set_margin_top(3)
-        self._apply_css(self._box)
-        self.show_all()
-        logger.debug("Render %s results", len(self._widgets))
+    def select(self, index: int) -> None:
+        self._select(index)
+        self._user_selected = True
 
     def go_up(self) -> None:
         self.select((self._index or len(self._widgets)) - 1)
@@ -85,11 +73,69 @@ class ResultsView(Gtk.ScrolledWindow):
         next_index = self._index + 1
         self.select(next_index if next_index < len(self._widgets) else 0)
 
-    def get_active_result(self) -> Result | None:
-        selected = self._selected
-        return selected.result if selected else None
+    def _replace_results(self, update: ResultsUpdate) -> None:
+        previous_pick = self.get_active_result() if self._user_selected else None
+        self._box.foreach(lambda w: w.destroy())
+        self._widgets = []
+        self._index = 0
 
-    def select(self, index: int) -> None:
+        result_list = update["results"][: self._limit()]
+        # stock sizing works for single-line results; only wrapped ones need _fit_results_height
+        self._has_wrapped_results = any(result.wrap for result in result_list)
+        if not self._has_wrapped_results:
+            self.set_min_content_height(-1)  # restore stock sizing
+
+        if not result_list:
+            # Hide the scroll container when there are no results since it normally takes up a
+            # minimum amount of space even if it is empty.
+            self._user_selected = False
+            self.hide()
+            logger.debug("Hiding results container, no results found")
+            return
+
+        self._add_widgets(result_list, update["query"], start_index=0)
+        self._apply_selection(update["selected_name"], previous_pick)
+        self._box.set_margin_bottom(10)
+        self._box.set_margin_top(3)
+        self._apply_css(self._box)
+        self.show_all()
+        logger.debug("Render %s results", len(self._widgets))
+
+    def _append_results(self, update: ResultsUpdate) -> None:
+        existing = len(self._widgets)
+        new_results = update["results"][: max(0, self._limit() - existing)]
+        if not new_results:
+            return
+        if any(result.wrap for result in new_results):
+            self._has_wrapped_results = True
+        self._add_widgets(new_results, update["query"], start_index=existing)
+        # keep the user's pick; only (re)evaluate the default when they haven't navigated
+        if not self._user_selected:
+            self._apply_selection(update["selected_name"], None)
+        self._apply_css(self._box)
+        self.show_all()
+        logger.debug("Append %s results (%s total)", len(new_results), len(self._widgets))
+
+    def _add_widgets(self, results: list[Result], query: Query, start_index: int) -> None:
+        from ulauncher.ui.result_widget import ResultWidget
+
+        jump_keys = self._settings.get_jump_keys()
+        for offset, result in enumerate(results):
+            widget = ResultWidget(result, start_index + offset, query, jump_keys)
+            self._widgets.append(widget)
+            self._box.add(widget)
+
+    def _apply_selection(self, selected_name: str | None, previous_pick: Result | None) -> None:
+        # Keep the user's pick across a streaming replace if it is still present.
+        if previous_pick:
+            for index, widget in enumerate(self._widgets):
+                if widget.result.name == previous_pick.name:
+                    self.select(index)
+                    return
+            self._user_selected = False
+        self._select(self._index_for_name(selected_name))
+
+    def _select(self, index: int) -> None:
         if not self._widgets:
             return
         if not 0 <= index < len(self._widgets):
@@ -104,6 +150,9 @@ class ResultsView(Gtk.ScrolledWindow):
         if len(self._widgets) > self._index:
             return self._widgets[self._index]
         return None
+
+    def _limit(self) -> int:
+        return len(self._settings.get_jump_keys()) or 25
 
     def _index_for_name(self, name: str | None) -> int:
         """Index of the first searchable result with this name, or 0 if none matches."""


### PR DESCRIPTION
## Stream results from extensions

### What this does

Today a query handler builds its whole result list, then Ulauncher paints it once. If part of the list is slow (a network call, a big search), the user stares at nothing until everything is ready.

This PR lets results show up in batches. A handler can paint what it has now and add more as it finds it. The user sees the fast results right away.

This is implemented consistently for the app communication. Any mode can send results in batches. Extensions also has the yield shortcut which will now stream results. Nothing changes for handlers that still return a list. They send one batch, same as before. And most extensions using yield already will effectively work the same. It's only if any result takes longer than 50ms that the partial result before it will render.

There is also a new way: yielding result lists will replace the previously rendered results.

If you yield a single item after yielding a list, it appends to the list:

```python
class MyExtension(Extension):
    def on_input(self, query_str, trigger_id):
        # show instant results first
        yield [Result(name="A"), Result(name="B"), Result(name="C")]

        # then add slow ones as they arrive
        for item in fetch_from_network(query_str):
            yield Result(name="D")
```

I'm not 100% sure this is what you want for this case. You might prefer to render a placeholder list like this prematurely and have it replaced by the "actual results", but I think in that case there are other (more fitting/explicit) solutions, for example adding something like `Result(placeholder=True)`.

So to recap: `yield result` appends one. `yield [results]` replaces the list.

### How it behaves

- The first batch of a query always replaces the old list, so stale results never linger.
- Batches that arrive close together are coalesced into one paint (50ms throttle), so streaming does not cause flicker.
- If you've moved the selection, your pick is kept as new batches come in. It is not yanked back to the top.
- If you type again, the in-flight stream is dropped and the new query takes over.

