### PR TITLE
refactor(extension): drop extension registry cache

### DIFF
--- a/tests/modes/apps/extensions/test_extension_registry.py
+++ b/tests/modes/apps/extensions/test_extension_registry.py
@@ -12,13 +12,15 @@ def test_iterate__orders_preview_running_then_rest(mocker: MockerFixture) -> Non
     stopped = SimpleNamespace(id="stopped", is_preview=False, is_enabled=True, is_running=False, has_error=False)
     errored = SimpleNamespace(id="errored", is_preview=False, is_enabled=True, is_running=False, has_error=True)
 
-    controllers = {
-        disabled.id: disabled,
-        stopped.id: stopped,
-        preview.id: preview,
-        errored.id: errored,
-        running.id: running,
-    }
-    mocker.patch.object(extension_registry, "_ext_controllers", controllers)
+    controllers = {c.id: c for c in (disabled, stopped, preview, errored, running)}
+    mocker.patch.object(extension_registry.preview, "ext_id", preview.id)
+    mocker.patch.object(
+        extension_registry.extension_finder,
+        "iterate",
+        return_value=[(c.id, f"/path/{c.id}") for c in controllers.values() if not c.is_preview],
+    )
+    mocker.patch.object(
+        extension_registry, "ExtensionController", side_effect=lambda ext_id, _path: controllers[ext_id]
+    )
 
-    assert list(extension_registry.iterate()) == [preview, running, stopped, errored, disabled]
+    assert list(extension_registry.iterate(sort=True)) == [preview, running, stopped, errored, disabled]

--- a/ulauncher/cli/commands/__init__.py
+++ b/ulauncher/cli/commands/__init__.py
@@ -18,7 +18,7 @@ def get_ext_controller(input_arg: str) -> ExtensionController | None:
         parse_result = parse_extension_url(arg)
         arg = parse_result.ext_id
 
-    return extension_registry.load(arg)
+    return extension_registry.get(arg, include_preview=False)
 
 
 def normalize_ext_arg(path: str) -> str:

--- a/ulauncher/cli/commands/extensions.py
+++ b/ulauncher/cli/commands/extensions.py
@@ -7,7 +7,7 @@ logger = logging.getLogger(__name__)
 
 
 def run(_: CLIArguments) -> int:
-    extensions = list(extension_registry.iterate(include_preview=False))
+    extensions = list(extension_registry.iterate(include_preview=False, sort=True))
     for controller in extensions:
         disabled_label = " [DISABLED]" if not controller.is_enabled else ""
         logger.info("- %s (%s)%s", controller.manifest.name, controller.id, disabled_label)

--- a/ulauncher/cli/commands/extensions.py
+++ b/ulauncher/cli/commands/extensions.py
@@ -7,7 +7,7 @@ logger = logging.getLogger(__name__)
 
 
 def run(_: CLIArguments) -> int:
-    extensions = extension_registry.load_all()
+    extensions = list(extension_registry.iterate(include_preview=False))
     for controller in extensions:
         disabled_label = " [DISABLED]" if not controller.is_enabled else ""
         logger.info("- %s (%s)%s", controller.manifest.name, controller.id, disabled_label)

--- a/ulauncher/cli/commands/upgrade.py
+++ b/ulauncher/cli/commands/upgrade.py
@@ -27,7 +27,7 @@ def _log_url_error(ext_id: str, url: str, *, fatal: bool) -> None:
 async def _upgrade_all_extensions() -> list[str]:
     updated_extensions: list[str] = []
 
-    for controller in extension_registry.load_all():
+    for controller in extension_registry.iterate(include_preview=False):
         if not controller.is_manageable or not controller.state.url:
             continue
 

--- a/ulauncher/modes/extensions/extension_controller.py
+++ b/ulauncher/modes/extensions/extension_controller.py
@@ -202,8 +202,6 @@ class ExtensionController:
         controller = cls(remote.ext_id, remote.target_dir)
         await controller._install(remote, commit_hash, url=url)
         logger.info("Extension %s installed successfully", controller.id)
