### PR TITLE
feat(ext): capture extension stdout and format its output app-side

### DIFF
--- a/tests/internals/test_log_wire.py
+++ b/tests/internals/test_log_wire.py
@@ -1,0 +1,48 @@
+import logging
+
+from ulauncher.internals import log_wire
+
+
+def _wire(**overrides: object) -> str:
+    fields: dict[str, object] = {
+        "name": "my.ext",
+        "level": logging.WARNING,
+        "pathname": "/ext/main.py",
+        "lineno": 12,
+        "msg": "hello",
+        "args": None,
+        "exc_info": None,
+        "func": "run",
+    }
+    fields.update(overrides)
+    return log_wire.WireFormatter().format(logging.LogRecord(**fields))  # type: ignore[arg-type]
+
+
+def test_round_trip__preserves_the_record() -> None:
+    parsed = log_wire.parse(_wire(name="__main__"), "my.ext")
+
+    assert parsed
+    assert (parsed.levelno, parsed.pathname, parsed.lineno, parsed.funcName) == (
+        logging.WARNING,
+        "/ext/main.py",
+        12,
+        "run",
+    )
+    assert parsed.getMessage() == "hello"
+    assert parsed.name == "my.ext.__main__"  # the extension's own logger name keeps its id as-is
+    assert log_wire.parse(_wire(), "my.ext").name == "my.ext"  # type: ignore[union-attr]
+
+
+def test_round_trip__multiline_message__stays_one_line_on_the_wire() -> None:
+    message = 'Traceback (most recent call last):\n  File "main.py"\nValueError: back\\slash'
+    line = _wire(msg=message)
+
+    assert "\n" not in line
+    parsed = log_wire.parse(line, "my.ext")
+    assert parsed
+    assert parsed.getMessage() == message
+
+
+def test_parse__plain_output__is_not_a_record() -> None:
+    assert log_wire.parse("just a print", "my.ext") is None
+    assert log_wire.parse("WARNING\x1fmy.ext\x1f/ext/main.py\x1f12\x1frun\x1fhello", "my.ext") is None

--- a/tests/modes/extensions/test_extension_runtime.py
+++ b/tests/modes/extensions/test_extension_runtime.py
@@ -1,10 +1,13 @@
+import logging
 import signal
 from typing import Any
 from unittest.mock import MagicMock, Mock
 
 import pytest
+from _pytest.logging import LogCaptureFixture
 from pytest_mock import MockerFixture
 
+from ulauncher.internals import log_wire
 from ulauncher.modes.extensions.extension_runtime import ExtensionRuntime, aborted_subprocesses
 
 
@@ -15,7 +18,9 @@ class TestExtensionRuntime:
 
     @pytest.fixture(autouse=True)
     def data_input_stream(self, mocker: MockerFixture) -> MagicMock:
-        return mocker.patch("ulauncher.modes.extensions.extension_runtime.Gio.DataInputStream")
+        stream_class = mocker.patch("ulauncher.modes.extensions.extension_runtime.Gio.DataInputStream")
+        stream_class.new.side_effect = lambda _pipe: Mock()
+        return stream_class
 
     @pytest.fixture(autouse=True)
     def message_socket(self, mocker: MockerFixture) -> MagicMock:
@@ -48,7 +53,9 @@ class TestExtensionRuntime:
 
         subprocess_launcher.new.assert_called_once()
         runtime._subprocess.wait_async.assert_called_once()
-        runtime._error_stream.read_line_async.assert_called_once()
+        assert set(runtime._output_streams) == {"stdout", "stderr"}
+        for stream in runtime._output_streams.values():
+            stream.read_line_async.assert_called_once()
 
     def test_read_stderr_line(self) -> None:
         test_output1 = "Test Output 1"
@@ -57,20 +64,65 @@ class TestExtensionRuntime:
         mock_read_line_finish_utf8 = Mock()
 
         runtime: Any = ExtensionRuntime(extid, ["mock/path/to/ext"])
-        runtime._error_stream.read_line_finish_utf8 = mock_read_line_finish_utf8
+        stream = runtime._output_streams["stderr"]
+        stream.read_line_finish_utf8 = mock_read_line_finish_utf8
+        reads_after_launch = stream.read_line_async.call_count
 
         mock_read_line_finish_utf8.return_value = (test_output1, len(test_output1))
