### PR TITLE
feat(ext): warn on legacy API use from v3 extensions

### DIFF
--- a/ulauncher/api/_deprecation.py
+++ b/ulauncher/api/_deprecation.py
@@ -1,0 +1,34 @@
+from __future__ import annotations
+
+import os
+import warnings
+
+
+class ApiDeprecationWarning(DeprecationWarning):
+    """Emitted when an extension uses the pre-v3 (v2) Ulauncher extension API."""
+
+
+# Set by the app only for v3 extensions. v2 extensions already get a compatibility-mode warning,
+# and standalone runs (unset) stay quiet.
+_enabled = os.getenv("ULAUNCHER_API_DEPRECATION_WARNINGS") == "1"
+
+if _enabled:
+    # "once" dedups by message, and also enables DeprecationWarning outside __main__
+    warnings.filterwarnings("once", category=ApiDeprecationWarning)
+
+
+def warn_legacy_import(module: str) -> None:
+    if not _enabled:
+        return
+    warnings.warn(
+        f"Importing from `{module}` is deprecated. It is part of the Ulauncher extension API v2 and "
+        "will be removed in a future release. Use the v3 API in `ulauncher.api` instead.",
+        ApiDeprecationWarning,
+        stacklevel=2,
+    )
+
+
+def warn_legacy_api(name: str, hint: str) -> None:
+    if not _enabled:
+        return
+    warnings.warn(f"`{name}` is deprecated (Ulauncher extension API v2). {hint}", ApiDeprecationWarning, stacklevel=3)

--- a/ulauncher/api/_deprecation.py
+++ b/ulauncher/api/_deprecation.py
@@ -1,7 +1,11 @@
 from __future__ import annotations
 
+import logging
 import os
 import warnings
+from typing import TextIO
+
+from ulauncher.utils.logging_color_formatter import ColoredFormatter
 
 
 class ApiDeprecationWarning(DeprecationWarning):
@@ -11,10 +15,36 @@ class ApiDeprecationWarning(DeprecationWarning):
 # Set by the app only for v3 extensions. v2 extensions already get a compatibility-mode warning,
 # and standalone runs (unset) stay quiet.
 _enabled = os.getenv("ULAUNCHER_API_DEPRECATION_WARNINGS") == "1"
+_ext_id = os.getenv("ULAUNCHER_EXTENSION_ID")
+_log_handler = logging.StreamHandler()
+_log_handler.setFormatter(ColoredFormatter())
+_logger = logging.getLogger(_ext_id)
+_logger.addHandler(_log_handler)
+
+
+def _install_logging_showwarning() -> None:
+    default_showwarning = warnings.showwarning
+
+    def showwarning(
+        message: Warning | str,
+        category: type[Warning],
+        filename: str,
+        lineno: int,
+        file: TextIO | None = None,
+        line: str | None = None,
+    ) -> None:
+        if issubclass(category, ApiDeprecationWarning):
+            _logger.warning("%s (%s:%s)", message, filename, lineno)
+            return
+        default_showwarning(message, category, filename, lineno, file, line)
+
+    warnings.showwarning = showwarning
+
 
 if _enabled:
     # "once" dedups by message, and also enables DeprecationWarning outside __main__
     warnings.filterwarnings("once", category=ApiDeprecationWarning)
+    _install_logging_showwarning()
 
 
 def warn_legacy_import(module: str) -> None:

--- a/ulauncher/api/_deprecation.py
+++ b/ulauncher/api/_deprecation.py
@@ -1,11 +1,10 @@
 from __future__ import annotations
 
-import logging
 import os
 import warnings
 from typing import TextIO
 
-from ulauncher.utils.logging_color_formatter import ColoredFormatter
+from ulauncher.api._logging import get_extension_logger
 
 
 class ApiDeprecationWarning(DeprecationWarning):
@@ -15,11 +14,7 @@ class ApiDeprecationWarning(DeprecationWarning):
 # Set by the app only for v3 extensions. v2 extensions already get a compatibility-mode warning,
 # and standalone runs (unset) stay quiet.
 _enabled = os.getenv("ULAUNCHER_API_DEPRECATION_WARNINGS") == "1"
