### PR TITLE
fix(extensions): atomic installs

### DIFF
--- a/ulauncher/modes/extensions/extension_controller.py
+++ b/ulauncher/modes/extensions/extension_controller.py
@@ -4,12 +4,11 @@ import asyncio
 import json
 import logging
 import sys
-import tempfile
 from collections import defaultdict
 from datetime import datetime
 from os.path import isfile, join
 from pathlib import Path
-from shutil import copytree, rmtree
+from shutil import move, rmtree
 from typing import Any, Callable
 
 from ulauncher import cli, paths
@@ -137,6 +136,37 @@ def _load_preferences(ext_id: str) -> JsonConf:
     return JsonConf.load(f"{paths.EXTENSIONS_CONFIG}/{ext_id}.json")
 
 
+def _swap_dir(new_dir: str, target: str) -> bool:
+    """Replace `target` with `new_dir`, rolling back to the original on failure. Returns whether it succeeded."""
+    previous = f"{new_dir}.bak"
+    # A stale .bak would be an existing dir, so move() nests target inside it instead of replacing.
+    rmtree(previous, ignore_errors=True)
+    backed_up = False
+    if Path(target).exists():
+        try:
+            move(target, previous)
+            backed_up = True
+        except OSError:
+            logger.exception("Could not back up the current version of %s; keeping it in place", target)
+            rmtree(new_dir, ignore_errors=True)
+            return False
+    try:
+        move(new_dir, target)
+    except OSError:
+        logger.exception("Could not swap extension into %s; keeping the previous version", target)
+        # A cross-device move can fail after partially creating target; clear it before restoring.
+        rmtree(target, ignore_errors=True)
+        if backed_up:
+            try:
+                move(previous, target)
+            except OSError:
+                logger.exception("Could not restore the previous version of %s; it remains at %s", target, previous)
+        rmtree(new_dir, ignore_errors=True)
+        return False
+    rmtree(previous, ignore_errors=True)
+    return True
+
+
 class ExtensionController:
     """Manages the lifecycle of an extension."""
 
@@ -262,44 +292,40 @@ class ExtensionController:
         events.emit("extension_lifecycle:removed", self.id)
 
     async def _install(self, remote: ExtensionRemote, commit_hash: str | None, **extra_state: Any) -> None:
