### PR TITLE
feat(calc): autocomplete partial function and constant names

### DIFF
--- a/tests/modes/calc/test_calc_mode.py
+++ b/tests/modes/calc/test_calc_mode.py
@@ -92,6 +92,11 @@ class TestCalcMode:
         assert not mode.matches_query_str("5*zz")
         assert not mode.matches_query_str("5*sqx")
         assert not mode.matches_query_str("sq")
+
+        # Only known functions are stripped, so an unknown call isn't reduced to its math prefix
+        assert not mode.matches_query_str("5*foo(")
+        assert not mode.matches_query_str("7-zip(")
+        assert not mode.matches_query_str("5*mysin(")
         assert not mode.matches_query_str("co")
 
     def test_get_completions(self) -> None:

--- a/tests/modes/calc/test_calc_mode.py
+++ b/tests/modes/calc/test_calc_mode.py
@@ -9,8 +9,15 @@ from pytest_mock import MockerFixture
 from ulauncher.internals.effects import EffectType
 from ulauncher.internals.query import Query
 from ulauncher.internals.result import Result
-from ulauncher.modes.calc.calc_mode import CalcMode, eval_expr
-from ulauncher.modes.calc.calc_result import CalcErrorResult
+from ulauncher.modes.calc.calc_mode import (
+    CalcMode,
+    constants,
+    descriptions,
+    eval_expr,
+    functions,
+    get_completions,
+)
+from ulauncher.modes.calc.calc_result import CalcCompletionResult, CalcErrorResult
 
 
 def get_results(mode: CalcMode, query: Query) -> list[Result]:
@@ -63,6 +70,44 @@ class TestCalcMode:
         assert not mode.matches_query_str("pi2")
         assert not mode.matches_query_str("cospitanagamma")
 
+    def test_is_enabled__partial_names(self, mode: CalcMode) -> None:
+        assert mode.matches_query_str("5*s")
+        assert mode.matches_query_str("5*sq")
+        assert mode.matches_query_str("5*sqrt")
+        assert mode.matches_query_str("5*sqrt(")
+        assert mode.matches_query_str("5 * si")
+        assert mode.matches_query_str("2*sqrt(3)+co")
+        assert mode.matches_query_str("sqrt(s")
+        assert mode.matches_query_str("(co")
+        assert mode.matches_query_str("-s")
+
+        # Names can only follow an operator or bracket, so app names starting with a number are unaffected
+        assert not mode.matches_query_str("0ad")
+        assert not mode.matches_query_str("2fa")
+        assert not mode.matches_query_str("10a")
+        assert not mode.matches_query_str("2-player")
+        assert not mode.matches_query_str("wifi-s")
+        assert not mode.matches_query_str("5*zz")
+        assert not mode.matches_query_str("5*sqx")
+        assert not mode.matches_query_str("sq")
+        assert not mode.matches_query_str("co")
+
+    def test_get_completions(self) -> None:
+        assert get_completions("5*s") == (("sin", "5*sin("), ("sinh", "5*sinh("), ("sqrt", "5*sqrt("))
+        assert get_completions("5 * sq") == (("sqrt", "5 * sqrt("),)
+        assert get_completions("sqrt(2)+ta") == (("tan", "sqrt(2)+tan("), ("tanh", "sqrt(2)+tanh("))
+        # Constants complete without a bracket
+        assert get_completions("5*p") == (("pi", "5*pi"),)
+        # A completion identical to the query is left out
+        assert get_completions("5*pi") == ()
+        assert get_completions("5*e") == (("erf", "5*erf("), ("erfc", "5*erfc("), ("exp", "5*exp("))
+        assert get_completions("5*sqrt") == (("sqrt", "5*sqrt("),)
+        assert get_completions("0ad") == ()
+        assert get_completions("5*zz") == ()
+
+    def test_all_completions_have_descriptions(self) -> None:
+        assert set(descriptions) == {*functions, *constants}
+
     def test_eval_expr_no_floating_point_errors(self) -> None:
         assert eval_expr("110 / 3") == "36.666666666666667"
         assert eval_expr("1.1 + 2.2") == "3.3"
@@ -97,6 +142,27 @@ class TestCalcMode:
         assert get_results(mode, Query(None, "3+2*"))[0].result == "5"
         assert get_results(mode, Query(None, "2-2"))[0].result == "0"
         assert get_results(mode, Query(None, "5%2"))[0].result == "1"