-_ext_id = os.getenv("ULAUNCHER_EXTENSION_ID")
-_log_handler = logging.StreamHandler()
-_log_handler.setFormatter(ColoredFormatter())
-_logger = logging.getLogger(_ext_id)
-_logger.addHandler(_log_handler)
+_logger = get_extension_logger()
 
 
 def _install_logging_showwarning() -> None:

--- a/ulauncher/api/_logging.py
+++ b/ulauncher/api/_logging.py
@@ -17,6 +17,9 @@ def get_extension_logger() -> logging.Logger:
 
     logger = logging.getLogger(log_name)
 
+    # Own handler below, so don't also forward records to the root logger's handler
+    logger.propagate = False
+
     # Only add handler if not already present (avoid duplicates on re-import)
     if not logger.handlers:
         handler = logging.StreamHandler()

--- a/ulauncher/api/_logging.py
+++ b/ulauncher/api/_logging.py
@@ -1,0 +1,26 @@
+"""Shared logging setup for the extension API and deprecation warnings."""
+
+from __future__ import annotations
+
+import logging
+import os
+import sys
+from pathlib import Path
+
+from ulauncher.utils.logging_color_formatter import ColoredFormatter
+
+
+def get_extension_logger() -> logging.Logger:
+    """Get or create a logger for the extension."""
+    # The env var id is always set, but fallback anyway on the dirname
+    log_name = os.getenv("ULAUNCHER_EXTENSION_ID") or Path(sys.argv[0]).resolve().parent.name
+
+    logger = logging.getLogger(log_name)
+
+    # Only add handler if not already present (avoid duplicates on re-import)
+    if not logger.handlers:
+        handler = logging.StreamHandler()
+        handler.setFormatter(ColoredFormatter())
+        logger.addHandler(handler)
+
+    return logger

--- a/ulauncher/api/client/EventListener.py
+++ b/ulauncher/api/client/EventListener.py
@@ -2,6 +2,8 @@ from __future__ import annotations  # noqa: N999
 
 from typing import TYPE_CHECKING
 
+from ulauncher.api._deprecation import warn_legacy_api
+
 if TYPE_CHECKING:
     from ulauncher.api.event import BaseEvent
     from ulauncher.api.extension import Extension
@@ -12,6 +14,11 @@ class EventListener:
     """
     Base event listener class
     """
+
+    def __init__(self) -> None:
+        warn_legacy_api(
+            "EventListener", "Define handler methods like `on_input` directly on your `Extension` subclass."
+        )
 
     def on_event(self, _event: BaseEvent, _extension: Extension) -> effects.EffectMessageInput | None:
         """

--- a/ulauncher/api/client/Extension.py
+++ b/ulauncher/api/client/Extension.py
@@ -1,3 +1,10 @@
-from ulauncher.api.extension import Extension  # noqa: N999
+from ulauncher.api._deprecation import warn_legacy_api  # noqa: N999
+from ulauncher.api.extension import Extension as _Extension
 
 __all__ = ["Extension"]
+
+
+class Extension(_Extension):
+    def __init__(self) -> None:
+        warn_legacy_api("Extension", "Import `Extension` from `ulauncher.api` instead.")
+        super().__init__()

--- a/ulauncher/api/client/__init__.py
+++ b/ulauncher/api/client/__init__.py
@@ -1,0 +1,3 @@
+from ulauncher.api._deprecation import warn_legacy_import
+
+warn_legacy_import("ulauncher.api.client")

--- a/ulauncher/api/event.py
+++ b/ulauncher/api/event.py
@@ -1,8 +1,9 @@
 from __future__ import annotations
 
-from typing import Any, Dict, Final, Union
+from typing import TYPE_CHECKING, Any, Dict, Final, Union
 
-from ulauncher.internals.query import Query
+if TYPE_CHECKING:
+    from ulauncher.api.shared.query import Query
 
 ExtensionPreferenceValue = Union[str, int, bool]
 ExtensionPreferences = Dict[str, ExtensionPreferenceValue]
@@ -27,17 +28,19 @@ class InputTriggerEvent(BaseEvent):
     """
 
 