-        """Download the new version over the extension's directory, stopping the running process first
-        and restoring the previous files if it fails, then record the new commit. A previously-running
-        extension is restarted afterwards on success or failure; a brand-new install was not running, so
-        the caller starts it instead.
+        """Install (atomically): download, stop, swap and restart (if previously running).
 
         `extra_state` is merged into the saved state (install records the source url; update adds nothing).
         """
         target_path = self.path
-        remote.target_dir = target_path
-        existed = Path(target_path).exists()  # noqa: ASYNC240
+        # Fixed path per extension so failed installs don't accumulate.
+        # Concurrent installs of the same id clobber each other (wouldn't have worked anyway).
+        staging_dir = str(Path(paths.EXTENSIONS_STAGING) / self.id)
+        rmtree(staging_dir, ignore_errors=True)
+        Path(staging_dir).mkdir(parents=True)  # noqa: ASYNC240
+        remote.target_dir = staging_dir
         was_running = self.is_running
         try:
-            with tempfile.TemporaryDirectory(prefix="ulauncher_ext_") as backup_dir:
-                if existed:
-                    copytree(target_path, backup_dir, dirs_exist_ok=True)
-                await self.stop()
-                try:
-                    downloaded_hash, commit_timestamp = _run_gio_blocking(
-                        lambda on_success, on_error: remote.download(on_success, on_error, commit_hash)
-                    )
-                    _run_gio_blocking(ExtensionDependencies(remote.ext_id, target_path).install)
-                    self._seed_default_state()
-                    self.state.save(
-                        **extra_state,
-                        browser_url=remote.browser_url or "",
-                        commit_hash=downloaded_hash,
-                        commit_time=datetime.fromtimestamp(commit_timestamp).isoformat(),
-                        updated_at=datetime.now().isoformat(),
-                        error_type="",
-                        error_message="",
-                    )
-                except (ext_exceptions.ExtensionError, OSError):
-                    logger.exception("Could not install extension '%s'; restoring the previous version", self.id)
-                    rmtree(target_path, ignore_errors=True)
-                    if existed:
-                        copytree(backup_dir, target_path, dirs_exist_ok=True)
-                    raise
+            downloaded_hash, commit_timestamp = _run_gio_blocking(
+                lambda on_success, on_error: remote.download(on_success, on_error, commit_hash)
+            )
+            _run_gio_blocking(ExtensionDependencies(remote.ext_id, staging_dir).install)
+            await self.stop()
+            if not _swap_dir(staging_dir, target_path):
+                msg = f"Failed to swap the staged extension into {target_path}"
+                raise OSError(msg)
+            ExtensionManifest.load(target_path, force=True)  # bust the path cache so the swapped-in files win
+            self._seed_default_state()
+            self.state.save(
+                **extra_state,
+                browser_url=remote.browser_url or "",
+                commit_hash=downloaded_hash,
+                commit_time=datetime.fromtimestamp(commit_timestamp).isoformat(),
+                updated_at=datetime.now().isoformat(),
+                error_type="",
+                error_message="",
+            )
         finally:
+            rmtree(staging_dir, ignore_errors=True)
             if was_running:
                 self.start()
 

--- a/ulauncher/paths.py
+++ b/ulauncher/paths.py
@@ -16,6 +16,8 @@ CONFIG = os.path.join(os.environ.get("XDG_CONFIG_HOME", f"{HOME}/.config"), "ula
 DATA = os.path.join(os.environ.get("XDG_DATA_HOME", f"{HOME}/.local/share"), "ulauncher")
 STATE = os.path.join(os.environ.get("XDG_STATE_HOME", f"{HOME}/.local/state"), "ulauncher")
 USER_EXTENSIONS = os.path.join(DATA, "extensions")
+# Sibling of the installed extensions so the post-install swap is a same-filesystem rename.
+EXTENSIONS_STAGING = os.path.join(USER_EXTENSIONS, ".staging")
 ALL_EXTENSIONS_DIRS = [USER_EXTENSIONS, *[os.path.join(p, "ulauncher", "extensions") for p in XDG_DATA_DIRS]]
 EXTENSIONS_CONFIG = os.path.join(CONFIG, "ext_preferences")
 EXTENSIONS_STATE = os.path.join(STATE, "ext_state")

--- a/ulauncher/ui/app.py
+++ b/ulauncher/ui/app.py
@@ -10,7 +10,7 @@ import gi
 from gi.repository import Gdk, Gtk
 
 import ulauncher
-from ulauncher import app_id, first_run
+from ulauncher import app_id, first_run, paths
 from ulauncher.core import UlauncherCore
 from ulauncher.gi import Gio, GLib
 from ulauncher.internals.results_update import ResultsUpdate
@@ -287,6 +287,13 @@ class UlauncherApp(Gtk.Application):
             self.hold() if value else self.release()
             self.toggle_tray_icon(Settings.load().show_tray_icon)
 
+    def cleanup(self) -> None:
+        # Staging dirs left behind when an install was interrupted before its own cleanup ran.
+        from shutil import rmtree
+
+        rmtree(paths.EXTENSIONS_STAGING, ignore_errors=True)
+
     @events.on
     def quit(self) -> None:  # pyrefly: ignore[bad-override]
+        self.cleanup()
         super().quit()

--- a/ulauncher/ui/app.py
+++ b/ulauncher/ui/app.py
@@ -288,10 +288,22 @@ class UlauncherApp(Gtk.Application):
             self.toggle_tray_icon(Settings.load().show_tray_icon)
 
     def _cleanup(self) -> None:
-        # Staging dirs left behind when an install was interrupted before its own cleanup ran.
+        import os
+        import time
+        from contextlib import suppress
         from shutil import rmtree
 
-        rmtree(paths.EXTENSIONS_STAGING, ignore_errors=True)
+        # Prune staging entries, except recent entries (within 1h) since they could be ongoing installs via the cli
+        threshold = time.time() - 3600
+        with suppress(OSError):
+            for e in os.scandir(paths.EXTENSIONS_STAGING):
+                with suppress(OSError):
+                    if e.stat(follow_symlinks=False).st_mtime > threshold:
+                        continue
+                    if e.is_dir(follow_symlinks=False):
+                        rmtree(e.path, ignore_errors=True)
+                    else:
+                        os.unlink(e.path)
 
     @events.on
     def quit(self) -> None:  # pyrefly: ignore[bad-override]

--- a/ulauncher/ui/app.py
+++ b/ulauncher/ui/app.py
@@ -287,7 +287,7 @@ class UlauncherApp(Gtk.Application):
             self.hold() if value else self.release()
             self.toggle_tray_icon(Settings.load().show_tray_icon)
 
-    def cleanup(self) -> None:
+    def _cleanup(self) -> None:
         # Staging dirs left behind when an install was interrupted before its own cleanup ran.
         from shutil import rmtree
 
@@ -295,5 +295,5 @@ class UlauncherApp(Gtk.Application):
 
     @events.on
     def quit(self) -> None:  # pyrefly: ignore[bad-override]
-        self.cleanup()
+        self._cleanup()
         super().quit()

--- a/ulauncher/ui/preferences/utils/ext_handlers.py
+++ b/ulauncher/ui/preferences/utils/ext_handlers.py
@@ -108,7 +108,7 @@ class ExtensionHandlers:
 
                 run_when_idle(update_ui)
 
-            except (ext_exceptions.ExtensionError, ValueError, asyncio.CancelledError) as error:
+            except (ext_exceptions.ExtensionError, ValueError, OSError, asyncio.CancelledError) as error:
 
                 def show_error(error: BaseException) -> None:
                     progress_dialog.destroy()


### PR DESCRIPTION
Stage installs and updates, swap atomically after exit:

_install downloaded straight into the extension's live directory. For a
git-based extension that is a checkout in place, so a still-running process
whose UNLOAD handler lazily imports a module could read half-written files,
and a download that failed partway left the extension corrupted.

Download and build the new version (checkout/extract + pip deps) in a
staging dir first, leaving the live extension untouched and running. Only
once it is fully prepared do we stop the process and swap the new dir into
place. The staging dir lives under USER_EXTENSIONS so the swap is a
same-filesystem rename, and _swap_dir renames the old dir aside first so a
failed swap restores the previous version. A failed download now never
touches the running extension at all.

The manifest is reloaded with force=True after the swap to drop the path
cache, so the swapped-in files win.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Ulauncher/Ulauncher/pull/1765?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

