### PR TITLE
feat(ext): capture extension stdout and format its output app-side

### DIFF
--- a/tests/internals/test_log_wire.py
+++ b/tests/internals/test_log_wire.py
@@ -1,0 +1,37 @@
+import logging
+
+from ulauncher.internals import log_wire
+
+
+def _wire(name: str, message: str) -> str:
+    record = logging.LogRecord(name, logging.WARNING, "/ext/main.py", 12, message, None, None, func="run")
+    return log_wire.WireFormatter().format(record)
+
+
+def test_round_trip__preserves_the_record() -> None:
+    message = 'Traceback (most recent call last):\n  File "main.py"\nValueError: back\\slash'
+    line = _wire("__main__", message)
+
+    assert "\n" not in line
+    parsed = log_wire.parse(line, "my.ext")
+    assert parsed
+    assert (parsed.levelno, parsed.pathname, parsed.lineno, parsed.funcName) == (
+        logging.WARNING,
+        "/ext/main.py",
+        12,
+        "run",
+    )
+    assert parsed.getMessage() == message
+    assert parsed.name == "my.ext.__main__"
+
+
+def test_round_trip__extensions_own_logger__keeps_its_name() -> None:
+    parsed = log_wire.parse(_wire("my.ext", "hello"), "my.ext")
+
+    assert parsed
+    assert parsed.name == "my.ext"
+
+
+def test_parse__plain_output__is_not_a_record() -> None:
+    assert log_wire.parse("just a print", "my.ext") is None
+    assert log_wire.parse('{"name": "my.ext"}', "my.ext") is None

--- a/tests/modes/extensions/test_extension_runtime.py
+++ b/tests/modes/extensions/test_extension_runtime.py
@@ -1,10 +1,13 @@
+import logging
 import signal
 from typing import Any
 from unittest.mock import MagicMock, Mock
 
 import pytest
+from _pytest.logging import LogCaptureFixture
 from pytest_mock import MockerFixture
 
+from ulauncher.internals import log_wire
 from ulauncher.modes.extensions.extension_runtime import ExtensionRuntime, aborted_subprocesses
 
 
@@ -15,7 +18,9 @@ class TestExtensionRuntime:
 
     @pytest.fixture(autouse=True)
     def data_input_stream(self, mocker: MockerFixture) -> MagicMock:
-        return mocker.patch("ulauncher.modes.extensions.extension_runtime.Gio.DataInputStream")
+        stream_class = mocker.patch("ulauncher.modes.extensions.extension_runtime.Gio.DataInputStream")
+        stream_class.new.side_effect = lambda _pipe: Mock()
+        return stream_class
 
     @pytest.fixture(autouse=True)
     def message_socket(self, mocker: MockerFixture) -> MagicMock:
@@ -48,29 +53,58 @@ class TestExtensionRuntime:
 
         subprocess_launcher.new.assert_called_once()
         runtime._subprocess.wait_async.assert_called_once()
-        runtime._error_stream.read_line_async.assert_called_once()
+        assert set(runtime._output_streams) == {"stdout", "stderr"}
+        for stream in runtime._output_streams.values():
+            stream.read_line_async.assert_called_once()
 
-    def test_read_stderr_line(self) -> None:
+    def test_handle_output__stderr__records_recent_errors(self) -> None:
         test_output1 = "Test Output 1"
         test_output2 = "Test Output 2"
-        extid = "mock.test_read_stderr_line"
+        extid = "mock.test_handle_output__stderr__records_recent_errors"
         mock_read_line_finish_utf8 = Mock()
 
         runtime: Any = ExtensionRuntime(extid, ["mock/path/to/ext"])
-        runtime._error_stream.read_line_finish_utf8 = mock_read_line_finish_utf8
+        stream = runtime._output_streams["stderr"]
+        stream.read_line_finish_utf8 = mock_read_line_finish_utf8
+        reads_after_launch = stream.read_line_async.call_count
 
         mock_read_line_finish_utf8.return_value = (test_output1, len(test_output1))
-        runtime.handle_stderr(runtime._error_stream, Mock())
+        runtime.handle_output(stream, Mock(), "stderr")
         # Confirm the output is stored in recent_errors and read_line_async is called for the next
         # line.
         assert runtime._recent_errors[0] == test_output1
-        assert runtime._error_stream.read_line_async.call_count == 2
+        assert stream.read_line_async.call_count == reads_after_launch + 1
 
         mock_read_line_finish_utf8.return_value = (test_output2, len(test_output2))
-        runtime.handle_stderr(runtime._error_stream, Mock())
+        runtime.handle_output(stream, Mock(), "stderr")
         # The latest line should replace the previous line
         assert runtime._recent_errors[0] == test_output2