+
+    def test_handle_query__completions(self, mode: CalcMode) -> None:
+        results = get_results(mode, Query(None, "5*s"))
+        assert [result.name for result in results] == ["5*sin(", "5*sinh(", "5*sqrt("]
+        assert results[2].description == "Square root"
+
+        # A complete name evaluates, but still offers the longer names
+        results = get_results(mode, Query(None, "5*e"))
+        assert [result.name for result in results] == ["13.591409142295225", "5*erf(", "5*erfc(", "5*exp("]
+
+    def test_handle_query__incomplete_call(self, mode: CalcMode) -> None:
+        assert get_results(mode, Query(None, "5*sqrt("))[0].result == "5"
+        assert get_results(mode, Query(None, "5*sqrt(2"))[0].result == "7.071067811865475"
+
+    def test_handle_query__complete_called(self, mode: CalcMode, mocker: MockerFixture) -> None:
+        query = Query(None, "5*sq")
+        result = get_results(mode, query)[0]
+        assert isinstance(result, CalcCompletionResult)
+        callback = mocker.MagicMock()
+        mode.activate_result("complete", result, query, callback)
+        assert callback.call_args[0][0] == {"type": EffectType.SET_QUERY, "query": "5*sqrt("}
 
     def test_handle_query__copy_called(self, mode: CalcMode, event_emit: MagicMock, mocker: MockerFixture) -> None:
         query = Query(None, "3+2")

--- a/tests/modes/calc/test_calc_mode.py
+++ b/tests/modes/calc/test_calc_mode.py
@@ -80,6 +80,8 @@ class TestCalcMode:
         assert mode.matches_query_str("sqrt(s")
         assert mode.matches_query_str("(co")
         assert mode.matches_query_str("-s")
+        assert mode.matches_query_str("5*st")
+        assert mode.matches_query_str("5*ah")
 
         # Names can only follow an operator or bracket, so app names starting with a number are unaffected
         assert not mode.matches_query_str("0ad")
@@ -104,6 +106,20 @@ class TestCalcMode:
         assert get_completions("5*sqrt") == (("sqrt", "5*sqrt("),)
         assert get_completions("0ad") == ()
         assert get_completions("5*zz") == ()
+
+    def test_get_completions__fuzzy(self) -> None:
+        # The partial name matches as a subsequence
+        assert get_completions("5*st") == (("sqrt", "5*sqrt("),)
+        assert get_completions("5*ah") == (("acosh", "5*acosh("), ("asinh", "5*asinh("), ("atanh", "5*atanh("))
+        # Prefix matches come before the rest
+        assert get_completions("5*as") == (
+            ("asin", "5*asin("),
+            ("asinh", "5*asinh("),
+            ("acos", "5*acos("),
+            ("acosh", "5*acosh("),
+        )
+        # The first character still has to match, so unrelated app names are unaffected
+        assert get_completions("5*qt") == ()
 
     def test_all_completions_have_descriptions(self) -> None:
         assert set(descriptions) == {*functions, *constants}

--- a/ulauncher/modes/calc/calc_mode.py
+++ b/ulauncher/modes/calc/calc_mode.py
@@ -104,10 +104,19 @@ def normalize_expr(expr: str) -> str:
     return expr  # noqa: RET504
 
 
+def _matches_name(partial: str, name: str) -> bool:
+    # Anchoring on the first character keeps "5*a" from listing every name containing an "a"
+    if not name.startswith(partial[0]):
+        return False
+    remaining = iter(name)
+    return all(char in remaining for char in partial)
+
+
 @lru_cache(maxsize=1000)
 def get_completions(query_str: str) -> tuple[tuple[str, str], ...]:
     """
     Queries ending with a partial name, like "5*sq", complete to full queries like "5*sqrt(".
+    The partial name matches as a subsequence, so "5*st" also completes to "5*sqrt(".
     Returns pairs of the function or constant name and the completed query.
     """
     query_str = query_str.rstrip()
@@ -118,7 +127,10 @@ def get_completions(query_str: str) -> tuple[tuple[str, str], ...]:
     # Substituting a number for the partial name tells us whether the rest is math
     if not _is_enabled(normalize_expr(f"{head}1")):
         return ()
-    names = sorted(name for name in (*functions, *constants) if name.startswith(partial))
+    names = sorted(
+        (name for name in (*functions, *constants) if _matches_name(partial, name)),
+        key=lambda name: (not name.startswith(partial), name),
+    )
     completions = ((name, f"{head}{name}(" if name in functions else f"{head}{name}") for name in names)
     return tuple((name, completion) for name, completion in completions if completion != query_str)
 

