### PR TITLE
refactor: clarify extension runtime ownership

### DIFF
--- a/tests/modes/apps/extensions/test_extension_controller.py
+++ b/tests/modes/apps/extensions/test_extension_controller.py
@@ -1,0 +1,21 @@
+import pytest
+from pytest_mock import MockerFixture
+
+from ulauncher.modes.extensions.extension_controller import ExtensionController, supervisor
+
+
+@pytest.fixture(autouse=True)
+def unclaimed_supervisor(mocker: MockerFixture) -> None:
+    mocker.patch.object(supervisor, "is_owner", False)
+
+
+def test_start__raises_when_process_does_not_own_extension_runtimes() -> None:
+    controller = ExtensionController("test.guard", "/nonexistent")
+    with pytest.raises(RuntimeError):
+        controller.start()
+
+
+def test_send_message__raises_when_process_does_not_own_extension_runtimes() -> None:
+    controller = ExtensionController("test.guard", "/nonexistent")
+    with pytest.raises(RuntimeError):
+        controller.send_message({"type": "event:unload"})

--- a/tests/modes/apps/extensions/test_extension_registry.py
+++ b/tests/modes/apps/extensions/test_extension_registry.py
@@ -12,7 +12,7 @@ def test_iterate__orders_preview_enabled_error_disabled(mocker: MockerFixture) -
     disabled = SimpleNamespace(id="disabled", is_preview=False, is_enabled=False, has_error=False)
 
     controllers = {c.id: c for c in (disabled, errored, preview, enabled)}
