### PR TITLE
nix: change the nix version to be aligned with the actual app version

### DIFF
--- a/nix/default.nix
+++ b/nix/default.nix
@@ -33,8 +33,18 @@
 }:
 let
   pname = "ulauncher";
-  version = "v6";
 
+  # nixpkgs' pythonMetadataCheckHook compares this to the built dist-info metadata.
+  # Therefore the version string is extracted from _version.py.
+  versionFile = builtins.readFile ../ulauncher/_version.py;
+  versionMatch =
+    builtins.match ''
+      .*version = "([0-9]+\.[0-9]+\..*)".*
+    '' versionFile;
+  version =
+    if versionMatch == null then
+      throw "Failed to parse version"
+    else builtins.elemAt versionMatch 0;
   src.python = ../.;
 
   packages.tests.python = pp: (with pp; [


### PR DESCRIPTION
<!--
Thank you for submitting a PR to Ulauncher!

Please read our contribution instructions if you haven't:
https://github.com/Ulauncher/Ulauncher#code-contribution

* Explain the changes in this PR and link to related issue(s) if applicable
* When applicable, please update the documentation according to your changes.
* Ensure that the PR doesn't break existing tests, and please add your own if applicable.

A git action will verify your PR, but you can also test locally with `make check`

-->
 Hi, I am a NixOS user using the NixOS unstable channel with flakes, and lately I was unable to build Ulauncher 6 unless the version string in nix matched the one in "_version.py"
 
 Relevant logs from build before the suggested change:
 ```
> Executing pythonMetadataCheckPhase
       > The 'ulauncher' derivation has version 'v6' but .dist-info/METADATA specifies version '6.0.0b31'.
       > This usually means that the wrong version is hardcoded in pyproject.toml or setup.{py,cfg}.
       > Use the pyprojectVersionPatchHook or patch the version manually so that the project metadata matches the derivation's version.

```
 
 I am unsure if the proposed change is the optimal one, as I am not very familiar with the codebase... but at least I am raising this issue that one can not use the latest Ulauncher 6 builds on NixOS/unstable using flakes.



<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Ulauncher/Ulauncher/pull/1784?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