-        if is_new_install:
-            events.emit("extension_lifecycle:installed", controller)
         return controller
 
     @property

--- a/ulauncher/modes/extensions/extension_mode.py
+++ b/ulauncher/modes/extensions/extension_mode.py
@@ -50,7 +50,7 @@ class ExtensionMode(Mode):
         scheduling.run_when_idle(self._start_extensions)
 
     def _start_extensions(self) -> None:
-        for ext in extension_registry.load_all():
+        for ext in extension_registry.iterate():
             if ext.state.is_enabled:
                 ext.start()
 
@@ -109,7 +109,7 @@ class ExtensionMode(Mode):
         self._send_request(event, callback)
 
     def _iter_enabled_triggers(self) -> Iterator[tuple[ExtensionController, str, ExtensionControllerTrigger]]:
-        for ext in extension_registry.iterate():
+        for ext in extension_registry.iterate(sort=True):
             if not ext.is_enabled:
                 continue
             for trigger_id, trigger in ext.triggers.items():
@@ -206,7 +206,7 @@ class ExtensionMode(Mode):
     ) -> None:
         ext_controllers: list[ExtensionController] = []
         for ext_id in extension_ids:
-            if ext := extension_registry.get(ext_id) or extension_registry.load(ext_id):
+            if ext := extension_registry.get(ext_id):
                 ext_controllers.append(ext)  # noqa: PERF401
 
         # run the reload in a separate thread to avoid blocking the main thread
@@ -424,11 +424,14 @@ class ExtensionMode(Mode):
             return
 
         logger.info("[preview] Stopping preview %s", ext_id)
-        preview.clear()
 
         def restore_original() -> None:
+            # Clear the preview only after its process has stopped, so its exit handler still sees a
+            # preview (and won't persist a stop-time error onto the installed extension), and so the
+            # lookup below resolves the installed controller rather than the preview one.
+            preview.clear()
             # Reload from the installed path, or drop the controller if the extension was never installed.
-            controller = extension_registry.load(ext_id)
+            controller = extension_registry.get(ext_id)
             if controller and controller.is_enabled:
                 self._run_ext_batch_job([ext_id], ["start"])
 

--- a/ulauncher/modes/extensions/extension_mode.py
+++ b/ulauncher/modes/extensions/extension_mode.py
@@ -404,17 +404,13 @@ class ExtensionMode(Mode):
         logger.info("[preview] Previewing ext_id=%s path=%s debugger=%s", ext_id, path, with_debugger)
         preview.set(ext_id, path, with_debugger)
 
-        # Register a controller so a not-yet-installed extension's triggers become available; an
-        # installed one already has one (now launching from the preview path). Restart it so a
-        # background-running installed instance relaunches from the dev path.
-        extension_registry.get(ext_id) or extension_registry.load(ext_id, path)
-
         # Guard the restart against a stop_preview that races in during the stop: only relaunch if
         # this preview is still the active one, otherwise stop_preview owns restoring the extension.
         def start_if_still_previewing() -> None:
             if preview.ext_id == ext_id:
                 self._run_ext_batch_job([ext_id], ["start"])
 
+        # Relaunch from the dev path, stopping any conflicting installed instances
         self._run_ext_batch_job([ext_id], ["stop"], callback=start_if_still_previewing)
 
     @events.on

--- a/ulauncher/modes/extensions/extension_registry.py
+++ b/ulauncher/modes/extensions/extension_registry.py
@@ -10,7 +10,6 @@ from ulauncher.utils.eventbus import EventBus
 events = EventBus("extension_lifecycle")
 
 logger = logging.getLogger(__name__)
-_ext_controllers: dict[str, ExtensionController] = {}
 
 
 def _get_preview_controller() -> ExtensionController | None:
@@ -19,14 +18,21 @@ def _get_preview_controller() -> ExtensionController | None:
     return None
 
 
-def get(ext_id: str) -> ExtensionController | None:
-    if ext_id == preview.ext_id and (preview_ext := _get_preview_controller()):
+def get(ext_id: str, include_preview: bool = True) -> ExtensionController | None:
+    if include_preview and ext_id == preview.ext_id and (preview_ext := _get_preview_controller()):
         return preview_ext
