### PR TITLE
fix(ext): restrict input query responses to result effects

### DIFF
--- a/ulauncher/api/extension.py
+++ b/ulauncher/api/extension.py
@@ -204,6 +204,13 @@ class Extension:
         else:
             # Schedule the response on the main thread to avoid races on shared state
             effect_msg = effect_utils.convert_to_effect_message(result)
+            if event["type"] == EventType.INPUT_TRIGGER and not effect_utils.is_valid_input_effect(effect_msg):
+                self.logger.warning(
+                    "Invalid effect %s from input handler. Supported types are: results, `effect.do_nothing()`,"
+                    "legacy `DoNothingAction()` or a legacy `ActionList()` which doesn't close the window",
+                    effect_msg["type"],
+                )
+                effect_msg = effects.do_nothing()
             scheduling.run_when_idle(self._send_response, request_id, event, effect_msg, input_request_id)
 
     def _stream_response(

--- a/ulauncher/internals/effect_utils.py
+++ b/ulauncher/internals/effect_utils.py
@@ -35,6 +35,13 @@ def should_close(effect_msg: EffectMessage) -> bool:
     return True
 
 
+def is_valid_input_effect(effect_msg: EffectMessage) -> bool:
+    """Whether the effect is a valid input query response (non-interruptive)"""
+    if effect_msg["type"] == EffectType.LEGACY_RUN_MANY:
+        return all(map(is_valid_input_effect, effect_msg["effects"]))
+    return effect_msg["type"] in (EffectType.RENDER_RESULTS, EffectType.DO_NOTHING)
+
+
 def handle(effect_msg: EffectMessage, prevent_close: bool = False) -> None:
     """Process effects by dispatching to appropriate handlers."""
 

--- a/ulauncher/internals/effect_utils.py
+++ b/ulauncher/internals/effect_utils.py
@@ -42,7 +42,9 @@ def is_valid_input_effect(effect_msg: EffectMessage) -> bool:
         return isinstance(effects, list) and all(
             is_effect_message(effect) and is_valid_input_effect(effect) for effect in effects
         )
-    return effect_msg["type"] in (EffectType.RENDER_RESULTS, EffectType.DO_NOTHING)
+    if effect_msg["type"] == EffectType.RENDER_RESULTS:
+        return isinstance(effect_msg.get("results"), list)
+    return effect_msg["type"] == EffectType.DO_NOTHING
 
 
 def handle(effect_msg: EffectMessage, prevent_close: bool = False) -> None:

--- a/ulauncher/internals/effect_utils.py
+++ b/ulauncher/internals/effect_utils.py
@@ -38,7 +38,10 @@ def should_close(effect_msg: EffectMessage) -> bool:
 def is_valid_input_effect(effect_msg: EffectMessage) -> bool:
     """Whether the effect is a valid input query response (non-interruptive)"""
     if effect_msg["type"] == EffectType.LEGACY_RUN_MANY:
-        return all(is_effect_message(effect) and is_valid_input_effect(effect) for effect in effect_msg["effects"])
+        effects = effect_msg.get("effects")
+        return isinstance(effects, list) and all(
+            is_effect_message(effect) and is_valid_input_effect(effect) for effect in effects
+        )
     return effect_msg["type"] in (EffectType.RENDER_RESULTS, EffectType.DO_NOTHING)
 
 

--- a/ulauncher/internals/effect_utils.py
+++ b/ulauncher/internals/effect_utils.py
@@ -38,7 +38,7 @@ def should_close(effect_msg: EffectMessage) -> bool:
 def is_valid_input_effect(effect_msg: EffectMessage) -> bool:
     """Whether the effect is a valid input query response (non-interruptive)"""
     if effect_msg["type"] == EffectType.LEGACY_RUN_MANY:
-        return all(map(is_valid_input_effect, effect_msg["effects"]))
+        return all(is_effect_message(effect) and is_valid_input_effect(effect) for effect in effect_msg["effects"])
     return effect_msg["type"] in (EffectType.RENDER_RESULTS, EffectType.DO_NOTHING)
 
 


### PR DESCRIPTION
The query listener should only render a result list or be able to run other effects/actions that doesn't close the window or hijack the input the user is currently typing into.

Handlers for input events can no longer close, hijack or otherwise alter the window mid-typing. Only render_results and do_nothing are allowed, plus legacy_run_many when all its nested effects are allowed. Anything else is dropped with a warning. This also stops a handler that returns None from closing the window, since None converts to the close-window effect.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Ulauncher/Ulauncher/pull/1774?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