-        runtime.handle_stderr(runtime._error_stream, Mock())
+        runtime.handle_output(stream, Mock(), "stderr")
         # Confirm the output is stored in recent_errors and read_line_async is called for the next
         # line.
         assert runtime._recent_errors[0] == test_output1
-        assert runtime._error_stream.read_line_async.call_count == 2
+        assert stream.read_line_async.call_count == reads_after_launch + 1
 
         mock_read_line_finish_utf8.return_value = (test_output2, len(test_output2))
-        runtime.handle_stderr(runtime._error_stream, Mock())
+        runtime.handle_output(stream, Mock(), "stderr")
         # The latest line should replace the previous line
         assert runtime._recent_errors[0] == test_output2
-        assert runtime._error_stream.read_line_async.call_count == 3
+        assert stream.read_line_async.call_count == reads_after_launch + 2
+
+    def test_read_stdout_line__is_not_treated_as_an_error(self) -> None:
+        extid = "mock.test_read_stdout_line__is_not_treated_as_an_error"
+
+        runtime: Any = ExtensionRuntime(extid, ["mock/path/to/ext"])
+        stream = runtime._output_streams["stdout"]
+        stream.read_line_finish_utf8 = Mock(return_value=("printed to stdout", 17))
+
+        runtime.handle_output(stream, Mock(), "stdout")
+
+        assert not runtime._recent_errors
+
+    def test_handle_output__blank_line__keeps_reading(self) -> None:
+        extid = "mock.test_handle_output__blank_line__keeps_reading"
+        mock_read_line_finish_utf8 = Mock()
+
+        runtime: Any = ExtensionRuntime(extid, ["mock/path/to/ext"])
+        stream = runtime._output_streams["stderr"]
+        stream.read_line_finish_utf8 = mock_read_line_finish_utf8
+        reads_after_launch = stream.read_line_async.call_count
+
+        mock_read_line_finish_utf8.return_value = ("", 0)
+        runtime.handle_output(stream, Mock(), "stderr")
+        assert not runtime._recent_errors
+        assert stream.read_line_async.call_count == reads_after_launch + 1
+
+        mock_read_line_finish_utf8.return_value = (None, 0)  # end of stream
+        runtime.handle_output(stream, Mock(), "stderr")
+        assert stream.read_line_async.call_count == reads_after_launch + 1
+
+    def test_emit_output__wire_encoded__restores_the_extensions_record(self, caplog: LogCaptureFixture) -> None:
+        extid = "mock.test_emit_output"
+        runtime: Any = ExtensionRuntime(extid, ["mock/path/to/ext"])
+        line = log_wire.WireFormatter().format(
+            logging.LogRecord(extid, logging.WARNING, "/ext/main.py", 42, "line one\nline two", None, None, func="run")
+        )
+
+        with caplog.at_level(logging.DEBUG):
+            message = runtime.emit_output(line, "stderr")
+
+        assert message == "line one\nline two"
+        record = caplog.records[-1]
+        assert (record.name, record.levelno, record.funcName, record.lineno) == (extid, logging.WARNING, "run", 42)
 
     def test_handle_exit__signaled(self) -> None:
         extid = "mock.test_handle_exit__signaled"

--- a/tests/utils/test_logging_color_formatter.py
+++ b/tests/utils/test_logging_color_formatter.py
@@ -1,0 +1,13 @@
+import logging
+import random
+
+from ulauncher.utils.logging_color_formatter import ColoredFormatter
+
+
+def test_format__leaves_the_shared_random_state_alone() -> None:
+    record = logging.LogRecord("ulauncher.some.module", logging.WARNING, "/src/mod.py", 42, "hi", None, None)
+    state = random.getstate()
+
+    ColoredFormatter().format(record)
+
+    assert random.getstate() == state

--- a/ulauncher/api/_logging.py
+++ b/ulauncher/api/_logging.py
@@ -7,7 +7,17 @@ import os
 import sys
 from pathlib import Path
 
+from ulauncher.internals import log_wire
 from ulauncher.utils.logging_color_formatter import ColoredFormatter
+
+
+def get_extension_handler() -> logging.Handler:
+    """The handler every logger in the extension process writes through."""
+    handler = logging.StreamHandler()
+    # Ulauncher imports this module too, where nothing parses the wire format back
+    in_extension_process = bool(os.getenv("SOCKETPAIR_FD"))
+    handler.setFormatter(log_wire.WireFormatter() if in_extension_process else ColoredFormatter())
+    return handler
 
 
 def get_extension_logger() -> logging.Logger:
@@ -22,8 +32,6 @@ def get_extension_logger() -> logging.Logger:
 
     # Only add handler if not already present (avoid duplicates on re-import)
     if not logger.handlers:
-        handler = logging.StreamHandler()
-        handler.setFormatter(ColoredFormatter())
-        logger.addHandler(handler)
+        logger.addHandler(get_extension_handler())
 
     return logger

--- a/ulauncher/api/extension.py
+++ b/ulauncher/api/extension.py
@@ -11,7 +11,7 @@ from collections import defaultdict
 from typing import TYPE_CHECKING, Any, Callable, Iterable, Iterator, cast
 
 from ulauncher.api._deprecation import warn_legacy_api
-from ulauncher.api._logging import get_extension_logger
+from ulauncher.api._logging import get_extension_handler, get_extension_logger
 from ulauncher.api._utils import convert_to_effect_message
 from ulauncher.api.event import BaseEvent, EventType, LegacyKeywordQueryEvent, PreferencesUpdateEvent, events
 from ulauncher.api.socket_client import Client
@@ -39,9 +39,12 @@ class Extension:
             raise RuntimeError(err_msg)
         self._client = Client(self)
 
-        # Set up logging level for the root logger
+        # Root gets the same handler, so `logging.getLogger(__name__)` matches `self.logger`.
+        # Forced, since basicConfig is a no-op if an import configured the root logger first.
         logging.basicConfig(
             level=logging.DEBUG if os.getenv("VERBOSE") == "1" else logging.WARNING,
+            handlers=[get_extension_handler()],
+            force=True,
         )
 
         self.logger = get_extension_logger()

--- a/ulauncher/init_helpers.py
+++ b/ulauncher/init_helpers.py
@@ -33,7 +33,8 @@ def configure_logging(*, verbose: bool, use_app_logging: bool) -> None:
         from ulauncher.utils.logging_color_formatter import ColoredFormatter
 
         stream_handler.setFormatter(ColoredFormatter())
-        log_format = "%(asctime)s | %(levelname)s | %(message)s | %(module)s.%(funcName)s():%(lineno)s"
+        # Extensions log through here too, under their extension id
+        log_format = "%(asctime)s | %(levelname)s | %(name)s | %(message)s | %(module)s.%(funcName)s():%(lineno)s"
         handlers.append(logging.FileHandler(paths.LOG_FILE, mode="w+"))
 
     stream_handler.setLevel(log_level)

--- a/ulauncher/internals/log_wire.py
+++ b/ulauncher/internals/log_wire.py
@@ -1,0 +1,48 @@
+"""Wire format for log records an extension sends Ulauncher over its stdout/stderr pipes.
+
+Ulauncher formats and colors them once, on its end. Output not in this form (a bare `print`,
+an unhandled traceback) is passed through as-is.
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+
+SEPARATOR = "\x1f"  # ASCII unit separator: never occurs in log text
+_FIELDS = ("%(levelno)d", "%(name)s", "%(pathname)s", "%(lineno)d", "%(funcName)s", "%(message)s")
+FORMAT = SEPARATOR.join(_FIELDS)
+
+
+class WireFormatter(logging.Formatter):
+    """Renders a record as exactly one line, so one line Ulauncher reads is always one record."""
+
+    def __init__(self) -> None:
+        super().__init__(FORMAT)
+
+    def format(self, record: logging.LogRecord) -> str:
+        return super().format(record).replace("\\", "\\\\").replace("\n", "\\n")
+
+
+def parse(line: str, ext_id: str) -> logging.LogRecord | None:
+    """Rebuild the record an extension logged, or None if the line didn't come from its handler."""
+    fields = line.split(SEPARATOR, len(_FIELDS) - 1)
+    # isdecimal, not isdigit: int() rejects digits like "²"
+    if len(fields) != len(_FIELDS) or not fields[0].isdecimal():
+        return None
+
+    levelno, name, pathname, lineno, func_name, message = (_unescape(field) for field in fields)
+    return logging.LogRecord(
+        name=name if name == ext_id else f"{ext_id}.{name}",
+        level=int(levelno),
+        pathname=pathname,
+        lineno=int(lineno) if lineno.isdecimal() else 0,
+        msg=message,
+        args=None,
+        exc_info=None,
+        func=func_name,
+    )
+
+
+def _unescape(text: str) -> str:
+    return re.sub(r"\\(.)", lambda match: "\n" if match.group(1) == "n" else match.group(1), text)