-        assert runtime._error_stream.read_line_async.call_count == 3
+        assert stream.read_line_async.call_count == reads_after_launch + 2
+
+    def test_read_stdout_line__is_not_treated_as_an_error(self) -> None:
+        extid = "mock.test_read_stdout_line__is_not_treated_as_an_error"
+
+        runtime: Any = ExtensionRuntime(extid, ["mock/path/to/ext"])
+        stream = runtime._output_streams["stdout"]
+        stream.read_line_finish_utf8 = Mock(return_value=("printed to stdout", 17))
+
+        runtime.handle_output(stream, Mock(), "stdout")
+
+        assert not runtime._recent_errors
+
+    def test_emit_output__wire_encoded__restores_the_extensions_record(self, caplog: LogCaptureFixture) -> None:
+        extid = "mock.test_emit_output"
+        runtime: Any = ExtensionRuntime(extid, ["mock/path/to/ext"])
+        line = log_wire.WireFormatter().format(
+            logging.LogRecord(extid, logging.WARNING, "/ext/main.py", 42, "line one\nline two", None, None, func="run")
+        )
+
+        with caplog.at_level(logging.DEBUG):
+            message = runtime.emit_output(line, "stderr")
+
+        assert message == "line one\nline two"
+        record = caplog.records[-1]
+        assert (record.name, record.levelno, record.funcName, record.lineno) == (extid, logging.WARNING, "run", 42)
 
     def test_handle_exit__signaled(self) -> None:
         extid = "mock.test_handle_exit__signaled"

--- a/ulauncher/api/_logging.py
+++ b/ulauncher/api/_logging.py
@@ -5,7 +5,14 @@ from __future__ import annotations
 import logging
 import os
 
-from ulauncher.utils.logging_color_formatter import ColoredFormatter
+from ulauncher.internals import log_wire
+
+
+def get_extension_handler() -> logging.Handler:
+    """The handler every logger in the extension process writes through. Ulauncher formats the output."""
+    handler = logging.StreamHandler()
+    handler.setFormatter(log_wire.WireFormatter())
+    return handler
 
 
 def get_extension_logger() -> logging.Logger:
@@ -17,8 +24,6 @@ def get_extension_logger() -> logging.Logger:
 
     # Only add handler if not already present (avoid duplicates on re-import)
     if not logger.handlers:
-        handler = logging.StreamHandler()
-        handler.setFormatter(ColoredFormatter())
-        logger.addHandler(handler)
+        logger.addHandler(get_extension_handler())
 
     return logger

--- a/ulauncher/api/extension.py
+++ b/ulauncher/api/extension.py
@@ -11,7 +11,7 @@ from collections import defaultdict
 from typing import TYPE_CHECKING, Any, Callable, Iterable, Iterator, cast
 
 from ulauncher.api._deprecation import warn_legacy_api
-from ulauncher.api._logging import get_extension_logger
+from ulauncher.api._logging import get_extension_handler, get_extension_logger
 from ulauncher.api._utils import convert_to_effect_message
 from ulauncher.api.event import BaseEvent, EventType, LegacyKeywordQueryEvent, PreferencesUpdateEvent, events
 from ulauncher.api.socket_client import Client
@@ -39,9 +39,12 @@ class Extension:
             raise RuntimeError(err_msg)
         self._client = Client(self)
 
-        # Set up logging level for the root logger
+        # Root gets the same handler, so `logging.getLogger(__name__)` matches `self.logger`.
+        # Forced, since basicConfig is a no-op if an import configured the root logger first.
         logging.basicConfig(
             level=logging.DEBUG if os.getenv("VERBOSE") == "1" else logging.WARNING,
+            handlers=[get_extension_handler()],
+            force=True,
         )
 
         self.logger = get_extension_logger()

--- a/ulauncher/init_helpers.py
+++ b/ulauncher/init_helpers.py
@@ -33,6 +33,7 @@ def configure_logging(*, verbose: bool, use_app_logging: bool) -> None:
         from ulauncher.utils.logging_color_formatter import ColoredFormatter
 
         stream_handler.setFormatter(ColoredFormatter())
+        # Extensions log through here too, under their extension id
         log_format = "%(asctime)s | %(levelname)s | %(name)s | %(message)s | %(module)s.%(funcName)s():%(lineno)s"
         handlers.append(logging.FileHandler(paths.LOG_FILE, mode="w+"))
 