--- a/ulauncher/modes/calc/calc_mode.py
+++ b/ulauncher/modes/calc/calc_mode.py
@@ -11,7 +11,7 @@ from typing import Callable
 from ulauncher.internals import effects
 from ulauncher.internals.query import Query
 from ulauncher.internals.result import Result
-from ulauncher.modes.calc.calc_result import CalcErrorResult, CalcResult
+from ulauncher.modes.calc.calc_result import CalcCompletionResult, CalcErrorResult, CalcResult
 from ulauncher.modes.mode import Mode
 from ulauncher.utils.eventbus import EventBus
 from ulauncher.utils.lru_cache import lru_cache
@@ -54,7 +54,38 @@ functions: dict[str, Callable[..., float | Decimal]] = {
 }
 
 constants = {"pi": Decimal(math.pi), "e": Decimal(math.e)}
+
+descriptions = {
+    "sqrt": "Square root",
+    "exp": "Exponential (e to the power of x)",
+    "ln": "Natural logarithm",
+    "log10": "Base-10 logarithm",
+    "sin": "Sine (radians)",
+    "cos": "Cosine (radians)",
+    "tan": "Tangent (radians)",
+    "asin": "Arc sine (radians)",
+    "acos": "Arc cosine (radians)",
+    "atan": "Arc tangent (radians)",
+    "sinh": "Hyperbolic sine",
+    "cosh": "Hyperbolic cosine",
+    "tanh": "Hyperbolic tangent",
+    "asinh": "Inverse hyperbolic sine",
+    "acosh": "Inverse hyperbolic cosine",
+    "atanh": "Inverse hyperbolic tangent",
+    "erf": "Error function",
+    "erfc": "Complementary error function",
+    "gamma": "Gamma function",
+    "lgamma": "Natural logarithm of the gamma function",
+    "pi": "Pi (3.14159...)",
+    "e": "Euler's number (2.71828...)",
+}
+
 logger = logging.getLogger(__name__)
+
+_trailing_operator_re = re.compile(r"\s*[.+\-*/%]\*?\s*$")
+_incomplete_call_re = re.compile(r"\s*[.+\-*/%]?\*?\s*(?:(?<![\w.])[a-zA-Z_]\w*)?\(\s*$")
+# A name is only completable where an operand can start, so it must follow an operator or a bracket
+_partial_name_re = re.compile(r"^(?P<head>.*[-+*/%^(]\s*)(?P<partial>[a-zA-Z_]\w*)$")
 
 
 # Show a friendlier output for incomplete queries, instead of "Invalid"
@@ -64,10 +95,32 @@ def normalize_expr(expr: str) -> str:
     # ^ means xor in Python. ** is the Python notation for pow
     expr = expr.replace("^", "**")
     # Strip trailing operator
-    expr = re.sub(r"\s*[\.\+\-\*/%\(]\*?\s*$", "", expr)
+    expr = _trailing_operator_re.sub("", expr)
+    # Strip calls that have no argument yet, so "5*sqrt(" evaluates as "5"
+    while (stripped := _incomplete_call_re.sub("", expr)) != expr:
+        expr = stripped
     # Complete unfinished brackets
     expr = expr + ")" * (expr.count("(") - expr.count(")"))
     return expr  # noqa: RET504
+
+
+@lru_cache(maxsize=1000)
+def get_completions(query_str: str) -> tuple[tuple[str, str], ...]:
+    """
+    Queries ending with a partial name, like "5*sq", complete to full queries like "5*sqrt(".
+    Returns pairs of the function or constant name and the completed query.
+    """
+    query_str = query_str.rstrip()
+    match = _partial_name_re.match(query_str)
+    if not match:
+        return ()
+    head, partial = match["head"], match["partial"]
+    # Substituting a number for the partial name tells us whether the rest is math
+    if not _is_enabled(normalize_expr(f"{head}1")):
+        return ()
+    names = sorted(name for name in (*functions, *constants) if name.startswith(partial))
+    completions = ((name, f"{head}{name}(" if name in functions else f"{head}{name}") for name in names)
+    return tuple((name, completion) for name, completion in completions if completion != query_str)
 
 
 def eval_expr(expr: str) -> str:
@@ -161,25 +214,38 @@ def _eval(node: ast.expr) -> int | float | Decimal:
     raise TypeError(node)
 
 
