### PR TITLE
fix(ext): don't stop a running preview when installing or updating matching extension

### DIFF
--- a/ulauncher/modes/extensions/extension_controller.py
+++ b/ulauncher/modes/extensions/extension_controller.py
@@ -284,13 +284,14 @@ class ExtensionController:
         rmtree(staging_dir, ignore_errors=True)
         Path(staging_dir).mkdir(parents=True)  # noqa: ASYNC240
         remote.target_dir = staging_dir
-        # keep preview extensions alive (they run from the dev paths, unaffected by installs)
-        should_restart = self.owns_runtime and not self.is_preview
+        should_restart = False
         try:
             downloaded_hash, commit_timestamp = _run_gio_blocking(
                 lambda on_success, on_error: remote.download(on_success, on_error, commit_hash)
             )
             _run_gio_blocking(ExtensionDependencies(remote.ext_id, staging_dir).install)
+            # preview extensions need not and should not be restarted (they run from the dev paths)
+            should_restart = self.owns_runtime and not self.is_preview
             if should_restart:
                 await self.stop()
             if not _swap_dir(staging_dir, target_path):

--- a/ulauncher/modes/extensions/extension_controller.py
+++ b/ulauncher/modes/extensions/extension_controller.py
@@ -284,15 +284,20 @@ class ExtensionController:
         rmtree(staging_dir, ignore_errors=True)
         Path(staging_dir).mkdir(parents=True)  # noqa: ASYNC240
         remote.target_dir = staging_dir
-        should_restart = False
+        was_running = False
+
+        def _should_restart() -> bool:
+            # a preview extension need not and should not be restarted (runs from dev path)
+            return was_running and not self.is_preview
+
         try:
             downloaded_hash, commit_timestamp = _run_gio_blocking(
                 lambda on_success, on_error: remote.download(on_success, on_error, commit_hash)
             )
             _run_gio_blocking(ExtensionDependencies(remote.ext_id, staging_dir).install)
-            # preview extensions need not and should not be restarted (they run from the dev paths)
-            should_restart = self.owns_runtime and not self.is_preview
-            if should_restart:
+
+            was_running = self.owns_runtime
+            if _should_restart():
                 await self.stop()
             if not _swap_dir(staging_dir, target_path):
                 msg = f"Failed to swap the staged extension into {target_path}"
@@ -310,7 +315,7 @@ class ExtensionController:
             )
         finally:
             rmtree(staging_dir, ignore_errors=True)
-            if should_restart:
+            if _should_restart():
                 self.start()
 
     async def update(self) -> bool:

--- a/ulauncher/modes/extensions/extension_controller.py
+++ b/ulauncher/modes/extensions/extension_controller.py
@@ -284,13 +284,15 @@ class ExtensionController:
         rmtree(staging_dir, ignore_errors=True)
         Path(staging_dir).mkdir(parents=True)  # noqa: ASYNC240
         remote.target_dir = staging_dir
-        should_restart_after_swap = self.owns_runtime
+        # keep preview extensions alive (they run from the dev paths, unaffected by installs)
+        should_restart = self.owns_runtime and not self.is_preview
         try:
             downloaded_hash, commit_timestamp = _run_gio_blocking(
                 lambda on_success, on_error: remote.download(on_success, on_error, commit_hash)
             )
             _run_gio_blocking(ExtensionDependencies(remote.ext_id, staging_dir).install)
-            await self.stop()
+            if should_restart:
+                await self.stop()
             if not _swap_dir(staging_dir, target_path):
                 msg = f"Failed to swap the staged extension into {target_path}"
                 raise OSError(msg)
@@ -307,7 +309,7 @@ class ExtensionController:
             )
         finally:
             rmtree(staging_dir, ignore_errors=True)
-            if should_restart_after_swap:
+            if should_restart:
                 self.start()
 
     async def update(self) -> bool:


### PR DESCRIPTION
When preview extensions are running, they should override any installed extensions with a matching id.

But when installing or updating an extension with a matching id as a preview extension, it currently stops the preview, then starts the newly updated/installed extension (as a result of the atomic installs, although I think it predates #1765 for updates).

Also simplify `should_restart_after_swap` to just `should_restart`and reuse it to guard both the stop and start calls.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Ulauncher/Ulauncher/pull/1770?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