-    return _ext_controllers.get(ext_id)
+    path = extension_finder.locate(ext_id)
+    return ExtensionController(ext_id, path) if path else None
 
 
-def iterate() -> Iterator[ExtensionController]:
-    """Iterate over registered extension controllers."""
+def iterate(sort: bool = False, include_preview: bool = True) -> Iterator[ExtensionController]:
+    controllers = {ext_id: ExtensionController(ext_id, path) for ext_id, path in extension_finder.iterate()}
+    if include_preview and (preview_controller := _get_preview_controller()):
+        controllers[preview_controller.id] = preview_controller
+
+    if not sort:
+        yield from controllers.values()
+        return
 
     def sort_key(controller: ExtensionController) -> int:
         if controller.is_preview:
@@ -39,56 +45,19 @@ def iterate() -> Iterator[ExtensionController]:
             return 2
         return 1  # running
 
-    controllers = dict(_ext_controllers)
-    if preview_controller := _get_preview_controller():
-        controllers[preview_controller.id] = preview_controller
-
     yield from sorted(controllers.values(), key=sort_key)
-
-
-def load(ext_id: str, path: str | None = None) -> ExtensionController | None:
-    """Load an extension controller into the registry without starting it."""
-    if not path:
-        path = extension_finder.locate(ext_id)
-        if not path:
-            # Remove extension from registry if it can no longer be found
-            # This can happen when an extension is deleted via the CLI or manually,
-            # in which case the in-memory registry should reflect that
-            _ext_controllers.pop(ext_id, None)
-            return None
-
-    controller = ExtensionController(ext_id, path)
-    _ext_controllers[ext_id] = controller
-    return controller
-
-
-def load_all() -> list[ExtensionController]:
-    """Load all extensions found by the extension finder into the registry."""
-    for ext_id, ext_path in extension_finder.iterate():
-        load(ext_id, ext_path)
-
-    return list(_ext_controllers.values())
-
-
-@events.on
-def installed(controller: ExtensionController) -> None:
-    """Handle install events dispatched by controllers."""
-    _ext_controllers[controller.id] = controller
 
 
 @events.on
 def removed(ext_id: str) -> None:
     """Handle removal events dispatched by controllers."""
-    _ext_controllers.pop(ext_id, None)
-
-    # If extension still exists after being removed, it means it's a non-manageable extension
-    # Set its state to disabled instead of completely removing it
+    # A still-locatable extension after removal is a non-manageable copy (e.g. distro-packaged).
+    # Disable it rather than let it silently take over the removed extension's id.
     fallback_path = extension_finder.locate(ext_id)
     if fallback_path:
         fallback_controller = ExtensionController(ext_id, fallback_path)
         # TODO: Try to avoid accessing state attribute (we could call toggle_enabled() instead, but that's async)
         fallback_controller.state.save(is_enabled=False)
