### PR TITLE
feat(ext): deprecation warning for legacy on_enter and on_alt enter

### DIFF
--- a/ulauncher/api/__init__.py
+++ b/ulauncher/api/__init__.py
@@ -1,8 +1,22 @@
+from typing import Any
+
 from ulauncher.api.extension import Extension
 from ulauncher.internals import effects
-from ulauncher.internals.result import Result
+from ulauncher.internals.result import Result as _Result
 
 __all__ = ["Extension", "ExtensionResult", "ExtensionSmallResult", "Result", "effects"]
+
+
+class Result(_Result):
+    def __setitem__(self, key: str, value: Any) -> None:
+        if key in ["on_enter", "on_alt_enter"] and value is not None:
+            from ulauncher.api._deprecation import warn_legacy_api
+            from ulauncher.api._utils import convert_to_effect_message
+
+            warn_legacy_api(key, "Use the `actions` parameter instead.")
+            value = convert_to_effect_message(value)
+
+        super().__setitem__(key, value)
 
 
 class ExtensionResult(Result):

--- a/ulauncher/api/__init__.py
+++ b/ulauncher/api/__init__.py
@@ -11,10 +11,10 @@ class Result(_Result):
     def __setitem__(self, key: str, value: Any) -> None:
         if key in ["on_enter", "on_alt_enter"] and value is not None:
             from ulauncher.api._deprecation import warn_legacy_api
-            from ulauncher.api._utils import convert_to_effect_message
+            from ulauncher.internals import effect_utils
 
             warn_legacy_api(key, "Use the `actions` parameter instead.")
-            value = convert_to_effect_message(value)
+            value = effect_utils.convert_to_effect_message(value)
 
         super().__setitem__(key, value)
 

--- a/ulauncher/api/shared/item/ExtensionResultItem.py
+++ b/ulauncher/api/shared/item/ExtensionResultItem.py
@@ -2,8 +2,8 @@ from __future__ import annotations  # noqa: N999
 
 from typing import Any
 
+from ulauncher.api import Result
 from ulauncher.api._deprecation import warn_legacy_api
-from ulauncher.internals.result import Result
 
 
 class ExtensionResultItem(Result):

--- a/ulauncher/api/shared/item/ExtensionSmallResultItem.py
+++ b/ulauncher/api/shared/item/ExtensionSmallResultItem.py
@@ -1,7 +1,7 @@
 from typing import Any  # noqa: N999
 
+from ulauncher.api import Result
 from ulauncher.api._deprecation import warn_legacy_api
-from ulauncher.internals.result import Result
 
 
 class ExtensionSmallResultItem(Result):

--- a/ulauncher/internals/result.py
+++ b/ulauncher/internals/result.py
@@ -80,14 +80,6 @@ class Result(BaseDataClass):
         init_kwargs.update(kwargs)
         super().__init__(**init_kwargs)
 
-    def __setitem__(self, key: str, value: Any) -> None:
-        if key in ["on_enter", "on_alt_enter"] and value is not None:
-            from ulauncher.internals import effect_utils
-
-            value = effect_utils.convert_to_effect_message(value)
-
-        super().__setitem__(key, value)
-
     def get_highlightable_input(self, query_str: str) -> str:
         return query_str
 


### PR DESCRIPTION
Direct to the new `actions` parameter instead.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Ulauncher/Ulauncher/pull/1775?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