-    mocker.patch.object(extension_registry.preview, "ext_id", preview.id)
+    mocker.patch.object(extension_registry.supervisor.preview, "ext_id", preview.id)
     mocker.patch.object(
         extension_registry.extension_finder,
         "iterate",

--- a/ulauncher/modes/extensions/extension_controller.py
+++ b/ulauncher/modes/extensions/extension_controller.py
@@ -4,7 +4,6 @@ import asyncio
 import json
 import logging
 import sys
-from collections import defaultdict
 from datetime import datetime
 from os.path import isfile, join
 from pathlib import Path
@@ -23,6 +22,7 @@ from ulauncher.modes.extensions.extension_manifest import (
 )
 from ulauncher.modes.extensions.extension_remote import ExtensionRemote
 from ulauncher.modes.extensions.extension_runtime import ExtensionRuntime
+from ulauncher.modes.extensions.extension_supervisor import supervisor
 from ulauncher.utils.eventbus import EventBus
 from ulauncher.utils.json_utils import json_load
 
@@ -62,35 +62,8 @@ class ExtensionState(JsonConf):
 
 
 logger = logging.getLogger(__name__)
-extension_runtimes: dict[str, ExtensionRuntime] = {}
-stopped_listeners: dict[str, list[Callable[[], None]]] = defaultdict(list)
 
 events = EventBus()
-
-
-class PreviewExtension:
-    """The single extension currently being previewed from a dev path via the CLI, if any.
-
-    Only one runs at a time (the debugger binds a fixed port). While active, the controller whose id
-    matches launches from `path` (with `with_debugger`) instead of its installed location.
-    """
-
-    ext_id: str | None = None
-    path: str = ""
-    with_debugger: bool = False
-
-    def set(self, ext_id: str, path: str, with_debugger: bool) -> None:
-        self.ext_id = ext_id
-        self.path = path
-        self.with_debugger = with_debugger
-
-    def clear(self) -> None:
-        self.ext_id = None
-        self.path = ""
-        self.with_debugger = False
-
-
-preview = PreviewExtension()
 
 
 def _run_gio_blocking(start: Callable[[Callable[[Any], None], Callable[[Exception], None]], None]) -> Any:
@@ -206,13 +179,13 @@ class ExtensionController:
 
     @property
     def is_preview(self) -> bool:
-        return preview.ext_id == self.id
+        return supervisor.preview.ext_id == self.id
 
     @property
     def source_path(self) -> str:
         """Where to load and launch the extension from: the dev path while it is being previewed,
         otherwise `self.path`."""
-        return preview.path if self.is_preview else self.path
+        return supervisor.preview.path if self.is_preview else self.path
 
     @property
     def manifest(self) -> ExtensionManifest:
@@ -230,7 +203,7 @@ class ExtensionController:
     @property
     def owns_runtime(self) -> bool:
         """Whether the extension is running and owned by the current runtime (always False outside of the app)."""
-        return self.id in extension_runtimes
+        return self.id in supervisor.runtimes
 
     @property
     def is_manageable(self) -> bool:
@@ -377,7 +350,7 @@ class ExtensionController:
             return True  # if already started, count as successful
 
         def exit_handler(cause: str, error_msg: str) -> None:
-            listeners = stopped_listeners.get(self.id, [])
+            listeners = supervisor.stopped_listeners.get(self.id, [])
             for stop_listener in listeners:
                 stop_listener()
 
@@ -385,7 +358,7 @@ class ExtensionController:
 
             if cause != "Stopped":
                 logger.error('Extension "%s" exited with an error: %s (%s)', self.id, error_msg, cause)
-                extension_runtimes.pop(self.id, None)
+                supervisor.runtimes.pop(self.id, None)
                 # A failing preview must not disable the installed extension by persisting its error.
                 if not self.is_preview:
                     self.state.save(error_type=cause, error_message=error_msg)
@@ -410,7 +383,7 @@ class ExtensionController:
         cmd = [sys.executable, extension_main]
 
         # Preview extensions can opt into the remote debugger
-        if self.is_preview and preview.with_debugger:
+        if self.is_preview and supervisor.preview.with_debugger:
             cmd = [
                 sys.executable,
                 "-m",
@@ -438,7 +411,7 @@ class ExtensionController:
         # surfaced consistently and any queued start listeners get cleaned up, rather than
         # raising out into callers.
         try:
-            extension_runtimes[self.id] = ExtensionRuntime(self.id, cmd, env, exit_handler)
+            supervisor.runtimes[self.id] = ExtensionRuntime(self.id, cmd, env, exit_handler)
         except (OSError, GLib.Error) as err:
             exit_handler("FailedToStart", str(err))
             return False
@@ -446,9 +419,9 @@ class ExtensionController:
         return self.owns_runtime
 
     async def stop(self) -> None:
-        if runtime := extension_runtimes.pop(self.id, None):
+        if runtime := supervisor.runtimes.pop(self.id, None):
             stopped_future: asyncio.Future[None] = asyncio.Future()
-            stopped_listeners[self.id].append(lambda: stopped_future.set_result(None))
+            supervisor.stopped_listeners[self.id].append(lambda: stopped_future.set_result(None))
             runtime.stop()
 
             await asyncio.wait_for(stopped_future, timeout=5.0)
@@ -457,5 +430,5 @@ class ExtensionController:
         """
         Sends a JSON message to the extension if it is running.
         """
-        if runtime := extension_runtimes.get(self.id):
+        if runtime := supervisor.runtimes.get(self.id):
             runtime.send_message(message, request_id)

--- a/ulauncher/modes/extensions/extension_controller.py
+++ b/ulauncher/modes/extensions/extension_controller.py
@@ -203,7 +203,8 @@ class ExtensionController:
     @property
     def owns_runtime(self) -> bool:
         """Whether the extension is running and owned by the current runtime (always False outside of the app)."""
-        return self.id in supervisor.runtimes
+        # supervisor.is_owner check for making the behavior/contract explicit, but not actually needed
+        return supervisor.is_owner and self.id in supervisor.runtimes
 
     @property
     def is_manageable(self) -> bool:
@@ -346,6 +347,10 @@ class ExtensionController:
         Starts the extension in a subprocess
         Returns True if the extension was already running or successfully started, False otherwise.
         """
+        if not supervisor.is_owner:
+            msg = "Only the app process can start extensions. Ask it to via a D-Bus event ('extensions:reload')."
+            raise RuntimeError(msg)
+
         if self.owns_runtime:
             return True  # if already started, count as successful
 
@@ -419,6 +424,8 @@ class ExtensionController:
         return self.owns_runtime
 
     async def stop(self) -> None:
+        """Stops the extension process if this process owns one. Intentionally a no-op elsewhere
+        (the CLI): remote runtimes are stopped by sending D-Bus events to the app instead."""
         if runtime := supervisor.runtimes.pop(self.id, None):
             stopped_future: asyncio.Future[None] = asyncio.Future()
             supervisor.stopped_listeners[self.id].append(lambda: stopped_future.set_result(None))
@@ -430,5 +437,9 @@ class ExtensionController:
         """
         Sends a JSON message to the extension if it is running.
         """
+        if not supervisor.is_owner:
+            msg = "Only the app process can message extensions."
+            raise RuntimeError(msg)
+
         if runtime := supervisor.runtimes.get(self.id):
             runtime.send_message(message, request_id)

--- a/ulauncher/modes/extensions/extension_mode.py
+++ b/ulauncher/modes/extensions/extension_mode.py
@@ -15,8 +15,8 @@ from ulauncher.modes.extensions import extension_registry
 from ulauncher.modes.extensions.extension_controller import (
     ExtensionController,
     ExtensionControllerTrigger,
-    preview,
 )
+from ulauncher.modes.extensions.extension_supervisor import supervisor
 from ulauncher.modes.mode import Mode
 from ulauncher.utils import scheduling
 from ulauncher.utils.eventbus import EventBus
@@ -402,12 +402,12 @@ class ExtensionMode(Mode):
         """
 
         logger.info("[preview] Previewing ext_id=%s path=%s debugger=%s", ext_id, path, with_debugger)
-        preview.set(ext_id, path, with_debugger)
+        supervisor.preview.set(ext_id, path, with_debugger)
 
         # Guard the restart against a stop_preview that races in during the stop: only relaunch if
         # this preview is still the active one, otherwise stop_preview owns restoring the extension.
         def start_if_still_previewing() -> None:
-            if preview.ext_id == ext_id:
+            if supervisor.preview.ext_id == ext_id:
                 self._run_ext_batch_job([ext_id], ["start"])
 
         # Relaunch from the dev path, stopping any conflicting installed instances
@@ -417,7 +417,7 @@ class ExtensionMode(Mode):
     def stop_preview(self) -> None:
         """Stop the active preview and restore the installed extension. Triggered from the CLI via D-Bus"""
 
-        ext_id = preview.ext_id
+        ext_id = supervisor.preview.ext_id
         if not ext_id:
             # will happen if preview is interrupted before started
             logger.debug("[preview] Ignoring stop_preview; no preview active")
@@ -429,7 +429,7 @@ class ExtensionMode(Mode):
             # Clear the preview only after its process has stopped, so its exit handler still sees a
             # preview (and won't persist a stop-time error onto the installed extension), and so the
             # lookup below resolves the installed controller rather than the preview one.
-            preview.clear()
+            supervisor.preview.clear()
             # Reload from the installed path, or drop the controller if the extension was never installed.
             controller = extension_registry.get(ext_id)
             if controller and controller.is_enabled:

--- a/ulauncher/modes/extensions/extension_mode.py
+++ b/ulauncher/modes/extensions/extension_mode.py
@@ -45,6 +45,7 @@ class ExtensionMode(Mode):
     _request_id: int = 0
 
     def __init__(self) -> None:
+        supervisor.claim_ownership()
         self._trigger_cache = {}
         events.set_self(self)
         scheduling.run_when_idle(self._start_extensions)

--- a/ulauncher/modes/extensions/extension_registry.py
+++ b/ulauncher/modes/extensions/extension_registry.py
@@ -4,7 +4,8 @@ import logging
 from typing import Iterator
 
 from ulauncher.modes.extensions import extension_finder
-from ulauncher.modes.extensions.extension_controller import ExtensionController, preview
+from ulauncher.modes.extensions.extension_controller import ExtensionController
+from ulauncher.modes.extensions.extension_supervisor import supervisor
 from ulauncher.utils.eventbus import EventBus
 
 events = EventBus("extension_lifecycle")
@@ -13,13 +14,14 @@ logger = logging.getLogger(__name__)
 
 
 def _get_preview_controller() -> ExtensionController | None:
+    preview = supervisor.preview
     if preview.ext_id:
         return ExtensionController(preview.ext_id, preview.path)
     return None
 
 
 def get(ext_id: str, include_preview: bool = True) -> ExtensionController | None:
-    if include_preview and ext_id == preview.ext_id and (preview_ext := _get_preview_controller()):
+    if include_preview and ext_id == supervisor.preview.ext_id and (preview_ext := _get_preview_controller()):
         return preview_ext
     path = extension_finder.locate(ext_id)
     return ExtensionController(ext_id, path) if path else None

--- a/ulauncher/modes/extensions/extension_supervisor.py
+++ b/ulauncher/modes/extensions/extension_supervisor.py
@@ -1,0 +1,50 @@
+from __future__ import annotations
+
+from collections import defaultdict
+from typing import TYPE_CHECKING, Callable
+
+if TYPE_CHECKING:
+    from ulauncher.modes.extensions.extension_runtime import ExtensionRuntime
+
+
+class PreviewExtension:
+    """The single extension currently being previewed from a dev path via the CLI, if any.
+
+    Only one runs at a time (the debugger binds a fixed port). While active, the controller whose id
+    matches launches from `path` (with `with_debugger`) instead of its installed location.
+    """
+
+    ext_id: str | None = None
+    path: str = ""
+    with_debugger: bool = False
+
+    def set(self, ext_id: str, path: str, with_debugger: bool) -> None:
+        self.ext_id = ext_id
+        self.path = path
+        self.with_debugger = with_debugger
+
+    def clear(self) -> None:
+        self.ext_id = None
+        self.path = ""
+        self.with_debugger = False
+
+
+class ExtensionSupervisor:
+    """Holds the extension processes owned by this process.
+
+    Only the app process ever owns extension processes. Other processes importing this module
+    (the CLI) see it empty: previews and running extensions live in the app, and the CLI asks
+    the app to reconcile via D-Bus events ("extensions:reload", "extensions:stop", ...).
+    """
+
+    runtimes: dict[str, ExtensionRuntime]
+    stopped_listeners: dict[str, list[Callable[[], None]]]
+    preview: PreviewExtension
+
+    def __init__(self) -> None:
+        self.runtimes = {}
+        self.stopped_listeners = defaultdict(list)
+        self.preview = PreviewExtension()
+
+
+supervisor = ExtensionSupervisor()

--- a/ulauncher/modes/extensions/extension_supervisor.py
+++ b/ulauncher/modes/extensions/extension_supervisor.py
@@ -32,19 +32,25 @@ class PreviewExtension:
 class ExtensionSupervisor:
     """Holds the extension processes owned by this process.
 
-    Only the app process ever owns extension processes. Other processes importing this module
-    (the CLI) see it empty: previews and running extensions live in the app, and the CLI asks
-    the app to reconcile via D-Bus events ("extensions:reload", "extensions:stop", ...).
+    Only the app process claims ownership and may spawn extension processes. Other processes
+    importing this module (the CLI) see it empty and unclaimed: previews and running extensions
+    live in the app, and the CLI asks the app to reconcile via D-Bus events
+    ("extensions:reload", "extensions:stop", ...).
     """
 
     runtimes: dict[str, ExtensionRuntime]
     stopped_listeners: dict[str, list[Callable[[], None]]]
     preview: PreviewExtension
+    is_owner: bool
 
     def __init__(self) -> None:
         self.runtimes = {}
         self.stopped_listeners = defaultdict(list)
         self.preview = PreviewExtension()
+        self.is_owner = False
+
+    def claim_ownership(self) -> None:
+        self.is_owner = True
 
 
 supervisor = ExtensionSupervisor()


### PR DESCRIPTION
Clarify the ownership model some more by creating a new ExtensionSupervisor class, to hold the extension runtime state. And require claiming ownership in order to run the methods that should never run outside of the app runtime.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Ulauncher/Ulauncher/pull/1768?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

