### PR TITLE
refactor: deprecate primitive effect message inputs

### DIFF
--- a/ulauncher/api/__init__.py
+++ b/ulauncher/api/__init__.py
@@ -11,10 +11,10 @@ class Result(_Result):
     def __setitem__(self, key: str, value: Any) -> None:
         if key in ["on_enter", "on_alt_enter"] and value is not None:
             from ulauncher.api._deprecation import warn_legacy_api
-            from ulauncher.internals import effect_utils
+            from ulauncher.api._utils import convert_to_effect_message
 
             warn_legacy_api(key, "Use the `actions` parameter instead.")
-            value = effect_utils.convert_to_effect_message(value)
+            value = convert_to_effect_message(value)
 
         super().__setitem__(key, value)
 

--- a/ulauncher/api/_utils.py
+++ b/ulauncher/api/_utils.py
@@ -1,0 +1,40 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Iterable, cast
+
+from ulauncher.api._logging import get_extension_logger
+from ulauncher.internals import effect_utils, effects
+
+if TYPE_CHECKING:
+    from ulauncher.internals.result import Result
+
+_logger = get_extension_logger()
+
+
+def convert_to_effect_message(input_data: effects.EffectMessageInput | bool | str | None) -> effects.EffectMessage:
+    """Normalize input format that supports boolean and string to represent effects and iterable lists for results"""
+    if input_data is None:
+        return effects.close_window()
+
+    if isinstance(input_data, bool):
+        substitute = effects.do_nothing if input_data else effects.close_window
+        _logger.warning(
+            "Returning %r from extension handlers is deprecated. Use effects.%s() instead.",
+            input_data,
+            substitute.__name__,
+        )
+        return substitute()
+
+    if isinstance(input_data, str):
+        _logger.warning(
+            "Returning a string from extension handlers is deprecated. Use effects.set_query(<query>) instead."
+        )
+        return effects.set_query(input_data)
+
+    if isinstance(input_data, dict):
+        if effect_utils.is_effect_message(input_data):
+            return input_data
+        err_msg = f"Invalid effect message dict: {input_data}"
+        raise ValueError(err_msg)
+
+    return effects.render_results(list(cast("Iterable[Result]", input_data)))  # collect/flatten iterators to lists

--- a/ulauncher/api/extension.py
+++ b/ulauncher/api/extension.py
@@ -12,6 +12,7 @@ from typing import TYPE_CHECKING, Any, Callable, Iterable, Iterator, cast
 
 from ulauncher.api._deprecation import warn_legacy_api
 from ulauncher.api._logging import get_extension_logger
+from ulauncher.api._utils import convert_to_effect_message
 from ulauncher.api.event import BaseEvent, EventType, LegacyKeywordQueryEvent, PreferencesUpdateEvent, events
 from ulauncher.api.socket_client import Client
 from ulauncher.internals import effect_utils, effects, ipc
@@ -203,7 +204,7 @@ class Extension:
             self._stream_response(request_id, event, result, input_request_id)
         else:
             # Schedule the response on the main thread to avoid races on shared state
-            effect_msg = effect_utils.convert_to_effect_message(result)
+            effect_msg = convert_to_effect_message(result)
             if event["type"] == EventType.INPUT_TRIGGER and not effect_utils.is_valid_input_effect(effect_msg):
                 self.logger.warning(
                     "Invalid effect %s from input handler. Supported types are: results, `effect.do_nothing()`,"

--- a/ulauncher/internals/effect_utils.py
+++ b/ulauncher/internals/effect_utils.py
@@ -1,22 +1,15 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any, Final, Iterable, cast
+from typing import TYPE_CHECKING, Any, Final
 
 from ulauncher.internals.effects import (
     EffectMessage,
-    EffectMessageInput,
     EffectType,
-    close_window,
-    do_nothing,
-    render_results,
-    set_query,
 )
 from ulauncher.utils.eventbus import EventBus
 
 if TYPE_CHECKING:
     from typing_extensions import TypeGuard
-
-    from ulauncher.internals.result import Result
 
 _VALID_EFFECT_TYPES: Final = frozenset(getattr(EffectType, key) for key in EffectType.__annotations__)
 _events = EventBus()
@@ -74,17 +67,3 @@ def handle(effect_msg: EffectMessage, prevent_close: bool = False) -> None:
 
     if should_close(effect_msg) and not prevent_close:
         _events.emit("app:close_launcher")
-
-
-def convert_to_effect_message(input_data: EffectMessageInput | None) -> EffectMessage:
-    """Normalize input format that supports boolean and string to represent effects and iterable lists for results"""
-    if isinstance(input_data, bool) or input_data is None:
-        return do_nothing() if input_data else close_window()
-    if isinstance(input_data, str):
-        return set_query(input_data)
-    if isinstance(input_data, dict):
-        if is_effect_message(input_data):
-            return input_data
-        err_msg = f"Invalid effect message dict: {input_data}"
-        raise ValueError(err_msg)
-    return render_results(list(cast("Iterable[Result]", input_data)))  # collect/flatten iterators to lists

--- a/ulauncher/internals/effects.py
+++ b/ulauncher/internals/effects.py
@@ -84,7 +84,7 @@ EffectMessage = Union[
 # Input format that we will convert to an EffectMessage. A plain iterable of Results becomes one
 # render; a generator may also yield list[Result] batches to stream replace drafts (see
 # api.extension.Extension._stream_response).
-EffectMessageInput = Union[EffectMessage, bool, str, Iterable[Union["Result", "list[Result]"]]]
+EffectMessageInput = Union[EffectMessage, Iterable[Union["Result", "list[Result]"]]]
 
 
 def do_nothing() -> DoNothing:


### PR DESCRIPTION
These were a mistake, and the new effects is more explicit and clear.
This will still allow them, but warn on every call. Since these were never released not many extensions will use them, so I will try to phase them out more aggressively.

Move convert_to_effect_message to the api side since the app should never call it.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Ulauncher/Ulauncher/pull/1776?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