--- a/ulauncher/modes/extensions/extension_runtime.py
+++ b/ulauncher/modes/extensions/extension_runtime.py
@@ -9,7 +9,7 @@ from typing import Callable, Literal, cast
 from weakref import WeakSet
 
 from ulauncher.gi import Gio, GLib
-from ulauncher.internals import ipc
+from ulauncher.internals import ipc, log_wire
 from ulauncher.utils import scheduling
 from ulauncher.utils.socket_msg_controller import SocketMsgController
 
@@ -33,7 +33,7 @@ class ExtensionRuntime:
     _start_time: float
     _msg_controller: SocketMsgController
     _parent_socket: socket.socket | None = None
-    _error_stream: Gio.DataInputStream
+    _output_streams: dict[str, Gio.DataInputStream]
     _recent_errors: deque[str]
     _exit_handler: ExitHandlerCallback | None
     _message_handler: MessageHandlerCallback | None
@@ -53,11 +53,13 @@ class ExtensionRuntime:
         self._start_time = time()
 
         extension_env: dict[str, str] = env.copy() if env else {}
-        launcher = Gio.SubprocessLauncher.new(Gio.SubprocessFlags.STDERR_PIPE)
+        launcher = Gio.SubprocessLauncher.new(Gio.SubprocessFlags.STDOUT_PIPE | Gio.SubprocessFlags.STDERR_PIPE)
 
         for env_name, env_value in extension_env.items():
             launcher.setenv(env_name, env_value, True)
         launcher.setenv("ULAUNCHER_EXTENSION_ID", ext_id, True)
+        # Python block-buffers stdout when it isn't a terminal, holding back `print` output
+        launcher.setenv("PYTHONUNBUFFERED", "1", True)
 
         def socket_cleanup() -> None:
             if self._parent_socket:
@@ -82,15 +84,20 @@ class ExtensionRuntime:
             socket_cleanup()
             raise
 
-        error_input_stream = self._subprocess.get_stderr_pipe()
-        if not error_input_stream:
-            err_msg = "Subprocess must be created with Gio.SubprocessFlags.STDERR_PIPE"
+        out_pipe = self._subprocess.get_stdout_pipe()
+        err_pipe = self._subprocess.get_stderr_pipe()
+        if not out_pipe or not err_pipe:
+            err_msg = "Subprocess must be created with Gio.SubprocessFlags.STDOUT_PIPE and STDERR_PIPE"
             raise AssertionError(err_msg)
-        self._error_stream = Gio.DataInputStream.new(error_input_stream)
+        self._output_streams = {
+            "stdout": Gio.DataInputStream.new(out_pipe),
+            "stderr": Gio.DataInputStream.new(err_pipe),
+        }
 
         logger.debug("Launched %s using Gio.Subprocess", self._ext_id)
         self._subprocess.wait_async(None, self.handle_exit)
-        self.read_stderr_line()
+        for name in self._output_streams:
+            self.read_output_line(name)
         self._msg_controller.listen(self.handle_message)
 
     def stop(self) -> None:
@@ -114,8 +121,11 @@ class ExtensionRuntime:
             # The process may exit between this check and the signal; Gio delivers it race-free.
             self._subprocess.send_signal(signal.SIGKILL)
 
-    def read_stderr_line(self) -> None:
-        self._error_stream.read_line_async(GLib.PRIORITY_DEFAULT, None, self.handle_stderr)
+    def read_output_line(self, stream_name: str) -> None:
+        stream = self._output_streams[stream_name]
+        stream.read_line_async(
+            GLib.PRIORITY_DEFAULT, None, lambda stream, result: self.handle_output(stream, result, stream_name)
+        )
 
     def send_message(self, message: ipc.Event, request_id: int | None = None) -> None:
         self._msg_controller.send([message, request_id])
@@ -130,17 +140,31 @@ class ExtensionRuntime:
         if self._message_handler:
             self._message_handler(cast("ipc.ExtensionMessage", message))
 
-    def handle_stderr(self, error_stream: Gio.DataInputStream, result: Gio.AsyncResult) -> None:
+    def handle_output(self, stream: Gio.DataInputStream, result: Gio.AsyncResult, stream_name: str) -> None:
         try:
-            # append output to recent_errors
-            output, _ = error_stream.read_line_finish_utf8(result)
-            if output:
-                print(output, f" 🔌 from {self._ext_id}")  # noqa: T201
-                self._recent_errors.append(output)
-                self.read_stderr_line()
+            output, _ = stream.read_line_finish_utf8(result)
         except GLib.Error:
