### PR TITLE
fix(ext): never treat a previewed extension as manageable

### DIFF
--- a/tests/modes/extensions/test_extension_controller.py
+++ b/tests/modes/extensions/test_extension_controller.py
@@ -5,7 +5,11 @@ import pytest
 from pytest_mock import MockerFixture
 
 from ulauncher.api.shared.event import EventType
-from ulauncher.modes.extensions.extension_controller import ExtensionController, supervisor
+from ulauncher.modes.extensions.extension_controller import (
+    ExtensionController,
+    PreviewExtensionController,
+    supervisor,
+)
 
 
 @pytest.fixture(autouse=True)
@@ -23,6 +27,12 @@ def test_send_message__raises_when_process_does_not_own_extension_runtimes() -> 
     controller = ExtensionController("test.guard", "/nonexistent")
     with pytest.raises(RuntimeError):
         controller.send_message({"type": "event:unload"})
+
+
+def test_preview_is_never_manageable_even_inside_user_extensions_dir(mocker: MockerFixture) -> None:
+    mocker.patch("ulauncher.modes.extensions.extension_controller.extension_finder.is_manageable", return_value=True)
+    preview = PreviewExtensionController("test.preview", "/nonexistent")
+    assert preview.is_manageable is False
 
 
 def test_save_user_preferences__saves_and_sends_changed_values(mocker: MockerFixture) -> None:

--- a/ulauncher/modes/extensions/extension_controller.py
+++ b/ulauncher/modes/extensions/extension_controller.py
@@ -473,3 +473,8 @@ class PreviewExtensionController(ExtensionController):
     def __init__(self, ext_id: str, path: str, with_debugger: bool = False) -> None:
         super().__init__(ext_id, path)
         self.with_debugger = with_debugger
+
+    @property
+    def is_manageable(self) -> bool:
+        """Never manageable, so remove/update cannot delete or replace the dev checkout."""
+        return False


### PR DESCRIPTION
A preview loads from a dev path. Although that path should never be directly inside the user extensions directory (so `is_manageable` should not return `True`), this change makes that contract explicit, so that preferences UI never show "Remove" and "Check Updates", and the guards in delete etc will prevent it from being overridden.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Ulauncher/Ulauncher/pull/1771?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

