### PR TITLE
fix(calc): show an error for expressions that cannot be evaluated

### DIFF
--- a/tests/modes/calc/test_calc_mode.py
+++ b/tests/modes/calc/test_calc_mode.py
@@ -126,3 +126,19 @@ class TestCalcMode:
                 result = get_results(mode, query)[0]
                 # CalcErrorResult have no actions, so they never reach activate_result
                 assert isinstance(result, CalcErrorResult)
+
+    def test_handle_query__unevaluable_expr(self, mode: CalcMode, caplog: pytest.LogCaptureFixture) -> None:
+        bad_queries = [
+            "1/0",
+            "1%0",
+            "2**100000",
+            "sqrt(-1)",
+            "ln(0)",
+            "acos(2)",
+            "gamma(-1)",
+        ]
+
+        with caplog.at_level("CRITICAL"):
+            for query_str in bad_queries:
+                result = get_results(mode, Query(None, query_str))[0]
+                assert isinstance(result, CalcErrorResult)

--- a/ulauncher/modes/calc/calc_mode.py
+++ b/ulauncher/modes/calc/calc_mode.py
@@ -173,7 +173,9 @@ class CalcMode(Mode):
                 description="Enter to copy to the clipboard",
                 result=calc_result,
             )
-        except (SyntaxError, TypeError, IndexError):
+        # ArithmeticError covers the decimal exceptions (division by zero, overflow, sqrt of a negative number),
+        # ValueError the math module domain errors
+        except (SyntaxError, TypeError, IndexError, ArithmeticError, ValueError):
             logger.warning("Calc mode error triggered while handling query: '%s'", query.argument)
             result = CalcErrorResult()
 


### PR DESCRIPTION
Queries like `1/0`, `sqrt(-1)` and `acos(2)` parse as math, so calc mode picks them up, but evaluating them raises a decimal or math exception that the handler did not catch. The window showed no results at all instead of "Error!".

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Ulauncher/Ulauncher/pull/1779?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