+def _evaluate(query_str: str) -> Result:
+    try:
+        calc_result = eval_expr(query_str)
+        return CalcResult(
+            name=f"{Decimal(calc_result):n}",
+            description="Enter to copy to the clipboard",
+            result=calc_result,
+        )
+    # ArithmeticError covers the decimal exceptions (division by zero, overflow, sqrt of a negative number),
+    # ValueError the math module domain errors
+    except (SyntaxError, TypeError, IndexError, ArithmeticError, ValueError):
+        logger.warning("Calc mode error triggered while handling query: '%s'", query_str)
+        return CalcErrorResult()
+
+
 class CalcMode(Mode):
     def matches_query_str(self, query_str: str) -> bool:
-        return _is_enabled(normalize_expr(query_str))
+        return bool(get_completions(query_str)) or _is_enabled(normalize_expr(query_str))
 
     def handle_query(self, query: Query, callback: Callable[[effects.EffectMessage], None]) -> None:
-        try:
-            calc_result = eval_expr(query.argument or "")
-            result: Result = CalcResult(
-                name=f"{Decimal(calc_result):n}",
-                description="Enter to copy to the clipboard",
-                result=calc_result,
-            )
-        # ArithmeticError covers the decimal exceptions (division by zero, overflow, sqrt of a negative number),
-        # ValueError the math module domain errors
-        except (SyntaxError, TypeError, IndexError, ArithmeticError, ValueError):
-            logger.warning("Calc mode error triggered while handling query: '%s'", query.argument)
-            result = CalcErrorResult()
+        query_str = query.argument or ""
+        completions = get_completions(query_str)
+        results: list[Result] = []
+        # An incomplete name has no value to show, but a complete one like "5*e" has both
+        if not completions or _is_enabled(normalize_expr(query_str)):
+            results.append(_evaluate(query_str))
+        results.extend(
+            CalcCompletionResult(name=completion, description=descriptions[math_name], completion=completion)
+            for math_name, completion in completions
+        )
 
-        callback(effects.render_results([result]))
+        callback(effects.render_results(results))
 
     def activate_result(
         self,
@@ -195,6 +261,12 @@ class CalcMode(Mode):
                 return
             _events.emit("app:copy_and_close", result.result)
             callback(effects.close_window())
+        elif action_id == "complete":
+            if not isinstance(result, CalcCompletionResult):
+                logger.error("Unexpected result type for calc complete action: %s", type(result).__name__)
+                callback(effects.do_nothing())
+                return
+            callback(effects.set_query(result.completion))
         else:
             logger.error("Unexpected action '%s' for Calc mode result '%s'", action_id, result)
             callback(effects.do_nothing())

--- a/ulauncher/modes/calc/calc_mode.py
+++ b/ulauncher/modes/calc/calc_mode.py
@@ -83,7 +83,8 @@ descriptions = {
 logger = logging.getLogger(__name__)
 
 _trailing_operator_re = re.compile(r"\s*[.+\-*/%]\*?\s*$")
-_incomplete_call_re = re.compile(r"\s*[.+\-*/%]?\*?\s*(?:(?<![\w.])[a-zA-Z_]\w*)?\(\s*$")
+# Only known function names, so an app search like "5*foo(" isn't reduced to the math prefix "5"
+_incomplete_call_re = re.compile(rf"\s*[.+\-*/%]?\*?\s*(?:(?<![\w.])(?:{'|'.join(functions)}))?\(\s*$")
 # A name is only completable where an operand can start, so it must follow an operator or a bracket
 _partial_name_re = re.compile(r"^(?P<head>.*[-+*/%^(]\s*)(?P<partial>[a-zA-Z_]\w*)$")
 

--- a/ulauncher/modes/calc/calc_result.py
+++ b/ulauncher/modes/calc/calc_result.py
@@ -12,6 +12,12 @@ class CalcResult(Result):
     actions = {"copy": {"name": "Copy to clipboard", "icon": "edit-copy"}}
 
 
+class CalcCompletionResult(Result):
+    icon = calc_icon
+    completion = ""
+    actions = {"complete": {"name": "Complete expression", "icon": "go-next"}}
+
+
 class CalcErrorResult(Result):
     name = "Error!"
     description = "Invalid expression"


### PR DESCRIPTION
Queries ending with a partial name, like `5*sq` or `5*st`, now match calc mode and list the names it could become (`5*sqrt(`). Activating a completion sets the query, so you can keep typing the argument. Constants complete without a bracket, functions with one.

A name only completes where an operand can start, meaning right after an operator or a bracket. Queries like `7-zip` or `0ad` are not valid math and stay with the app search. A leading partial name is not completed either, so "sq" and "cos" still search apps.

Incomplete calls are also stripped when evaluating, so "5*sqrt(" shows "5" instead of "Error!". Without that the query would drop out of calc mode the moment you picked a completion.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Ulauncher/Ulauncher/pull/1780?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