--- a/ulauncher/internals/log_wire.py
+++ b/ulauncher/internals/log_wire.py
@@ -1,0 +1,49 @@
+"""Wire format for log records an extension sends Ulauncher over its stdout/stderr pipes.
+
+Ulauncher formats and colors them once, on its end. Output not in this form (a bare `print`,
+an unhandled traceback) is passed through as-is.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+
+
+class WireFormatter(logging.Formatter):
+    """Renders a record as one JSON line, so one line Ulauncher reads is always one record."""
+
+    def __init__(self) -> None:
+        # Only the message, so the traceback logger.exception appends stays inside that field
+        super().__init__("%(message)s")
+
+    def format(self, record: logging.LogRecord) -> str:
+        return json.dumps(
+            {
+                "levelno": record.levelno,
+                "name": record.name,
+                "pathname": record.pathname,
+                "lineno": record.lineno,
+                "funcName": record.funcName,
+                "message": super().format(record),
+            }
+        )
+
+
+def parse(line: str, ext_id: str) -> logging.LogRecord | None:
+    """Rebuild the record an extension logged, or None if the line didn't come from its handler."""
+    try:
+        fields = json.loads(line)
+        name = fields["name"]
+        return logging.LogRecord(
+            name=name if name == ext_id else f"{ext_id}.{name}",
+            level=int(fields["levelno"]),
+            pathname=fields["pathname"],
+            lineno=int(fields["lineno"]),
+            msg=fields["message"],
+            args=None,
+            exc_info=None,
+            func=fields["funcName"],
+        )
+    except (KeyError, TypeError, ValueError):
+        return None

--- a/ulauncher/modes/extensions/extension_runtime.py
+++ b/ulauncher/modes/extensions/extension_runtime.py
@@ -9,7 +9,7 @@ from typing import Callable, Literal, cast
 from weakref import WeakSet
 
 from ulauncher.gi import Gio, GLib
-from ulauncher.internals import ipc
+from ulauncher.internals import ipc, log_wire
 from ulauncher.utils import scheduling
 from ulauncher.utils.socket_msg_controller import SocketMsgController
 
@@ -33,7 +33,7 @@ class ExtensionRuntime:
     _start_time: float
     _msg_controller: SocketMsgController
     _parent_socket: socket.socket | None = None
-    _error_stream: Gio.DataInputStream
+    _output_streams: dict[str, Gio.DataInputStream]
     _recent_errors: deque[str]
     _exit_handler: ExitHandlerCallback | None
     _message_handler: MessageHandlerCallback | None
@@ -53,11 +53,13 @@ class ExtensionRuntime:
         self._start_time = time()
 
         extension_env: dict[str, str] = env.copy() if env else {}
-        launcher = Gio.SubprocessLauncher.new(Gio.SubprocessFlags.STDERR_PIPE)
+        launcher = Gio.SubprocessLauncher.new(Gio.SubprocessFlags.STDOUT_PIPE | Gio.SubprocessFlags.STDERR_PIPE)
 
         for env_name, env_value in extension_env.items():
             launcher.setenv(env_name, env_value, True)
         launcher.setenv("ULAUNCHER_EXTENSION_ID", ext_id, True)
+        # Python block-buffers stdout when it isn't a terminal, holding back `print` output
+        launcher.setenv("PYTHONUNBUFFERED", "1", True)
 
         def socket_cleanup() -> None:
             if self._parent_socket:
@@ -82,15 +84,20 @@ class ExtensionRuntime:
             socket_cleanup()
             raise
 
-        error_input_stream = self._subprocess.get_stderr_pipe()
-        if not error_input_stream:
-            err_msg = "Subprocess must be created with Gio.SubprocessFlags.STDERR_PIPE"
+        out_pipe = self._subprocess.get_stdout_pipe()
+        err_pipe = self._subprocess.get_stderr_pipe()
+        if not out_pipe or not err_pipe:
+            err_msg = "Subprocess must be created with Gio.SubprocessFlags.STDOUT_PIPE and STDERR_PIPE"
             raise AssertionError(err_msg)
-        self._error_stream = Gio.DataInputStream.new(error_input_stream)
+        self._output_streams = {
+            "stdout": Gio.DataInputStream.new(out_pipe),
+            "stderr": Gio.DataInputStream.new(err_pipe),
+        }
 
         logger.debug("Launched %s using Gio.Subprocess", self._ext_id)
         self._subprocess.wait_async(None, self.handle_exit)
-        self.read_stderr_line()
+        for name in self._output_streams:
+            self.read_output_line(name)
         self._msg_controller.listen(self.handle_message)
 
     def stop(self) -> None:
@@ -114,8 +121,11 @@ class ExtensionRuntime:
             # The process may exit between this check and the signal; Gio delivers it race-free.
             self._subprocess.send_signal(signal.SIGKILL)
 
-    def read_stderr_line(self) -> None:
-        self._error_stream.read_line_async(GLib.PRIORITY_DEFAULT, None, self.handle_stderr)
+    def read_output_line(self, stream_name: str) -> None:
+        stream = self._output_streams[stream_name]
+        stream.read_line_async(
+            GLib.PRIORITY_DEFAULT, None, lambda source, result: self.handle_output(source, result, stream_name)
+        )
 
     def send_message(self, message: ipc.Event, request_id: int | None = None) -> None:
         self._msg_controller.send([message, request_id])