-# TODO: Add deprecation warning
 class LegacyKeywordQueryEvent(BaseEvent):
     """
     Deprecated older variant of InputTriggerEvent
     """
 
     def __init__(self, query_str: str) -> None:
+        # Imported lazily so the always-loaded core doesn't pull in a legacy module for v3 extensions.
+        from ulauncher.api.shared.query import Query
+
         argument: str | None = None
         components = query_str.split(" ", 1)
         if len(components) > 1:
-            # argument will be an empty string if there is only a space after the keyword (see is_active property)
+            # "" when there is only a space after the keyword (see is_active).
             argument = components[1]
         self.query = Query(components[0], argument)
         super().__init__([self.query])

--- a/ulauncher/api/extension.py
+++ b/ulauncher/api/extension.py
@@ -11,12 +11,12 @@ from collections import defaultdict
 from typing import TYPE_CHECKING, Any, Callable, Iterable, Iterator, cast
 
 from ulauncher.api._deprecation import warn_legacy_api
+from ulauncher.api._logging import get_extension_logger
 from ulauncher.api.event import BaseEvent, EventType, LegacyKeywordQueryEvent, PreferencesUpdateEvent, events
 from ulauncher.api.socket_client import Client
 from ulauncher.internals import effect_utils, effects, ipc
 from ulauncher.internals.result import Result
 from ulauncher.utils import scheduling
-from ulauncher.utils.logging_color_formatter import ColoredFormatter
 
 if TYPE_CHECKING:
     from ulauncher.api.client.EventListener import EventListener as LegacyEventListener
@@ -37,13 +37,13 @@ class Extension:
             err_msg = "ULAUNCHER_EXTENSION_ID env variable not set"
             raise RuntimeError(err_msg)
         self._client = Client(self)
-        log_handler = logging.StreamHandler()
-        log_handler.setFormatter(ColoredFormatter())
+
+        # Set up logging level for the root logger
         logging.basicConfig(
             level=logging.DEBUG if os.getenv("VERBOSE") == "1" else logging.WARNING,
-            handlers=[log_handler],
         )