-            logger.exception("Failed to read stderr line for %s", self._ext_id)
+            logger.exception("Failed to read %s line for %s", stream_name, self._ext_id)
             return
+
+        if output is None:  # end of stream, not a blank line
+            return
+
+        if output:
+            message = self.emit_output(output, stream_name)
+            if message and stream_name == "stderr":
+                self._recent_errors.append(message)
+        self.read_output_line(stream_name)
+
+    def emit_output(self, output: str, stream_name: str) -> str:
+        """Re-emit what the extension wrote through Ulauncher's handlers. Returns the message."""
+        record = log_wire.parse(output, self._ext_id)
+        if not record:
+            # Unformatted stderr is a traceback or warning, and has to clear the app's WARNING level
+            level = logging.WARNING if stream_name == "stderr" else logging.INFO
+            record = logging.LogRecord(self._ext_id, level, "", 0, output, None, None, func=stream_name)
+        logging.getLogger(record.name).handle(record)
+        return record.getMessage()
 
     def handle_exit(self, _subprocess: Gio.Subprocess, _result: Gio.AsyncResult) -> None:
         self._msg_controller.close()

--- a/ulauncher/utils/logging_color_formatter.py
+++ b/ulauncher/utils/logging_color_formatter.py
@@ -19,16 +19,26 @@ class ColoredFormatter(logging.Formatter):
         logging.CRITICAL: ("⚠️", 31),  # red
     }
 
+    def __init__(self) -> None:
+        # Varying parts are injected as record fields, so this is built once, not per record
+        super().__init__("%(asctime)s %(color_prefix)s %(message)s %(color_suffix)s")
+        self._name_colors: dict[str, int] = {}
+
+    def _name_color(self, name: str) -> int:
+        if name not in self._name_colors:
+            # Own generator, so the same name keeps its color without reseeding the shared one
+            self._name_colors[name] = random.Random(name).randint(32, 37)
+        return self._name_colors[name]
+
     def format(self, record: logging.LogRecord) -> str:
         # Great reference for terminal colors: https://chrisyeh96.github.io/2020/03/28/terminal-colors.html
         symbol, level_color = self.formats.get(record.levelno, ("", 0))
         prefix = f"{symbol}  {mkcolor(level_color, True)}{record.levelname}{mkcolor(0)}"
         if record.name != "root":
-            # Ensure the same name gets the same color every time
-            random.seed(record.name)
-            name_color = random.randint(32, 37)
             name = record.name[len("ulauncher.") :] if record.name.startswith("ulauncher.") else record.name
-            prefix += f"{mkcolor(name_color, True)} {name}{mkcolor(0)}:"
-        suffix = f"{mkcolor(2)}{record.funcName}:{record.lineno}{mkcolor(0)}"  # 2 means faded
-        formatter = logging.Formatter(f"%(asctime)s {prefix} %(message)s {suffix}")
-        return formatter.format(record)
+            prefix += f"{mkcolor(self._name_color(record.name), True)} {name}{mkcolor(0)}:"
+        # Raw extension output has no source location, only a stream name
+        location = f"{record.funcName}:{record.lineno}" if record.lineno else record.funcName
+        record.__dict__["color_prefix"] = prefix
+        record.__dict__["color_suffix"] = f"{mkcolor(2)}{location}{mkcolor(0)}"  # 2 means faded
+        return super().format(record)


### PR DESCRIPTION
Extension processes formatted their own log records, timestamps and colors included, and Ulauncher printed the result verbatim to its own stdout. That output never reached last.log, and `print()` was not captured at all, because only stderr was piped.

Extensions now emit records in a machine-readable form that Ulauncher parses back into LogRecords and hands to its own handlers. The timestamp and colors are applied once, by whichever handler writes the output, so the terminal gets ANSI and last.log stays plain and greppable. Both stdout and stderr are piped, with PYTHONUNBUFFERED so a `print` isn't held back by Python's block buffering.

The same handler now backs the root logger in the extension process, so `logging.getLogger(__name__)` in extension code behaves like `self.logger` instead of falling back to the stdlib defaults.

ColoredFormatter no longer builds a Formatter per record, and takes name colors from its own random generator rather than reseeding the shared one on every line.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Ulauncher/Ulauncher/pull/1781?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

