### PR TITLE
refactor(core):  typed BaseDataClass constructors

### DIFF
--- a/docs/architecture/base_data_class.md
+++ b/docs/architecture/base_data_class.md
@@ -16,22 +16,39 @@ Use `BaseDataClass` instead of:
 from ulauncher.data import BaseDataClass
 
 class MyData(BaseDataClass):
-    name = ""  # Declare with default values
-    count = 0
-    metadata = {}  # Deep copied on instantiation
+    name: str = ""  # Annotate and give a default
+    count: int = 0
+    metadata: dict[str, str] = {}  # Deep copied on instantiation
 
 data = MyData(name="test", count=5)
 data["name"]  # Works like a dict
 data.name  # Also works like an object
 ```
 
+## Annotate every field
+
+`BaseDataClass` uses PEP 681 `dataclass_transform`, so type checkers build a
+keyword-only `__init__` signature from the annotated attributes:
+
+```python
+MyData(name="test")       # checked
+MyData(nickname="test")   # error: unexpected keyword argument `nickname`
+MyData(count="five")      # error: not assignable to parameter `count`
+MyData({"name": "x"})     # error: positional, use MyData(**data) instead
+```
+
+Only annotated attributes become fields. Runtime behavior is unchanged, so an
+unannotated field still works, but type checkers reject passing it.
+
+`JsonConf` declares its own `__init__` to opt out, since it holds arbitrary keys.
+Its subclasses get the checked signature again.
+
 ## Key Features
 
 - **Inherits from dict** - Works with all dict methods (`get()`, `items()`, etc.)
 - **Deep-copied defaults** - Mutable defaults (lists, dicts) are copied per instance
-- **Keyword arguments only** - No positional args, always explicit
+- **Keyword arguments only** - Type checkers require keywords for annotated fields
 - **Runtime properties** - New properties can be added after instantiation
-- **Type flexible** - No type enforcement, use type hints for documentation
 
 ## Common Use Cases
 
@@ -39,27 +56,27 @@ data.name  # Also works like an object
 
 ```python
 class SearchResult(BaseDataClass):
-    name = ""
-    description = ""
-    icon = None
-    on_enter = None
+    name: str = ""
+    description: str = ""
+    icon: str = ""
+    on_enter: EffectMessage | None = None
 ```
 
 **Event payloads:**
 
 ```python
 class QueryEvent(BaseDataClass):
-    query = ""
-    mode_id = ""
-    timestamp = 0
+    query: str = ""
+    mode_id: str = ""
+    timestamp: int = 0
 ```
 
 **API responses:**
 
 ```python
 class ExtensionManifest(BaseDataClass):