-        self.logger = logging.getLogger(self.ext_id)
+
+        self.logger = get_extension_logger()
 
         self._listeners: dict[type[BaseEvent], list[tuple[LegacyEventListener | Extension, str | None]]] = defaultdict(
             list

--- a/ulauncher/api/extension.py
+++ b/ulauncher/api/extension.py
@@ -10,6 +10,7 @@ import threading
 from collections import defaultdict
 from typing import TYPE_CHECKING, Any, Callable, Iterable, Iterator, cast
 
+from ulauncher.api._deprecation import warn_legacy_api
 from ulauncher.api.event import BaseEvent, EventType, LegacyKeywordQueryEvent, PreferencesUpdateEvent, events
 from ulauncher.api.socket_client import Client
 from ulauncher.internals import effect_utils, effects, ipc
@@ -60,22 +61,29 @@ class Extension:
 
         # subscribe with methods if user has added their own
         if self.__class__.on_input is not Extension.on_input:
-            self.subscribe(events[EventType.INPUT_TRIGGER], "on_input")
+            self._subscribe(events[EventType.INPUT_TRIGGER], "on_input")
         if self.__class__.on_launch is not Extension.on_launch:
-            self.subscribe(events[EventType.LAUNCH_TRIGGER], "on_launch")
+            self._subscribe(events[EventType.LAUNCH_TRIGGER], "on_launch")
         if self.__class__.on_item_enter is not Extension.on_item_enter:
-            self.subscribe(events[EventType.LEGACY_ACTIVATE_CUSTOM], "on_item_enter")
+            self._subscribe(events[EventType.LEGACY_ACTIVATE_CUSTOM], "on_item_enter")
         if self.__class__.on_unload is not Extension.on_unload:
-            self.subscribe(events[EventType.UNLOAD], "on_unload")
+            self._subscribe(events[EventType.UNLOAD], "on_unload")
         if self.__class__.on_preferences_update is not Extension.on_preferences_update:
-            self.subscribe(events[EventType.UPDATE_PREFERENCES], "on_preferences_update")
+            self._subscribe(events[EventType.UPDATE_PREFERENCES], "on_preferences_update")
         if self.__class__.on_result_activation is not Extension.on_result_activation:
-            self.subscribe(events[EventType.RESULT_ACTIVATION], "on_result_activation")
+            self._subscribe(events[EventType.RESULT_ACTIVATION], "on_result_activation")
 
-    def subscribe(self, event_type: type[BaseEvent], listener: str | LegacyEventListener) -> None:
+    def subscribe(self, event_type: type[BaseEvent], listener: LegacyEventListener) -> None:
         """
-        Example: extension.subscribe(InputTriggerEvent, "on_input")
+        Example: extension.subscribe(KeywordQueryEvent, KeywordQueryEventListener())
         """
+        warn_legacy_api(
+            "Extension.subscribe",
+            "Define handler methods like `on_input` on your `Extension` subclass instead.",
+        )
+        self._subscribe(event_type, listener)
+
+    def _subscribe(self, event_type: type[BaseEvent], listener: str | LegacyEventListener) -> None:
         if isinstance(listener, str):
             self._listeners[event_type].append((self, listener))
         else:

--- a/ulauncher/api/shared/__init__.py
+++ b/ulauncher/api/shared/__init__.py
@@ -1,0 +1,3 @@
+from ulauncher.api._deprecation import warn_legacy_import
+
+warn_legacy_import("ulauncher.api.shared")

--- a/ulauncher/api/shared/action/ActionList.py
+++ b/ulauncher/api/shared/action/ActionList.py
@@ -1,18 +1,19 @@
 from __future__ import annotations  # noqa: N999
 
+from ulauncher.api._deprecation import warn_legacy_api
 from ulauncher.internals import effects
 
 
 def ActionList(effect_list: list[effects.EffectMessage]) -> effects.LegacyRunMany:  # noqa: N802
     """
-    ActionList is deprecated but maintained for backward compatibility.
-
-    It allows you to pass multiple legacy "actions" for sequential execution.
-
-    Note: Legacy actions have been replaced by effects and utils as of Extension version 3 (Ulauncher 6.0).
-    Effects are mutually exclusive, and combining them can lead to undefined behavior.
-    When writing new extensions, please use effects and/or utils instead.
+    Passes multiple legacy "actions" for sequential execution.
 
     :param list effect_list: List of effect messages
     """
+    warn_legacy_api(
+        "ActionList",
+        "API v2 Actions including ActionList have been deprecated in favor of class methods "
+        "`self.clipboard_store(...)` and `self.notify(...)` which can be called directly from Extension class methods, "
+        "and mutually exclusive Effects which can be returned only once per method",
+    )
     return {"type": effects.EffectType.LEGACY_RUN_MANY, "effects": effect_list}

--- a/ulauncher/api/shared/action/CopyToClipboardAction.py
+++ b/ulauncher/api/shared/action/CopyToClipboardAction.py
@@ -1,7 +1,9 @@
-from ulauncher.internals import effects  # noqa: N999
+from ulauncher.api._deprecation import warn_legacy_api  # noqa: N999
+from ulauncher.internals import effects
 
 
 def CopyToClipboardAction(text: str) -> effects.LegacyCopy:  # noqa: N802
+    warn_legacy_api("CopyToClipboardAction", "Call `self.clipboard_store(text)` on your Extension instead.")
     if not isinstance(text, str):
         msg = f'Copy argument "{text}" is invalid. It must be a string'
         raise TypeError(msg)

--- a/ulauncher/api/shared/action/DoNothingAction.py
+++ b/ulauncher/api/shared/action/DoNothingAction.py
@@ -1,3 +1,9 @@
-from ulauncher.internals.effects import do_nothing as DoNothingAction  # noqa: N812, N999
+from ulauncher.api._deprecation import warn_legacy_api  # noqa: N999
+from ulauncher.internals import effects
 
 __all__ = ["DoNothingAction"]
+
+
+def DoNothingAction() -> effects.DoNothing:  # noqa: N802
+    warn_legacy_api("DoNothingAction", "Use `ulauncher.api.effects.do_nothing()` instead.")
+    return effects.do_nothing()

--- a/ulauncher/api/shared/action/ExtensionCustomAction.py
+++ b/ulauncher/api/shared/action/ExtensionCustomAction.py
@@ -2,6 +2,7 @@ from __future__ import annotations  # noqa: N999
 
 from typing import Any
 
+from ulauncher.api._deprecation import warn_legacy_api
 from ulauncher.internals.effects import EffectType
 
 # This holds references to custom data for use with ExtensionCustomAction
@@ -14,6 +15,10 @@ def ExtensionCustomAction(data: Any, keep_app_open: bool = False) -> dict[str, A
     """
     This effect is used to pass custom data back to the extension when the result item is activated.
     """
+    warn_legacy_api(
+        "ExtensionCustomAction",
+        "Define `actions` on your `Result` and handle them in the extension's `on_result_activation` method instead.",
+    )
     ref = id(data)
     custom_data_store[ref] = data
     return {"type": EffectType.LEGACY_ACTIVATE_CUSTOM, "ref": ref, "keep_app_open": keep_app_open}

--- a/ulauncher/api/shared/action/HideWindowAction.py
+++ b/ulauncher/api/shared/action/HideWindowAction.py
@@ -1,3 +1,9 @@
-from ulauncher.internals.effects import close_window as HideWindowAction  # noqa: N812, N999
+from ulauncher.api._deprecation import warn_legacy_api  # noqa: N999
+from ulauncher.internals import effects
 
 __all__ = ["HideWindowAction"]
+
+
+def HideWindowAction() -> effects.CloseWindow:  # noqa: N802
+    warn_legacy_api("HideWindowAction", "Use `ulauncher.api.effects.close_window()` instead.")
+    return effects.close_window()

--- a/ulauncher/api/shared/action/OpenAction.py
+++ b/ulauncher/api/shared/action/OpenAction.py
@@ -1,3 +1,9 @@
-from ulauncher.internals.effects import open as OpenAction  # noqa: N812, N999
+from ulauncher.api._deprecation import warn_legacy_api  # noqa: N999
+from ulauncher.internals import effects
 
 __all__ = ["OpenAction"]
+
+
+def OpenAction(item: str) -> effects.Open:  # noqa: N802
+    warn_legacy_api("OpenAction", "Use `ulauncher.api.effects.open(path)` instead.")
+    return effects.open(item)

--- a/ulauncher/api/shared/action/OpenUrlAction.py
+++ b/ulauncher/api/shared/action/OpenUrlAction.py
@@ -1,3 +1,9 @@
-from ulauncher.internals.effects import open as OpenUrlAction  # noqa: N812, N999
+from ulauncher.api._deprecation import warn_legacy_api  # noqa: N999
+from ulauncher.internals import effects
 
 __all__ = ["OpenUrlAction"]
+
+
+def OpenUrlAction(url: str) -> effects.Open:  # noqa: N802
+    warn_legacy_api("OpenUrlAction", "Use `ulauncher.api.effects.open(url)` instead.")
+    return effects.open(url)

--- a/ulauncher/api/shared/action/RenderResultListAction.py
+++ b/ulauncher/api/shared/action/RenderResultListAction.py
@@ -1,3 +1,16 @@
-from ulauncher.internals.effects import render_results as RenderResultListAction  # noqa: N812, N999
+from __future__ import annotations  # noqa: N999
+
+from typing import TYPE_CHECKING
+
+from ulauncher.api._deprecation import warn_legacy_api
+from ulauncher.internals import effects
+
+if TYPE_CHECKING:
+    from ulauncher.internals.result import Result
 
 __all__ = ["RenderResultListAction"]
+
+
+def RenderResultListAction(results: list[Result], append: bool = False, final: bool = True) -> effects.RenderResults:  # noqa: N802
+    warn_legacy_api("RenderResultListAction", "Return a `list[Result]` from your handler instead.")
+    return effects.render_results(results, append, final)

--- a/ulauncher/api/shared/action/RunScriptAction.py
+++ b/ulauncher/api/shared/action/RunScriptAction.py
@@ -1,7 +1,9 @@
-from ulauncher.internals import effects  # noqa: N999
+from ulauncher.api._deprecation import warn_legacy_api  # noqa: N999
+from ulauncher.internals import effects
 
 
 def RunScriptAction(script: str, arg: str = "") -> effects.LegacyRunScript:  # noqa: N802
+    warn_legacy_api("RunScriptAction", "Run the script yourself from the event handler (e.g. with `subprocess`).")
     if not isinstance(script, str):
         msg = f'Script argument "{script}" is invalid. It must be a string'
         raise TypeError(msg)

--- a/ulauncher/api/shared/action/SetUserQueryAction.py
+++ b/ulauncher/api/shared/action/SetUserQueryAction.py
@@ -1,3 +1,9 @@
-from ulauncher.internals.effects import set_query as SetUserQueryAction  # noqa: N812, N999
+from ulauncher.api._deprecation import warn_legacy_api  # noqa: N999
+from ulauncher.internals import effects
 
 __all__ = ["SetUserQueryAction"]
+
+
+def SetUserQueryAction(query: str) -> effects.SetQuery:  # noqa: N802
+    warn_legacy_api("SetUserQueryAction", "Use `ulauncher.api.effects.set_query(query)` instead.")
+    return effects.set_query(query)

--- a/ulauncher/api/shared/action/__init__.py
+++ b/ulauncher/api/shared/action/__init__.py
@@ -1,1 +1,0 @@
-# @todo: Add deprecation warnings for all actions

--- a/ulauncher/api/shared/item/ExtensionResultItem.py
+++ b/ulauncher/api/shared/item/ExtensionResultItem.py
@@ -1,10 +1,16 @@
 from __future__ import annotations  # noqa: N999
 
+from typing import Any
+
+from ulauncher.api._deprecation import warn_legacy_api
 from ulauncher.internals.result import Result
 
 
-# TODO: deprecate this class. Use ulauncher.api.Result instead
 class ExtensionResultItem(Result):
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
+        warn_legacy_api("ExtensionResultItem", "Use `ulauncher.api.Result` instead.")
+        super().__init__(*args, **kwargs)
+
     def get_keyword(self) -> str:
         return self.keyword
 

--- a/ulauncher/api/shared/item/ExtensionSmallResultItem.py
+++ b/ulauncher/api/shared/item/ExtensionSmallResultItem.py
@@ -1,6 +1,12 @@
-from ulauncher.internals.result import Result  # noqa: N999
+from typing import Any  # noqa: N999
+
+from ulauncher.api._deprecation import warn_legacy_api
+from ulauncher.internals.result import Result
 
 
-# TODO: deprecate this class. Use ulauncher.api.Result with compact=True instead
 class ExtensionSmallResultItem(Result):
     compact = True
+
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
+        warn_legacy_api("ExtensionSmallResultItem", "Use `ulauncher.api.Result(compact=True)` instead.")
+        super().__init__(*args, **kwargs)

--- a/ulauncher/api/shared/query.py
+++ b/ulauncher/api/shared/query.py
@@ -1,4 +1,16 @@
-# Only for backward compatibility with extensions that imported this for types
-from ulauncher.internals.query import Query
+from __future__ import annotations
+
+from ulauncher.api._deprecation import warn_legacy_api
+from ulauncher.internals.query import Query as _Query
 
 __all__ = ["Query"]
+
+
+class Query(_Query):
+    def get_keyword(self) -> str | None:
+        warn_legacy_api("Query.get_keyword", "Use the `keyword` attribute instead.")
+        return self.keyword
+
+    def get_argument(self, default: str | None = None) -> str | None:
+        warn_legacy_api("Query.get_argument", "Use the `argument` attribute instead.")
+        return self.argument or default

--- a/ulauncher/internals/query.py
+++ b/ulauncher/internals/query.py
@@ -2,10 +2,7 @@ from __future__ import annotations
 
 
 class Query:
-    """
-    argument should be None if there is no space after the keyword.
-    If there is only a space after, argument should be an empty string
-    """
+    """argument is None when nothing follows the keyword, or "" when only a space follows."""
 
     keyword: str | None
     argument: str | None
@@ -22,17 +19,5 @@ class Query:
 
     @property
     def is_active(self) -> bool:
-        """
-        If the query has an argument that is not None it counts as active
-        If the query has a keyword and a space after the keyword, it counts as active because
-        then the argument is an empty string
-        """
+        # A trailing space after the keyword sets argument to "", which still counts as active.
         return self.argument is not None
-
-    def get_keyword(self) -> str | None:
-        # TODO: Add deprecation warning
-        return self.keyword
-
-    def get_argument(self, default: str | None = None) -> str | None:
-        # TODO: Add deprecation warning
-        return self.argument or default

--- a/ulauncher/modes/extensions/extension_manifest.py
+++ b/ulauncher/modes/extensions/extension_manifest.py
@@ -142,6 +142,10 @@ class ExtensionManifest(JsonConf):
                 return "option cannot be empty for select type"
         return None
 
+    def supports_current_api(self) -> bool:
+        """False for pre-v3 extensions that only run in v2 compatibility mode."""
+        return satisfies(api_version, self.api_version)
+
     def check_compatibility(self, verbose: bool = False) -> None:
         """
         Ensure the extension is compatible with the Ulauncher API (or raise error)

--- a/ulauncher/modes/extensions/extension_service.py
+++ b/ulauncher/modes/extensions/extension_service.py
@@ -178,6 +178,8 @@ class ExtensionService(ExtensionRegistry):
             "EXTENSION_PREFERENCES": json.dumps(v2_prefs, separators=(",", ":")),
             "ULAUNCHER_EXTENSION_ID": record.id,
             "ULAUNCHER_INPUT_DEBOUNCE": str(record.manifest.input_debounce),
+            # v2 extensions already get a compatibility-mode warning, so only warn v3 ones.
+            "ULAUNCHER_API_DEPRECATION_WARNINGS": "1" if record.manifest.supports_current_api() else "0",
         }
 
         # socketpair/spawnv can fail for host-environment reasons (fd exhaustion, fork limits,


### PR DESCRIPTION
Replace the "add deprecation warning" TODOs with real warnings that fire only for extensions targeting the current API version. Pre-v3 extensions already get a compatibility-mode warning, so the app gates these via the ULAUNCHER_API_DEPRECATION_WARNINGS env var (set from the manifest's declared api_version) and the extension process stays quiet otherwise.

Warnings come in two forms:
- A once-per-process import warning in the `ulauncher.api.shared` and `ulauncher.api.client` package inits, catching every legacy module (including unused imports that a per-call warning would miss).
- A per-callable warning with a "use X instead" hint on first use of each public legacy function/class. The thin effect aliases become real wrapper functions, and the result-item and client Extension/EventListener classes warn from their constructors.

Move the compat-only `Query.get_keyword`/`get_argument` off the core Query into a real wrapper in `ulauncher.api.shared.query`, imported lazily by the event module so the always-loaded core stays clean for v3 extensions.

Split `Extension.subscribe` into an internal `_subscribe` (used by the class-method wiring, no warning) and a public `subscribe` narrowed to the legacy listener type that warns.

Warnings dedup by message via a "once" filter on a dedicated ApiDeprecationWarning category, which also un-hides them outside __main__.

Closes #1582 (this is much more thorough and up to date than that ticket)

Also, I changed my mind. Originally I said I wanted extension devs to have time to migrate before activating this. But instead I gated it so you only get them if you have started, but not completed a migration to the new API. This will be more helpful to devs.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Ulauncher/Ulauncher/pull/1773?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