@@ -130,30 +140,39 @@ class ExtensionRuntime:
         if self._message_handler:
             self._message_handler(cast("ipc.ExtensionMessage", message))
 
-    def handle_stderr(self, error_stream: Gio.DataInputStream, result: Gio.AsyncResult) -> None:
+    def handle_output(self, stream: Gio.DataInputStream, result: Gio.AsyncResult, stream_name: str) -> None:
         try:
-            output, _ = error_stream.read_line_finish_utf8(result)
+            output, _ = stream.read_line_finish_utf8(result)
         except GLib.Error as error:
             # A decode error only fails its own line, so keep reading. Any other error means the
             # stream is broken, and re-reading it would fail the same way.
             if error.matches(GLib.convert_error_quark(), GLib.ConvertError.ILLEGAL_SEQUENCE):
-                logger.warning("Skipping undecodable stderr line for %s", self._ext_id)
-                self.read_stderr_line()
+                logger.warning("Skipping undecodable %s line for %s", stream_name, self._ext_id)
+                self.read_output_line(stream_name)
                 return
-            logger.exception("Failed to read stderr line for %s", self._ext_id)
+            logger.exception("Failed to read %s line for %s", stream_name, self._ext_id)
             return
 
-        # Only None means the stream ended. A blank line reads as "", and must not end the loop,
-        # or the rest of the extension's stderr is lost. It is not an error, so it isn't recorded
-        # either - _recent_errors holds one line, which a blank would evict.
+        # Only None ends the stream. A blank line reads as "" and must keep the loop going, but
+        # isn't emitted - _recent_errors holds one line, which a blank would evict.
         if output is None:
             return
 
         if output:
-            print(output, f" 🔌 from {self._ext_id}")  # noqa: T201
-            self._recent_errors.append(output)
+            message = self.emit_output(output, stream_name)
+            if message and stream_name == "stderr":
+                self._recent_errors.append(message)
+        self.read_output_line(stream_name)
 
-        self.read_stderr_line()
+    def emit_output(self, output: str, stream_name: str) -> str:
+        """Re-emit what the extension wrote through Ulauncher's handlers. Returns the message."""
+        record = log_wire.parse(output, self._ext_id)
+        if not record:
+            # Unformatted stderr is a traceback or warning, and has to clear the app's WARNING level
+            level = logging.WARNING if stream_name == "stderr" else logging.INFO
+            record = logging.LogRecord(self._ext_id, level, "", 0, output, None, None, func=stream_name)
+        logging.getLogger(record.name).handle(record)
+        return record.getMessage()
 
     def handle_exit(self, _subprocess: Gio.Subprocess, _result: Gio.AsyncResult) -> None:
         self._msg_controller.close()

--- a/ulauncher/utils/logging_color_formatter.py
+++ b/ulauncher/utils/logging_color_formatter.py
@@ -40,6 +40,8 @@ class ColoredFormatter(logging.Formatter):
         if record.name != "root":
             name = record.name[len("ulauncher.") :] if record.name.startswith("ulauncher.") else record.name
             prefix += f"{mkcolor(_name_color(record.name), True)} {name}{mkcolor(0)}:"
+        # Raw extension output has no source location, only a stream name
+        location = f"{record.funcName}:{record.lineno}" if record.lineno else record.funcName
         record.__dict__["color_prefix"] = prefix
-        record.__dict__["color_suffix"] = f"{mkcolor(2)}{record.funcName}:{record.lineno}{mkcolor(0)}"  # 2 is faded
+        record.__dict__["color_suffix"] = f"{mkcolor(2)}{location}{mkcolor(0)}"  # 2 is faded
         return super().format(record)


### PR DESCRIPTION
Extension processes formatted their own log records, timestamps and colors included, and Ulauncher printed the result verbatim to its own stdout. That output never reached last.log, and `print()` was not captured at all, because only stderr was piped.

Extensions now emit records in a machine-readable form that Ulauncher parses back into LogRecords and hands to its own handlers. The timestamp and colors are applied once, by whichever handler writes the output, so the terminal gets ANSI and last.log stays plain and greppable. Both stdout and stderr are piped, with PYTHONUNBUFFERED so a `print` isn't held back by Python's block buffering.

The same handler now backs the root logger in the extension process, so `logging.getLogger(__name__)` in extension code behaves like `self.logger` instead of falling back to the stdlib defaults.

Raw output carries no source location, only the stream it came from, so ColoredFormatter leaves out the line number when there isn't one.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Ulauncher/Ulauncher/pull/1782?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

