### PR TITLE
refactor(ext): make the preview state optional and encapsulate it

### DIFF
--- a/tests/modes/extensions/test_extension_registry.py
+++ b/tests/modes/extensions/test_extension_registry.py
@@ -3,20 +3,21 @@ from types import SimpleNamespace
 from pytest_mock import MockerFixture
 
 from ulauncher.modes.extensions import extension_registry
+from ulauncher.modes.extensions.extension_controller import PreviewExtensionController
 
 
 def test_iterate__orders_preview_enabled_error_disabled(mocker: MockerFixture) -> None:
-    preview = SimpleNamespace(id="preview", is_preview=True, is_enabled=True, has_error=False)
+    preview = PreviewExtensionController(ext_id="preview", path="/path/preview")
     enabled = SimpleNamespace(id="enabled", is_preview=False, is_enabled=True, has_error=False)
     errored = SimpleNamespace(id="errored", is_preview=False, is_enabled=True, has_error=True)
     disabled = SimpleNamespace(id="disabled", is_preview=False, is_enabled=False, has_error=False)
 
-    controllers = {c.id: c for c in (disabled, errored, preview, enabled)}
-    mocker.patch.object(extension_registry.supervisor.preview, "ext_id", preview.id)
+    controllers = {c.id: c for c in (disabled, errored, enabled)}
+    mocker.patch.object(extension_registry.supervisor, "_preview", preview)
     mocker.patch.object(
         extension_registry.extension_finder,
         "iterate",
-        return_value=[(c.id, f"/path/{c.id}") for c in controllers.values() if not c.is_preview],
+        return_value=[(c.id, f"/path/{c.id}") for c in controllers.values()],
     )
     mocker.patch.object(
         extension_registry, "ExtensionController", side_effect=lambda ext_id, _path: controllers[ext_id]

--- a/ulauncher/modes/extensions/extension_controller.py
+++ b/ulauncher/modes/extensions/extension_controller.py
@@ -176,13 +176,13 @@ class ExtensionController:
 
     @property
     def is_preview(self) -> bool:
-        return supervisor.preview.ext_id == self.id
+        return supervisor.get_preview(self.id) is not None
 
     @property
     def source_path(self) -> str:
         """Where to load and launch the extension from: the dev path while it is being previewed,
         otherwise `self.path`."""
-        return supervisor.preview.path if self.is_preview else self.path
+        return preview.path if (preview := supervisor.get_preview(self.id)) else self.path
 
     @property
     def manifest(self) -> ExtensionManifest:
@@ -396,7 +396,7 @@ class ExtensionController:
         cmd = [sys.executable, extension_main]
 
         # Preview extensions can opt into the remote debugger
-        if self.is_preview and supervisor.preview.with_debugger:
+        if (preview_ext := supervisor.get_preview(self.id)) and preview_ext.with_debugger:
             cmd = [
                 sys.executable,
                 "-m",
@@ -451,3 +451,17 @@ class ExtensionController:
 
         if runtime := supervisor.runtimes.get(self.id):
             runtime.send_message(message, request_id)
+
+
+class PreviewExtensionController(ExtensionController):
+    """An extension being previewed from a dev path via the CLI.
+
+    Only one runs at a time (the debugger binds a fixed port). This controller launches from the dev
+    `path` (with `with_debugger`) instead of the extension's installed location.
+    """
+
+    with_debugger = False
+
+    def __init__(self, ext_id: str, path: str, with_debugger: bool = False) -> None:
+        super().__init__(ext_id, path)
+        self.with_debugger = with_debugger

--- a/ulauncher/modes/extensions/extension_mode.py
+++ b/ulauncher/modes/extensions/extension_mode.py
@@ -389,12 +389,12 @@ class ExtensionMode(Mode):
         """
 
         logger.info("[preview] Previewing ext_id=%s path=%s debugger=%s", ext_id, path, with_debugger)
-        supervisor.preview.set(ext_id, path, with_debugger)
+        supervisor.set_preview(ext_id, path, with_debugger)
 
         # Guard the restart against a stop_preview that races in during the stop: only relaunch if
         # this preview is still the active one, otherwise stop_preview owns restoring the extension.
         def start_if_still_previewing() -> None:
-            if supervisor.preview.ext_id == ext_id:
+            if supervisor.get_preview(ext_id):
                 self._run_ext_batch_job([ext_id], ["start"])
 
         # Relaunch from the dev path, stopping any conflicting installed instances
@@ -404,22 +404,22 @@ class ExtensionMode(Mode):
     def stop_preview(self) -> None:
         """Stop the active preview and restore the installed extension. Triggered from the CLI via D-Bus"""
 
-        ext_id = supervisor.preview.ext_id
-        if not ext_id:
+        preview_ext = supervisor.get_preview()
+        if not preview_ext:
             # will happen if preview is interrupted before started
             logger.debug("[preview] Ignoring stop_preview; no preview active")
             return
 
-        logger.info("[preview] Stopping preview %s", ext_id)
+        logger.info("[preview] Stopping preview %s", preview_ext.id)
 
         def restore_original() -> None:
-            # Clear the preview only after its process has stopped, so its exit handler still sees a
+            # Drop the preview only after its process has stopped, so its exit handler still sees a
             # preview (and won't persist a stop-time error onto the installed extension), and so the
             # lookup below resolves the installed controller rather than the preview one.
-            supervisor.preview.clear()
+            supervisor.clear_preview()
             # Reload from the installed path, or drop the controller if the extension was never installed.
-            controller = extension_registry.get(ext_id)
+            controller = extension_registry.get(preview_ext.id)
             if controller and controller.is_enabled:
-                self._run_ext_batch_job([ext_id], ["start"])
+                self._run_ext_batch_job([preview_ext.id], ["start"])
 
-        self._run_ext_batch_job([ext_id], ["stop"], callback=restore_original)
+        self._run_ext_batch_job([preview_ext.id], ["stop"], callback=restore_original)

--- a/ulauncher/modes/extensions/extension_registry.py
+++ b/ulauncher/modes/extensions/extension_registry.py
@@ -9,19 +9,11 @@ from ulauncher.modes.extensions.extension_supervisor import supervisor
 from ulauncher.utils.eventbus import EventBus
 
 events = EventBus("extension_lifecycle")
-
 logger = logging.getLogger(__name__)
 
 
-def _get_preview_controller() -> ExtensionController | None:
-    preview = supervisor.preview
-    if preview.ext_id:
-        return ExtensionController(preview.ext_id, preview.path)
-    return None
-
-
 def get(ext_id: str, include_preview: bool = True) -> ExtensionController | None:
-    if include_preview and ext_id == supervisor.preview.ext_id and (preview_ext := _get_preview_controller()):
+    if include_preview and (preview_ext := supervisor.get_preview(ext_id)):
         return preview_ext
     path = extension_finder.locate(ext_id)
     return ExtensionController(ext_id, path) if path else None
@@ -29,8 +21,8 @@ def get(ext_id: str, include_preview: bool = True) -> ExtensionController | None
 
 def iterate(sort: bool = False, include_preview: bool = True) -> Iterator[ExtensionController]:
     controllers = {ext_id: ExtensionController(ext_id, path) for ext_id, path in extension_finder.iterate()}
-    if include_preview and (preview_controller := _get_preview_controller()):
-        controllers[preview_controller.id] = preview_controller
+    if include_preview and (preview_ext := supervisor.get_preview()):
+        controllers[preview_ext.id] = preview_ext
 
     if not sort:
         yield from controllers.values()

--- a/ulauncher/modes/extensions/extension_supervisor.py
+++ b/ulauncher/modes/extensions/extension_supervisor.py
@@ -4,29 +4,8 @@ from collections import defaultdict
 from typing import TYPE_CHECKING, Callable
 
 if TYPE_CHECKING:
+    from ulauncher.modes.extensions.extension_controller import PreviewExtensionController
     from ulauncher.modes.extensions.extension_runtime import ExtensionRuntime
-
-
-class PreviewExtension:
-    """The single extension currently being previewed from a dev path via the CLI, if any.
-
-    Only one runs at a time (the debugger binds a fixed port). While active, the controller whose id
-    matches launches from `path` (with `with_debugger`) instead of its installed location.
-    """
-
-    ext_id: str | None = None
-    path: str = ""
-    with_debugger: bool = False
-
-    def set(self, ext_id: str, path: str, with_debugger: bool) -> None:
-        self.ext_id = ext_id
-        self.path = path
-        self.with_debugger = with_debugger
-
-    def clear(self) -> None:
-        self.ext_id = None
-        self.path = ""
-        self.with_debugger = False
 
 
 class ExtensionSupervisor:
@@ -40,17 +19,31 @@ class ExtensionSupervisor:
 
     runtimes: dict[str, ExtensionRuntime]
     stopped_listeners: dict[str, list[Callable[[], None]]]
-    preview: PreviewExtension
+    _preview: PreviewExtensionController | None
     is_owner: bool
 
     def __init__(self) -> None:
         self.runtimes = {}
         self.stopped_listeners = defaultdict(list)
-        self.preview = PreviewExtension()
+        self._preview = None
         self.is_owner = False
 
     def claim_ownership(self) -> None:
         self.is_owner = True
+
+    def get_preview(self, ext_id: str | None = None) -> PreviewExtensionController | None:
+        """The active preview, or None. When `ext_id` is given, return it only if it targets that extension."""
+        if self._preview and (ext_id is None or self._preview.id == ext_id):
+            return self._preview
+        return None
+
+    def set_preview(self, ext_id: str, path: str, with_debugger: bool = False) -> None:
+        from ulauncher.modes.extensions.extension_controller import PreviewExtensionController
+
+        self._preview = PreviewExtensionController(ext_id=ext_id, path=path, with_debugger=with_debugger)
+
+    def clear_preview(self) -> None:
+        self._preview = None
 
 
 supervisor = ExtensionSupervisor()


### PR DESCRIPTION
The preview is now a PreviewExtensionController, a subclass of ExtensionController, and is None when nothing is being previewed. This replaces the set/clear methods and the "ext_id is None means inactive" convention. Because the preview is itself a controller, callers get it back directly instead of constructing one from a separate data holder's fields.

ExtensionSupervisor owns the preview behind get_preview/set_preview/clear_preview. get_preview takes an optional ext_id and returns the preview only when it targets that extension, so the "preview targets this id" check lives in one place and callers no longer touch the field.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Ulauncher/Ulauncher/pull/1769?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