-    name = ""
-    description = ""
-    developer_name = ""
-    preferences = []
+    name: str = ""
+    description: str = ""
+    developer_name: str = ""
+    preferences: list[dict[str, Any]] = []
 ```

--- a/tests/data/test_json_conf.py
+++ b/tests/data/test_json_conf.py
@@ -88,14 +88,14 @@ class TestJsonConf:
 
     def test_inheritance(self, tmp_path: Path) -> None:
         class ClassWDefault(JsonConf):
-            b = 1
-            a = 2
+            b: int = 1
+            a: int = 2
 
             def sum(self) -> int:
                 return self.a + self.b
 
         class SubclassWDefault(ClassWDefault):
-            c = 3
+            c: int = 3
 
         assert ClassWDefault().b == 1
         assert ClassWDefault(b=2).b == 2
@@ -124,7 +124,8 @@ class TestJsonConf:
             def __setitem__(self, key: str, value: Any) -> None:
                 super().__setitem__("_" + key, value)
 
-        data = UnderscorePrefix({"one": 1})
+        initial: dict[str, Any] = {"one": 1}
+        data = UnderscorePrefix(**initial)
         data.update({"two": 2})
         data.three = 3
         data["four"] = 4

--- a/tests/data/test_json_key_value_conf.py
+++ b/tests/data/test_json_key_value_conf.py
@@ -44,7 +44,7 @@ class TestJsonKeyValueConf:
         json_file = str(tmp_path / "jsonkvconf.json")
 
         class Record(JsonConf):
-            value = ""
+            value: str = ""
 
         class Store(JsonKeyValueConf[str, Record]):
             pass
@@ -71,7 +71,7 @@ class TestJsonKeyValueConf:
 
     def test_accepts_existing_value_instances(self) -> None:
         class Record(JsonConf):
-            value = ""
+            value: str = ""
 
         class Store(JsonKeyValueConf[str, Record]):
             pass
@@ -83,7 +83,7 @@ class TestJsonKeyValueConf:
 
     def test_infers_runtime_coercion_from_generic_value_type(self) -> None:
         class Record(JsonConf):
-            value = ""
+            value: str = ""
 
         class Store(JsonKeyValueConf[str, Record]):
             pass

--- a/tests/modes/extensions/test_extension_manifest.py
+++ b/tests/modes/extensions/test_extension_manifest.py
@@ -18,6 +18,11 @@ valid_manifest: dict[str, Any] = {
 }
 
 
+def manifest_with(**overrides: Any) -> ExtensionManifest:
+    merged: dict[str, Any] = {**valid_manifest, **overrides}
+    return ExtensionManifest(**merged)
+
+
 class TestExtensionManifest:
     def test_open__manifest_file__is_read(self) -> None:
         ext_path = os.path.dirname(os.path.abspath(__file__))
@@ -25,153 +30,118 @@ class TestExtensionManifest:
         assert manifest.name == "Test Extension"
 
     def test_validate__name_empty__exception_raised(self) -> None:
-        manifest = ExtensionManifest({"api_version": "1"})
+        manifest = ExtensionManifest(api_version="1")
         with pytest.raises(ext_exceptions.ManifestError):
             manifest.validate()
 
     def test_validate__valid_manifest__no_exceptions_raised(self) -> None:
-        manifest = ExtensionManifest(valid_manifest)
+        manifest = manifest_with()
         manifest.validate()
 
     def test_validate__prefs_incorrect_type__exception_raised(self) -> None:
-        manifest = ExtensionManifest({**valid_manifest, "preferences": {"id": {"type": "incorrect"}}})
+        manifest = manifest_with(preferences={"id": {"type": "incorrect"}})
         with pytest.raises(ext_exceptions.ManifestError):
             manifest.validate()
 
     def test_validate__type_kw_empty_name__exception_raised(self) -> None:
-        manifest = ExtensionManifest({**valid_manifest, "preferences": {"id": {"type": "incorrect", "keyword": "kw"}}})
+        manifest = manifest_with(preferences={"id": {"type": "incorrect", "keyword": "kw"}})
         with pytest.raises(ext_exceptions.ManifestError):
             manifest.validate()
 
     def test_validate__raises_error_if_empty_default_value_for_keyword(self) -> None:
-        manifest = ExtensionManifest(
-            {**valid_manifest, "preferences": {"id": {"type": "keyword", "name": "My Keyword"}}}
-        )
+        manifest = manifest_with(preferences={"id": {"type": "keyword", "name": "My Keyword"}})
         with pytest.raises(ext_exceptions.ManifestError):
             manifest.validate()
 
     def test_validate__doesnt_raise_if_empty_default_value_for_non_keyword(self) -> None:
-        manifest = ExtensionManifest({**valid_manifest, "preferences": {"city": {"type": "input", "name": "City"}}})
+        manifest = manifest_with(preferences={"city": {"type": "input", "name": "City"}})
         manifest.validate()
 
     def test_validate__trigger_missing_name__exception_raised(self) -> None:
-        manifest = ExtensionManifest({**valid_manifest, "triggers": {"t": {}}})
+        manifest = manifest_with(triggers={"t": {}})
         with pytest.raises(ext_exceptions.ManifestError):
             manifest.validate()
 
     def test_validate__pref_missing_name__exception_raised(self) -> None:
-        manifest = ExtensionManifest({**valid_manifest, "preferences": {"p": {"type": "input"}}})
+        manifest = manifest_with(preferences={"p": {"type": "input"}})
         with pytest.raises(ext_exceptions.ManifestError):
             manifest.validate()
 
     def test_validate__min_on_non_number__exception_raised(self) -> None:
-        manifest = ExtensionManifest(
-            {**valid_manifest, "preferences": {"p": {"type": "input", "name": "Text", "min": 5}}}
-        )
+        manifest = manifest_with(preferences={"p": {"type": "input", "name": "Text", "min": 5}})
         with pytest.raises(ext_exceptions.ManifestError):
             manifest.validate()
 
     def test_validate__max_on_non_number__exception_raised(self) -> None:
-        manifest = ExtensionManifest(
-            {**valid_manifest, "preferences": {"p": {"type": "input", "name": "Text", "max": 5}}}
-        )
+        manifest = manifest_with(preferences={"p": {"type": "input", "name": "Text", "max": 5}})
         with pytest.raises(ext_exceptions.ManifestError):
             manifest.validate()
 
     def test_validate__checkbox_bool_default__no_exception(self) -> None:
-        manifest = ExtensionManifest(
-            {**valid_manifest, "preferences": {"p": {"type": "checkbox", "name": "Flag", "default_value": True}}}
-        )
+        manifest = manifest_with(preferences={"p": {"type": "checkbox", "name": "Flag", "default_value": True}})
         manifest.validate()
 
     def test_validate__checkbox_no_default__no_exception(self) -> None:
-        manifest = ExtensionManifest({**valid_manifest, "preferences": {"p": {"type": "checkbox", "name": "Flag"}}})
+        manifest = manifest_with(preferences={"p": {"type": "checkbox", "name": "Flag"}})
         manifest.validate()
 
     def test_validate__checkbox_non_bool_default__exception_raised(self) -> None:
-        manifest = ExtensionManifest(
-            {**valid_manifest, "preferences": {"p": {"type": "checkbox", "name": "Flag", "default_value": "yes"}}}
-        )
+        manifest = manifest_with(preferences={"p": {"type": "checkbox", "name": "Flag", "default_value": "yes"}})
         with pytest.raises(ext_exceptions.ManifestError):
             manifest.validate()
 
     def test_validate__number_valid__no_exception(self) -> None:
-        manifest = ExtensionManifest(
-            {**valid_manifest, "preferences": {"p": {"type": "number", "name": "Count", "default_value": 5}}}
-        )
+        manifest = manifest_with(preferences={"p": {"type": "number", "name": "Count", "default_value": 5}})
         manifest.validate()
 
     def test_validate__number_no_default__exception_raised(self) -> None:
-        manifest = ExtensionManifest({**valid_manifest, "preferences": {"p": {"type": "number", "name": "Count"}}})
+        manifest = manifest_with(preferences={"p": {"type": "number", "name": "Count"}})
         with pytest.raises(ext_exceptions.ManifestError):
             manifest.validate()
 
     def test_validate__number_bool_default__exception_raised(self) -> None:
-        manifest = ExtensionManifest(
-            {**valid_manifest, "preferences": {"p": {"type": "number", "name": "Count", "default_value": True}}}
-        )
+        manifest = manifest_with(preferences={"p": {"type": "number", "name": "Count", "default_value": True}})
         with pytest.raises(ext_exceptions.ManifestError):
             manifest.validate()
 
     def test_validate__number_min_zero__no_exception(self) -> None:
-        manifest = ExtensionManifest(
-            {**valid_manifest, "preferences": {"p": {"type": "number", "name": "Count", "default_value": 0, "min": 0}}}
-        )
+        manifest = manifest_with(preferences={"p": {"type": "number", "name": "Count", "default_value": 0, "min": 0}})
         manifest.validate()
 
     def test_validate__number_default_below_min__exception_raised(self) -> None:
-        manifest = ExtensionManifest(
-            {**valid_manifest, "preferences": {"p": {"type": "number", "name": "Count", "default_value": 3, "min": 5}}}
-        )
+        manifest = manifest_with(preferences={"p": {"type": "number", "name": "Count", "default_value": 3, "min": 5}})
         with pytest.raises(ext_exceptions.ManifestError):
             manifest.validate()
 
     def test_validate__number_default_above_max__exception_raised(self) -> None:
-        manifest = ExtensionManifest(
-            {
-                **valid_manifest,
-                "preferences": {"p": {"type": "number", "name": "Count", "default_value": 15, "max": 10}},
-            }
-        )
+        manifest = manifest_with(preferences={"p": {"type": "number", "name": "Count", "default_value": 15, "max": 10}})
         with pytest.raises(ext_exceptions.ManifestError):
             manifest.validate()
 
     def test_validate__number_min_above_max__exception_raised(self) -> None:
-        manifest = ExtensionManifest(
-            {
-                **valid_manifest,
-                "preferences": {"p": {"type": "number", "name": "Count", "default_value": 10, "min": 8, "max": 3}},
-            }
+        manifest = manifest_with(
+            preferences={"p": {"type": "number", "name": "Count", "default_value": 10, "min": 8, "max": 3}}
         )
         with pytest.raises(ext_exceptions.ManifestError):
             manifest.validate()
 
     def test_validate__number_bool_min__exception_raised(self) -> None:
-        manifest = ExtensionManifest(
-            {
-                **valid_manifest,
-                "preferences": {"p": {"type": "number", "name": "Count", "default_value": 5, "min": True}},
-            }
+        manifest = manifest_with(
+            preferences={"p": {"type": "number", "name": "Count", "default_value": 5, "min": True}}
         )
         with pytest.raises(ext_exceptions.ManifestError):
             manifest.validate()
 
     def test_validate__number_bool_max__exception_raised(self) -> None:
-        manifest = ExtensionManifest(
-            {
-                **valid_manifest,
-                "preferences": {"p": {"type": "number", "name": "Count", "default_value": 5, "max": True}},
-            }
+        manifest = manifest_with(
+            preferences={"p": {"type": "number", "name": "Count", "default_value": 5, "max": True}}
         )
         with pytest.raises(ext_exceptions.ManifestError):
             manifest.validate()
 
     def test_validate__select_with_options__no_exception(self) -> None:
-        manifest = ExtensionManifest(
-            {
-                **valid_manifest,
-                "preferences": {"p": {"type": "select", "name": "Choice", "options": [{"value": "a", "text": "A"}]}},
-            }
+        manifest = manifest_with(
+            preferences={"p": {"type": "select", "name": "Choice", "options": [{"value": "a", "text": "A"}]}}
         )
         manifest.validate()
 
@@ -179,36 +149,38 @@ class TestExtensionManifest:
         # Workaround: pyrefly raises implicit-any for `[]` literals, but ruff rejects `list()`.
         # Typed variable avoids both. See https://github.com/facebook/pyrefly/issues/2442
         empty: list[str] = []
-        manifest = ExtensionManifest(
-            {**valid_manifest, "preferences": {"p": {"type": "select", "name": "Choice", "options": empty}}}
-        )
+        manifest = manifest_with(preferences={"p": {"type": "select", "name": "Choice", "options": empty}})
         with pytest.raises(ext_exceptions.ManifestError):
             manifest.validate()
 
     def test_check_compatibility__manifest_version_0__exception_raised(self) -> None:
-        manifest = ExtensionManifest({"name": "Test", "api_version": "0"})
+        manifest = ExtensionManifest(name="Test", api_version="0")
         with pytest.raises(ext_exceptions.CompatibilityError):
             manifest.check_compatibility()
 
     def test_check_compatibility__api_version__no_exceptions(self) -> None:
-        manifest = ExtensionManifest({"name": "Test", "api_version": "3"})
+        manifest = ExtensionManifest(name="Test", api_version="3")
         manifest.check_compatibility()
 
     def test_defaults_not_included_in_stringify(self) -> None:
         # Ensure defaults don't leak
         assert json_stringify(ExtensionManifest()) == '{"input_debounce": 0.05}'
-        manifest = ExtensionManifest(preferences={"ns": {"k": "v"}})
+        # __setitem__ converts the raw dict into ExtensionManifestPreference instances.
+        raw: dict[str, Any] = {"preferences": {"ns": {"k": "v"}}}
+        manifest = ExtensionManifest(**raw)
         assert json_stringify(manifest) == '{"input_debounce": 0.05, "preferences": {"ns": {"k": "v"}}}'
 
     def test_manifest_backwards_compatibility(self) -> None:
-        em = ExtensionManifest(
-            required_api_version="3",
-            developer_name="John",
-            manifest_version="1",
-            description="asdf",
-            options={"query_debounce": 0.555},
-            preferences=[{"id": "asdf", "name": "ghjk"}],
-        )
+        # Legacy key names, renamed by ExtensionManifest.__setitem__ rather than declared as fields.
+        legacy: dict[str, Any] = {
+            "required_api_version": "3",
+            "developer_name": "John",
+            "manifest_version": "1",
+            "description": "asdf",
+            "options": {"query_debounce": 0.555},
+            "preferences": [{"id": "asdf", "name": "ghjk"}],
+        }
+        em = ExtensionManifest(**legacy)
         assert em.get("options") is None
         assert em.get("required_api_version") is None
         assert em.get("developer_name") is None

--- a/tests/modes/shortcuts/test_shortcuts.py
+++ b/tests/modes/shortcuts/test_shortcuts.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from pathlib import Path
+from typing import Any
 
 from ulauncher.modes.shortcuts.shortcuts import Shortcut
 
@@ -17,6 +18,8 @@ class TestShortcut:
         assert shortcut.icon == "~/icons/custom.png"
 
     def test_converts_legacy_float_timestamp(self) -> None:
-        shortcut = Shortcut(added=123.5)
+        # Shortcut.__setitem__ coerces this to int, so the declared field type is narrower than the input.
+        legacy: dict[str, Any] = {"added": 123.5}
+        shortcut = Shortcut(**legacy)
 
         assert shortcut.added == 123

--- a/ulauncher/cli/__init__.py
+++ b/ulauncher/cli/__init__.py
@@ -16,11 +16,11 @@ CommandGroupName = Literal["App", "Extension"]
 
 
 class CLIArguments(BaseDataClass):
-    verbose = False
-    input = ""
-    path = ""
+    verbose: bool = False
+    input: str = ""
+    path: str = ""
     query: str | None = None
-    with_debugger = False
+    with_debugger: bool = False
     command: CommandName = "show"
 
 

--- a/ulauncher/data/base_data_class.py
+++ b/ulauncher/data/base_data_class.py
@@ -1,9 +1,19 @@
 from __future__ import annotations
 
 from copy import deepcopy
-from typing import Any
+from typing import TYPE_CHECKING, Any, Callable, TypeVar
 
 from ulauncher.utils.lru_cache import lru_cache
+
+if TYPE_CHECKING:
+    from typing_extensions import dataclass_transform
+else:
+    # Type-check-only decorator (PEP 681). typing_extensions must stay out of the runtime,
+    # and typing.dataclass_transform needs py3.11, so at runtime this is a no-op.
+    _T = TypeVar("_T")
+
+    def dataclass_transform(**_kwargs: Any) -> Callable[[_T], _T]:
+        return lambda cls: cls
 
 
 @lru_cache(maxsize=None)
@@ -23,6 +33,7 @@ def _apply_class_defaults(instance: BaseDataClass) -> None:
     instance.update(deepcopy(_class_defaults(type(instance))))
 
 
+@dataclass_transform(kw_only_default=True, eq_default=False)
 class BaseDataClass(dict):  # type: ignore [type-arg]
     """
     BaseDataClass
@@ -34,13 +45,15 @@ class BaseDataClass(dict):  # type: ignore [type-arg]
     * Unlike dataclasses, new props (set at runtime, but undeclared in the class) become part of the data.
     * Implemented using the AttrDict pattern, but it avoids self.__dict__ = self
 
+    * Annotated props become constructor keywords for type checkers (PEP 681), so annotate every field.
+
     # Example use:
     class Person(BaseDataClass):
-        # All props you declare need a default value (not None)
-        first_name = ""
-        last_name = ""
-        age = 0
-        metadata = {}  # Note: This will be cloned when you create a new instance, so you can ignore linter warnings
+        # All props you declare need an annotation and a default value (not None)
+        first_name: str = ""
+        last_name: str = ""
+        age: int = 0
+        metadata: dict[str, str] = {}  # Cloned per instance, so you can ignore linter warnings
 
         def full_name(self):
             return self.first_name + " " + self.last_name

--- a/ulauncher/data/json_conf.py
+++ b/ulauncher/data/json_conf.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import Any, TypeVar
+from typing import TYPE_CHECKING, Any, TypeVar
 
 from ulauncher.data._file_cache import _load_cached_file_instance, _save_cached_file_instance
 from ulauncher.data.base_data_class import BaseDataClass
@@ -19,6 +19,13 @@ class JsonConf(BaseDataClass):
 
     File paths are stored in an external reference object, which is not part of the data.
     """
+
+    if TYPE_CHECKING:
+        # Declaring __init__ opts this class out of the PEP 681 field synthesis, which would otherwise
+        # reject the arbitrary keys it holds. It is only a signature, so it stays out of the runtime and
+        # BaseDataClass.__init__ keeps handling construction. Subclasses that declare fields don't
+        # override __init__, so they still get the synthesis.
+        def __init__(self, *args: Any, **kwargs: Any) -> None: ...
 
     @classmethod
     def load(cls: type[T], path: str, *, force: bool = False) -> T:

--- a/ulauncher/internals/result.py
+++ b/ulauncher/internals/result.py
@@ -21,16 +21,15 @@ class Result(BaseDataClass):
                          (legacy: please use `actions` instead).
     """
 
-    compact = False  #: If True, the result will be displayed in a single line without a title
-    wrap = False  #: If True, name and description wrap over multiple lines instead of being ellipsized
-    highlightable = False  #: If True, a substring matching the query will be highlighted
-    searchable = False
-    name = ""  #: The name of the result item
-    description = ""  #: The description of the result item. Used only if `compact` is False
-    keyword = ""
-    icon = (
-        ""  #: An icon path relative to the extension root. If not set, the default icon of the extension will be used
-    )
+    compact: bool = False  #: If True, the result will be displayed in a single line without a title
+    wrap: bool = False  #: If True, name and description wrap over multiple lines instead of being ellipsized
+    highlightable: bool = False  #: If True, a substring matching the query will be highlighted
+    searchable: bool = False
+    name: str = ""  #: The name of the result item
+    description: str = ""  #: The description of the result item. Used only if `compact` is False
+    keyword: str = ""
+    #: An icon path relative to the extension root. If not set, the default icon of the extension will be used
+    icon: str = ""
     actions: dict[str, dict[Literal["name", "icon"], str]] = {}  #: dict of actions with display names and icons
     on_enter: effects.EffectMessage | None = None
     on_alt_enter: effects.EffectMessage | None = None
@@ -100,9 +99,9 @@ class ActionResult(Result):
     Used internally when a Result has multiple actions defined.
     """
 
-    action_id = ""  # The action ID from the parent result's actions dict
+    action_id: str = ""  # The action ID from the parent result's actions dict
     parent_result: Result | None = None  # Reference to the parent result
 
 
 class KeywordTrigger(Result):
-    searchable = True
+    searchable: bool = True

--- a/ulauncher/modes/apps/app_result.py
+++ b/ulauncher/modes/apps/app_result.py
@@ -15,9 +15,9 @@ ACTION_PREFIX = "action:"
 
 
 class AppResult(Result):
-    searchable = True
-    app_id = ""
-    _executable = ""
+    searchable: bool = True
+    app_id: str = ""
+    _executable: str = ""
 
     def __init__(self, app_info: GioUnix.DesktopAppInfo) -> None:
         actions: dict[str, dict[Literal["name", "icon"], str]] = {"launch": {"name": "Launch application"}}

--- a/ulauncher/modes/calc/calc_result.py
+++ b/ulauncher/modes/calc/calc_result.py
@@ -7,18 +7,18 @@ calc_icon = f"{paths.ASSETS}/icons/calculator.png"
 
 
 class CalcResult(Result):
-    icon = calc_icon
-    result = ""
+    icon: str = calc_icon
+    result: str = ""
     actions = {"copy": {"name": "Copy to clipboard", "icon": "edit-copy"}}
 
 
 class CalcCompletionResult(Result):
-    icon = calc_icon
-    completion = ""
+    icon: str = calc_icon
+    completion: str = ""
     actions = {"complete": {"name": "Complete expression", "icon": "go-next"}}
 
 
 class CalcErrorResult(Result):
-    name = "Error!"
-    description = "Invalid expression"
-    icon = calc_icon
+    name: str = "Error!"
+    description: str = "Invalid expression"
+    icon: str = calc_icon

--- a/ulauncher/modes/extensions/extension_manifest.py
+++ b/ulauncher/modes/extensions/extension_manifest.py
@@ -12,9 +12,9 @@ logger = logging.getLogger(__name__)
 
 
 class ExtensionManifestPreference(BaseDataClass):
-    name = ""
-    type = ""
-    description = ""
+    name: str = ""
+    type: str = ""
+    description: str = ""
     options: list[dict[str, Any]] = []
     default_value: str | int | bool = ""
     max: int | None = None
@@ -22,10 +22,10 @@ class ExtensionManifestPreference(BaseDataClass):
 
 
 class ExtensionManifestTrigger(BaseDataClass):
-    name = ""
-    description = ""
-    default_keyword = ""
-    icon = ""
+    name: str = ""
+    description: str = ""
+    default_keyword: str = ""
+    icon: str = ""
 
     def __setitem__(self, key: str, value: Any) -> None:  # type: ignore[override]
         # Backwards compatibility: rename "keyword" to "default_keyword"
@@ -35,12 +35,12 @@ class ExtensionManifestTrigger(BaseDataClass):
 
 
 class ExtensionManifest(JsonConf):
-    api_version = ""
-    authors = ""
-    name = ""
-    icon = ""
-    instructions = ""
-    input_debounce = 0.05
+    api_version: str = ""
+    authors: str = ""
+    name: str = ""
+    icon: str = ""
+    instructions: str = ""
+    input_debounce: float = 0.05
     triggers: dict[str, ExtensionManifestTrigger] = {}
     preferences: dict[str, ExtensionManifestPreference] = {}
 
@@ -59,18 +59,19 @@ class ExtensionManifest(JsonConf):
                 return
         # Convert triggers dicts to ExtensionManifestTrigger instances
         elif key == "triggers" and isinstance(value, dict):
-            value = {t_id: ExtensionManifestTrigger(trigger) for t_id, trigger in value.items()}
+            value = {t_id: ExtensionManifestTrigger(**trigger) for t_id, trigger in value.items()}
         # Convert preferences dicts to manifest preference instances (or trigger it's an old shortcuts)
         elif key == "preferences":
             if isinstance(value, dict):
-                value = {p_id: ExtensionManifestPreference(pref) for p_id, pref in value.items()}
+                value = {p_id: ExtensionManifestPreference(**pref) for p_id, pref in value.items()}
             elif isinstance(value, list):  # APIv2 backwards compatibility
                 prefs = {}
                 for p in value:
                     if isinstance(p, dict):
                         p_id = p.get("id")
                         if isinstance(p_id, str):
-                            pref = ExtensionManifestPreference(p, id=None)
+                            # The id becomes the dict key, so it is not carried on the preference
+                            pref = ExtensionManifestPreference(**{k: v for k, v in p.items() if k != "id"})
                             if pref.type != "keyword":
                                 prefs[p_id] = pref
                             else:

--- a/ulauncher/modes/extensions/extension_mode.py
+++ b/ulauncher/modes/extensions/extension_mode.py
@@ -28,9 +28,9 @@ LOADING_TIMEOUT = 10  # seconds to wait for a transitioning extension before giv
 
 
 class ExtensionLaunchTrigger(Result):
-    searchable = True
-    ext_id = ""
-    trigger_id = ""
+    searchable: bool = True
+    ext_id: str = ""
+    trigger_id: str = ""
     actions = {"__launch__": {"name": "Launch"}}
 
 

--- a/ulauncher/modes/extensions/extension_record.py
+++ b/ulauncher/modes/extensions/extension_record.py
@@ -22,23 +22,23 @@ class ExtensionPreference(ExtensionManifestPreference):
 
 
 class ExtensionRecordTrigger(BaseDataClass):
-    name = ""
-    description = ""
-    default_keyword = ""
-    icon = ""
-    keyword = ""
+    name: str = ""
+    description: str = ""
+    default_keyword: str = ""
+    icon: str = ""
+    keyword: str = ""
 
 
 class ExtensionState(JsonConf):
-    id = ""
-    url = ""
-    browser_url = ""
-    updated_at = ""
-    commit_hash = ""
-    commit_time = ""
-    is_enabled = True
-    error_message = ""
-    error_type = ""
+    id: str = ""
+    url: str = ""
+    browser_url: str = ""
+    updated_at: str = ""
+    commit_hash: str = ""
+    commit_time: str = ""
+    is_enabled: bool = True
+    error_message: str = ""
+    error_type: str = ""
 
     def __setitem__(self, key: str, value: Any) -> None:  # type: ignore[override]
         if key == "last_commit":
@@ -116,7 +116,7 @@ class ExtensionRecord:
         user_prefs_json = _load_preferences(self.id)
         triggers = {}
         for t_id, manifest_trigger in self.manifest.triggers.items():
-            trigger = ExtensionRecordTrigger(manifest_trigger)
+            trigger = ExtensionRecordTrigger(**manifest_trigger)
             trigger.keyword = user_prefs_json.get("triggers", {}).get(t_id, {}).get("keyword", trigger.default_keyword)
             triggers[t_id] = trigger
 

--- a/ulauncher/modes/extensions/extension_remote.py
+++ b/ulauncher/modes/extensions/extension_remote.py
@@ -137,8 +137,8 @@ class _BareRepo:
 
 
 class UrlParseResult(BaseDataClass):
-    ext_id: str
-    remote_url: str
+    ext_id: str = ""
+    remote_url: str = ""
     browser_url: str | None = None
     download_url_template: str | None = None
 

--- a/ulauncher/modes/file_browser/open_with.py
+++ b/ulauncher/modes/file_browser/open_with.py
@@ -9,9 +9,9 @@ logger = logging.getLogger(__name__)
 
 
 class OpenWithAppResult(Result):
-    compact = True
-    path = ""
-    app_id = ""
+    compact: bool = True
+    path: str = ""
+    app_id: str = ""
     actions = {"open_with_app": {"name": "Open with this application", "icon": "system-run"}}
 
 

--- a/ulauncher/modes/file_browser/results.py
+++ b/ulauncher/modes/file_browser/results.py
@@ -23,9 +23,9 @@ _FOLDER_ACTIONS: _Actions = {
 
 
 class FileResult(Result):
-    compact = True
-    highlightable = True
-    path = ""
+    compact: bool = True
+    highlightable: bool = True
+    path: str = ""
 
     def __init__(self, path: str) -> None:
         is_dir = isdir(path)

--- a/ulauncher/modes/shortcuts/results.py
+++ b/ulauncher/modes/shortcuts/results.py
@@ -4,14 +4,16 @@ from ulauncher.internals.result import Result
 
 
 class ShortcutResult(Result):
-    is_default_search = False
-    cmd = ""
+    is_default_search: bool = False
+    run_without_argument: bool = False
+    cmd: str = ""
     actions = {"run": {"name": "Run shortcut", "icon": "system-run"}}
 
 
 class ShortcutStaticTrigger(Result):
-    searchable = True
-    cmd = ""
+    searchable: bool = True
+    run_without_argument: bool = False
+    cmd: str = ""
     actions = {"run_static": {"name": "Run shortcut", "icon": "system-run"}}
 
 

--- a/ulauncher/modes/shortcuts/shortcuts.py
+++ b/ulauncher/modes/shortcuts/shortcuts.py
@@ -9,7 +9,7 @@ from ulauncher import paths
 from ulauncher.data import BaseDataClass, JsonKeyValueConf
 from ulauncher.utils.fold_user_path import fold_user_path
 
-INITIAL_SHORTCUTS = [
+INITIAL_SHORTCUTS: list[dict[str, Any]] = [
     {
         "id": "googlesearch",
         "keyword": "g",
@@ -38,14 +38,14 @@ INITIAL_SHORTCUTS = [
 
 
 class Shortcut(BaseDataClass):
-    name = ""
-    keyword = ""
-    cmd = ""
-    icon = ""
-    is_default_search = False
-    run_without_argument = False  # Only used in ShortcutTrigger (not Result)
-    added = 0
-    id = ""
+    name: str = ""
+    keyword: str = ""
+    cmd: str = ""
+    icon: str = ""
+    is_default_search: bool = False
+    run_without_argument: bool = False  # Only used in ShortcutTrigger (not Result)
+    added: int = 0
+    id: str = ""
 
     def __setitem__(self, key: str, value: Any) -> None:  # type: ignore[override]
         if key == "added" and isinstance(value, float):

--- a/ulauncher/ui/helpers/theme.py
+++ b/ulauncher/ui/helpers/theme.py
@@ -46,7 +46,8 @@ def get_themes() -> dict[str, Theme]:
         data = json.loads(manifest_path.read_text())
         if data.get("extend_theme", "") is None:
             del data["extend_theme"]
-        all_themes.append(LegacyTheme(**data, base_path=str(manifest_path.parent)))
+        data["base_path"] = str(manifest_path.parent)
+        all_themes.append(LegacyTheme(**data))
 
     for theme in all_themes:
         try:

--- a/ulauncher/ui/helpers/theme.py
+++ b/ulauncher/ui/helpers/theme.py
@@ -46,7 +46,7 @@ def get_themes() -> dict[str, Theme]:
         data = json.loads(manifest_path.read_text())
         if data.get("extend_theme", "") is None:
             del data["extend_theme"]
-        all_themes.append(LegacyTheme(data, base_path=str(manifest_path.parent)))
+        all_themes.append(LegacyTheme(**data, base_path=str(manifest_path.parent)))
 
     for theme in all_themes:
         try:
@@ -68,8 +68,8 @@ def get_themes() -> dict[str, Theme]:
 
 
 class Theme(JsonConf):
-    name = ""
-    base_path = ""  # Runtime value, should not be stored
+    name: str = ""
+    base_path: str = ""  # Runtime value, should not be stored
 
     def get_css_path(self) -> Path:
         return Path(self.base_path, f"{self.name}.css")
@@ -109,8 +109,8 @@ class Theme(JsonConf):
 
 
 class LegacyTheme(Theme):
-    css_file = ""
-    extend_theme = ""
+    css_file: str = ""
+    extend_theme: str = ""
     matched_text_hl_colors: dict[str, str] = {}
 
     def get_css_path(self) -> Path:

--- a/ulauncher/utils/settings.py
+++ b/ulauncher/utils/settings.py
@@ -9,25 +9,25 @@ _settings_file = f"{paths.CONFIG}/settings.json"
 
 
 class Settings(JsonConf):
-    arrow_key_aliases = "hjkl"
-    auto_resume = False
-    base_width = 750
-    close_on_focus_out = True
-    disable_desktop_filters = False
-    enable_application_mode = True
-    grab_mouse_pointer = False
-    hotkey_show_app = ""  # Note that this is no longer used, other than for migrating to the DE wrapper
-    jump_keys = "1234567890abcdefghijklmnopqrstuvwxyz"
-    keep_alive = True
-    layer_shell = True
-    max_recent_apps = 0
-    raise_if_started = False
-    render_on_screen = "mouse-pointer-monitor"
-    show_tray_icon = True
-    terminal_command = ""
-    theme_name = "light"
-    tray_icon_name = "ulauncher-indicator-symbolic"
-    window_shadow = 5
+    arrow_key_aliases: str = "hjkl"
+    auto_resume: bool = False
+    base_width: int = 750
+    close_on_focus_out: bool = True
+    disable_desktop_filters: bool = False
+    enable_application_mode: bool = True
+    grab_mouse_pointer: bool = False
+    hotkey_show_app: str = ""  # Note that this is no longer used, other than for migrating to the DE wrapper
+    jump_keys: str = "1234567890abcdefghijklmnopqrstuvwxyz"
+    keep_alive: bool = True
+    layer_shell: bool = True
+    max_recent_apps: int = 0
+    raise_if_started: bool = False
+    render_on_screen: str = "mouse-pointer-monitor"
+    show_tray_icon: bool = True
+    terminal_command: str = ""
+    theme_name: str = "light"
+    tray_icon_name: str = "ulauncher-indicator-symbolic"
+    window_shadow: int = 5
 
     # Convert dash to underscore
     def __setitem__(self, key: str, value: Any) -> None:  # type: ignore[override]


### PR DESCRIPTION
Mark BaseDataClass with PEP 681 dataclass_transform so type checkers build an __init__ from the annotated class attributes. Subclasses now get constructor autocompletion and keyword checking without declaring the fields a second time, and unlike typing.Unpack it composes with inheritance, so each subclass picks up its own fields on top of the inherited ones.

Only annotated attributes become fields, so every field declaration gains a type. JsonConf declares a permissive __init__ under TYPE_CHECKING to opt out, since it is a generic container for arbitrary keys. It is only a signature, so BaseDataClass.__init__ still handles construction at runtime.

The synthesized __init__ is keyword-only, so the few positional-dict constructions become **unpacking. Unpacking a dict[str, Any] is still allowed, which is what dynamic data (JSON, IPC payloads, legacy key aliases) relies on.

typing_extensions is type-check-only here and typing.dataclass_transform needs py3.11, so the decorator falls back to a runtime no-op.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Ulauncher/Ulauncher/pull/1785?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