-        _ext_controllers[ext_id] = fallback_controller
         logger.info(
             "Non-manageable extension with the same id exists in '%s'. It was kept disabled.",
             fallback_path,

--- a/ulauncher/modes/extensions/extension_registry.py
+++ b/ulauncher/modes/extensions/extension_registry.py
@@ -4,7 +4,7 @@ import logging
 from typing import Iterator
 
 from ulauncher.modes.extensions import extension_finder
-from ulauncher.modes.extensions.extension_controller import ExtensionController
+from ulauncher.modes.extensions.extension_controller import ExtensionController, preview
 from ulauncher.utils.eventbus import EventBus
 
 events = EventBus("extension_lifecycle")
@@ -13,7 +13,15 @@ logger = logging.getLogger(__name__)
 _ext_controllers: dict[str, ExtensionController] = {}
 
 
+def _get_preview_controller() -> ExtensionController | None:
+    if preview.ext_id:
+        return ExtensionController(preview.ext_id, preview.path)
+    return None
+
+
 def get(ext_id: str) -> ExtensionController | None:
+    if ext_id == preview.ext_id and (preview_ext := _get_preview_controller()):
+        return preview_ext
     return _ext_controllers.get(ext_id)
 
 
@@ -31,7 +39,11 @@ def iterate() -> Iterator[ExtensionController]:
             return 2
         return 1  # running
 
-    yield from sorted(_ext_controllers.values(), key=sort_key)
+    controllers = dict(_ext_controllers)
+    if preview_controller := _get_preview_controller():
+        controllers[preview_controller.id] = preview_controller
+
+    yield from sorted(controllers.values(), key=sort_key)
 
 
 def load(ext_id: str, path: str | None = None) -> ExtensionController | None:

--- a/ulauncher/ui/preferences/views/extensions.py
+++ b/ulauncher/ui/preferences/views/extensions.py
@@ -26,7 +26,7 @@ from ulauncher.utils import scheduling
 from ulauncher.utils.launch_detached import open_detached
 
 logger = logging.getLogger(__name__)
-REFRESH_INTERVAL = 0.25
+REFRESH_INTERVAL = 1
 
 
 class ExtensionsView(BaseView):

--- a/ulauncher/ui/preferences/views/extensions.py
+++ b/ulauncher/ui/preferences/views/extensions.py
@@ -79,7 +79,7 @@ class ExtensionsView(BaseView):
     def _list_has_changes(self) -> bool:
         extension_cache: dict[str, tuple[str, ext_utils.ExtStatus, str | None]] = {}
 
-        for ext in extension_registry.iterate():
+        for ext in extension_registry.iterate(sort=True):
             extension_cache[ext.id] = (
                 ext.manifest.name,
                 ext_utils.get_status_str(ext),

--- a/ulauncher/utils/migrate.py
+++ b/ulauncher/utils/migrate.py
@@ -74,7 +74,7 @@ def _migrate_user_prefs(ext_id: str, user_prefs: dict[str, dict[str, Any]]) -> d
 
     preferences: dict[str, Any] = {}
     triggers: dict[str, Any] = {}
-    controller = extension_registry.load(ext_id)
+    controller = extension_registry.get(ext_id, include_preview=False)
     for p_id, pref in user_prefs.items():
         try:
             if controller and controller.manifest.triggers.get(p_id):


### PR DESCRIPTION
I'm calling this a refactor but it's really a fix and a refactor.

## Why

The registry kept an in-memory dict of controllers that callers had to populate (load/load_all) before reading (get/iterate), and keep in sync on install and removal. This was confusing to use. It meant that the callers had to be aware of the caching model inside of the extension registry, which is both a code smell and a footgun imo: read without loading and you get nothing or stale data, and the app is not the only process managing extensions (the CLI does too over D-Bus, and distros can package them), so the cache could silently disagree with what is on disk.

The names `load()` and `load_all()` could also easily be misunderstood as loading the extensions runtime (eg starting them), rather than just loading the data into ExtensionControllers.

But it was also an active bug, because it assumes we can actually know that there have been no changes to the extensions since last time we loaded, and the user could have installed an extension through their package manager or copied it manually to the non-managed extension dirs.

## What

1. Removed the cache and all places reading from or writing to it.
2. Removed the `extension_lifecycle:installed` event and its handler are gone (no longer useful).
3. Removed `get` and `iterate`, and renamed `load` and and `load_all` to become the new `get` and `iterate`. The new `iterate` now takes an optional `sort` flag for optional sorting like the old iterate. Most callers do not need the display ordering.
4. Added sorted output for the ulauncher extension list command. d1a2ff8a
5. Furthermore, both methods take include_preview (default `True`) so that it's possible to opt out (primarily from the CLI methods). This doesn't effectively matter since the preview extension state object lives in the app runtime only.
6. Extension list in preferences UI now refresh once every second instead if 4 times per second, given it does a file system scan each time 4 times per second felt crazy. Once per second might be too.

This of course will make these operations slightly slower, but I it's in microseconds, and doesn't affect the boot time. Further optimizations might come.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Ulauncher/Ulauncher/pull/1767?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

