### PR TITLE
refactor: rewrite extension lifecycle without asyncio and threading

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -147,6 +147,7 @@ select = [
 banned-module-level-imports = ["typing_extensions"]
 
 [tool.ruff.lint.flake8-tidy-imports.banned-api]
+"asyncio" = {msg = "To handle async operations, use Gio or Glib async methods that run in the background. See ulauncher.utils.subprocess_utils."}
 "gi.repository" = {msg = "Import GI modules from ulauncher.gi, not gi.repository directly."}
 "ulauncher.ui" = {msg = "Import ulauncher.ui only from ulauncher/cli/commands/start.py - it pulls in GTK and must not leak into extension or CLI runtime."}
 "ulauncher.api" = {msg = "ulauncher.api is the extension process API. Importing it into the app runs its module-level setup there. Shared types belong in ulauncher.internals."}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -154,6 +154,7 @@ banned-module-level-imports = ["typing_extensions"]
 "functools.lru_cache" = {msg = "Use ulauncher.utils.lru_cache instead to preserve parameter types."}
 "functools.cache" = {msg = "Use ulauncher.utils.lru_cache instead to preserve parameter types."}
 "functools.cached_property" = {msg = "cached_property erases property types. If you need to use this, create a typed wrapper similar to ulauncher.utils.lru_cache"}
+"threading" = {msg = "Avoid threading. Use callbacks with Glib async methods that run in the background when possible"}
 
 [tool.ruff.lint.per-file-ignores]
 "tests/**/*.py" = [  # Relax some linting rules for tests

--- a/tests/modes/extensions/test_extension_lifecycle.py
+++ b/tests/modes/extensions/test_extension_lifecycle.py
@@ -1,0 +1,341 @@
+"""State-machine tests for the extension lifecycle: desired-state reconciliation and the
+per-extension job queue in ExtensionService.
+
+ExtensionRuntime is faked so the tests control when "processes" exit, which makes the
+interleavings scriptable. The registry's disk/network operations (update, uninstall) are
+faked at the ExtensionRegistry level with the same stop-swap-report contract as the real
+chains, minus the I/O. The fakes log every step, so the tests assert the full event order.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Any, Callable, Iterator
+
+import pytest
+from pytest_mock import MockerFixture
+
+from ulauncher.modes.extensions import extension_registry, extension_service
+from ulauncher.modes.extensions.extension_registry import ExtensionRegistry
+from ulauncher.modes.extensions.extension_service import ExtensionService
+
+
+class FakeManifest:
+    triggers: dict[str, Any] = {}
+    input_debounce = 0.05
+
+    def validate(self) -> None:
+        pass
+
+    def check_compatibility(self, verbose: bool = False) -> None:
+        pass
+
+    def supports_current_api(self) -> bool:
+        return True
+
+
+class FakeState:
+    is_enabled = True
+    error_type = ""
+    error_message = ""
+
+    def save(self, **kwargs: Any) -> None:
+        for key, value in kwargs.items():
+            setattr(self, key, value)
+
+
+class FakeRecord:
+    is_preview = False
+
+    def __init__(self, ext_id: str) -> None:
+        self.id = ext_id
+        self.path = f"/fake/{ext_id}"
+        self.state = FakeState()
+        self.manifest = FakeManifest()
+        self.preferences: dict[str, Any] = {}
+
+    @property
+    def is_enabled(self) -> bool:
+        return self.is_preview or (self.state.is_enabled and not self.has_error)
+
+    @property
+    def has_error(self) -> bool:
+        return not self.is_preview and bool(self.state.error_type)
+
+    def reload_state(self) -> None:
+        pass
+
+
+class FakePreviewRecord(FakeRecord):
+    is_preview = True
+
+    def __init__(self, ext_id: str, path: str, with_debugger: bool = False) -> None:
+        super().__init__(ext_id)
+        self.path = path
+        self.with_debugger = with_debugger
+
+
+class FakeRuntime:
+    def __init__(self, ext_id: str, exit_handler: Callable[[str, str], None]) -> None:
+        self.ext_id = ext_id
+        self.stop_requested = False
+        self._exit_handler = exit_handler
+
+    def stop(self) -> None:
+        self.stop_requested = True
+
+    def exit(self, cause: str = "Stopped", error_msg: str = "") -> None:
+        self._exit_handler(cause, error_msg)
+
+
+class Harness:
+    service: ExtensionService
+    disk: dict[str, FakeRecord]
+    spawned: list[FakeRuntime]
+    log: list[str]
+
+    def __init__(self, mocker: MockerFixture, tmp_path: Path) -> None:
+        self.disk = {}
+        self.spawned = []
+        self.log = []
+        harness = self
+
+        def make_runtime(
+            ext_id: str,
+            _cmd: list[str],
+            _env: dict[str, str],
+            exit_handler: Callable[[str, str], None],
+            _message_handler: Any,
+        ) -> FakeRuntime:
+            harness.log.append(f"spawn:{ext_id}")
+            runtime = FakeRuntime(ext_id, exit_handler)
+            harness.spawned.append(runtime)
+            return runtime
+
+        # The registry fakes mirror the real chains' contract: stop through the lifecycle,
+        # do the disk work, report. The real service.stop_extension decides whether a previewed
+        # id actually needs stopping.
+
+        def fake_update(service: Any, record: Any, on_success: Callable[[bool], None], _on_error: Any) -> None:
+            harness.log.append(f"update-start:{record.id}")
+
+            def swap() -> None:
+                harness.log.append(f"update-swap:{record.id}")
+                on_success(True)
+
+            service.stop_extension(record, swap)
+
+        def fake_uninstall(service: Any, record: Any, on_done: Callable[[], None], _on_error: Any) -> None:
+            def remove() -> None:
+                harness.log.append(f"uninstall-remove:{record.id}")
+                del harness.disk[record.id]
+                on_done()
+
+            service.stop_extension(record, remove)
+
+        mocker.patch.object(extension_service, "ExtensionRuntime", make_runtime)
+        mocker.patch.object(extension_service, "PreviewExtensionRecord", FakePreviewRecord)
+        mocker.patch.object(extension_service.cli, "get_args", return_value=SimpleNamespace(verbose=False))
+        mocker.patch.object(
+            extension_registry.extension_finder,
+            "locate",
+            side_effect=lambda ext_id: self.disk[ext_id].path if ext_id in self.disk else None,
+        )
+        mocker.patch.object(extension_registry, "ExtensionRecord", side_effect=lambda ext_id, _path: self.disk[ext_id])
+        mocker.patch.object(ExtensionRegistry, "update", fake_update)
+        mocker.patch.object(ExtensionRegistry, "uninstall", fake_uninstall)
+        # redirect the preview log off the real state dir so its file writes land in tmp_path
+        mocker.patch.object(extension_service.paths, "PREVIEW_LOG_FILE", str(tmp_path / "preview.log"))
+        self.service = ExtensionService()
+
+    def add_installed(self, ext_id: str) -> Any:
+        record = FakeRecord(ext_id)
+        self.disk[ext_id] = record
+        return record
+
+    def start(self, record: Any) -> FakeRuntime:
+        self.service.start_extension(record)
+        return self.spawned[-1]
+
+
+@pytest.fixture
+def harness(mocker: MockerFixture, tmp_path: Path) -> Iterator[Harness]:
+    yield Harness(mocker, tmp_path)
+    # rebind the event bus to the module singleton; the harness service took over the binding
+    extension_service.events.set_self(extension_service.ext_service)
+
+
+def unexpected_error(error: Exception) -> None:
+    pytest.fail(f"Unexpected error reported: {error}")
+
+
+def test_update_then_uninstall_runs_in_order_and_does_not_resurrect(harness: Harness) -> None:
+    record = harness.add_installed("ext")
+    runtime = harness.start(record)
+    results: list[Any] = []
+
+    harness.service.update(record, lambda updated: results.append(("updated", updated)), unexpected_error)
+    harness.service.uninstall(record, lambda: results.append("removed"), unexpected_error)
+
+    # the update job holds the id: it has requested the stop, the uninstall is queued behind it
+    assert runtime.stop_requested
+    assert "uninstall-remove:ext" not in harness.log
+
+    runtime.exit("Stopped")
+
+    assert results == [("updated", True), "removed"]
+    # the swap lands before the removal, and the final reconcile finds no record:
+    # nothing respawns and no error state is written
+    assert harness.log == ["spawn:ext", "update-start:ext", "update-swap:ext", "uninstall-remove:ext"]
+    assert record.state.error_type == ""
+
+
+def test_update_queued_behind_uninstall_is_dropped(harness: Harness) -> None:
+    record = harness.add_installed("ext")
+    runtime = harness.start(record)
+    results: list[Any] = []
+
+    harness.service.uninstall(record, lambda: results.append("removed"), unexpected_error)
+    harness.service.update(
+        record,
+        lambda updated: results.append(("updated", updated)),
+        lambda error: results.append(("error", error)),
+    )
+
+    # the uninstall job holds the id: it has requested the stop, the update is queued behind it
+    assert runtime.stop_requested
+    assert "update-start:ext" not in harness.log
+
+    runtime.exit("Stopped")
+
+    # the uninstall runs to completion; the queued update re-resolves the record, finds it
+    # gone, and is dropped rather than resurrecting the extension
+    assert results[0] == "removed"
+    assert results[1][0] == "error"
+    assert "update-start:ext" not in harness.log
+    assert "ext" not in harness.disk
+
+
+def test_disable_update_enable_starts_the_new_version_last(harness: Harness) -> None:
+    record = harness.add_installed("ext")
+    runtime = harness.start(record)
+
+    harness.service.toggle_enabled(record, False)
+    assert runtime.stop_requested
+
+    harness.service.update(record, lambda _updated: None, unexpected_error)
+    harness.service.toggle_enabled(record, True)
+    # the update job still holds the id, so enabling must not start anything yet
+    assert len(harness.spawned) == 1
+
+    runtime.exit("Stopped")
+
+    # the swap completed before the job's reconcile started the extension again
+    assert harness.log == ["spawn:ext", "update-start:ext", "update-swap:ext", "spawn:ext"]
+
+
+def test_concurrent_updates_of_one_id_serialize(harness: Harness) -> None:
+    record = harness.add_installed("ext")
+    runtime = harness.start(record)
+
+    harness.service.update(record, lambda _updated: None, unexpected_error)
+    harness.service.update(record, lambda _updated: None, unexpected_error)
+    # the second update is queued, not started
+    assert harness.log.count("update-start:ext") == 1
+
+    runtime.exit("Stopped")
+
+    # the updates ran back to back, with one restart at the end instead of one per update
+    assert harness.log == [
+        "spawn:ext",
+        "update-start:ext",
+        "update-swap:ext",
+        "update-start:ext",
+        "update-swap:ext",
+        "spawn:ext",
+    ]
+
+
+def test_disabling_during_update_leaves_it_stopped(harness: Harness) -> None:
+    record = harness.add_installed("ext")
+    runtime = harness.start(record)
+
+    harness.service.update(record, lambda _updated: None, unexpected_error)
+    harness.service.toggle_enabled(record, False)
+    runtime.exit("Stopped")
+
+    assert "update-swap:ext" in harness.log
+    assert len(harness.spawned) == 1
+    assert not harness.service.is_running(record)
+
+
+def test_crash_does_not_restart(harness: Harness) -> None:
+    record = harness.add_installed("ext")
+    runtime = harness.start(record)
+
+    runtime.exit("Exited", "boom")
+
+    assert record.state.error_type == "Exited"
+    assert len(harness.spawned) == 1
+    assert not harness.service.is_running(record)
+
+
+def test_stop_during_stop_waits_for_the_same_exit(harness: Harness) -> None:
+    record = harness.add_installed("ext")
+    runtime = harness.start(record)
+    stopped: list[str] = []
+
+    harness.service.stop_extension(record, lambda: stopped.append("first"))
+    harness.service.stop_extension(record, lambda: stopped.append("second"))
+    assert stopped == []
+
+    runtime.exit("Stopped")
+    assert stopped == ["first", "second"]
+
+
+def test_preview_crash_during_a_pending_stop_does_not_respawn_the_preview(harness: Harness) -> None:
+    record = harness.add_installed("ext")
+    runtime = harness.start(record)
+
+    harness.service.preview_ext("ext", "/dev/ext")
+    runtime.exit("Stopped")
+    preview_runtime = harness.spawned[-1]
+
+    # A restart registers a stop callback for the preview's exit. The exit can still arrive
+    # classified as a crash: ExtensionRuntime.stop() gives up without marking the subprocess as
+    # aborted when Gio has already reaped it, so the exit is reported as an error.
+    harness.service.reload(["ext"])
+    assert preview_runtime.stop_requested
+    preview_runtime.exit("Exited", "boom")
+
+    # The overlay is gone and the installed extension took over. A reconcile that ran before
+    # stop_preview cleared the overlay would have respawned the dead preview first.
+    assert harness.service.preview is None
+    assert len(harness.spawned) == 3
+    assert not harness.spawned[-1].stop_requested
+
+
+def test_update_during_preview_keeps_preview_running_until_stop_preview(harness: Harness) -> None:
+    record = harness.add_installed("ext")
+    runtime = harness.start(record)
+
+    harness.service.preview_ext("ext", "/dev/ext")
+    assert runtime.stop_requested
+    runtime.exit("Stopped")
+
+    # the reconcile after the restart job launched the preview
+    preview_runtime = harness.spawned[-1]
+    assert len(harness.spawned) == 2
+
+    harness.service.update(record, lambda _updated: None, unexpected_error)
+    # the update swapped the installed files but did not touch the running preview
+    assert not preview_runtime.stop_requested
+    assert len(harness.spawned) == 2
+
+    harness.service.stop_preview()
+    assert preview_runtime.stop_requested
+    preview_runtime.exit("Stopped")
+
+    # only after stop_preview does the updated installed version start
+    assert harness.log == ["spawn:ext", "spawn:ext", "update-start:ext", "update-swap:ext", "spawn:ext"]

--- a/tests/modes/extensions/test_extension_record.py
+++ b/tests/modes/extensions/test_extension_record.py
@@ -20,3 +20,16 @@ def test_seed_default_state__ignores_keys_the_state_rejects(tmp_path: Path) -> N
 
     assert record.state.is_enabled is False
     assert "save" not in record.state
+
+
+def test_reload_state__resets_to_the_defaults_when_the_file_is_gone(tmp_path: Path) -> None:
+    (tmp_path / ".default-state.json").write_text(json.dumps({"url": "https://example.com"}))
+    record = ExtensionRecord("test_record_reloads_deleted_state", str(tmp_path))
+    record.state.save(is_enabled=False, error_type="Terminated")
+    record._state_path.unlink()
+
+    record.reload_state()
+
+    assert record.state.is_enabled is True
+    assert record.state.error_type == ""
+    assert record.state.url == "https://example.com"

--- a/tests/utils/test_subprocess_utils.py
+++ b/tests/utils/test_subprocess_utils.py
@@ -66,8 +66,8 @@ def test_run_command_spawn_failure() -> None:
 
 
 def test_run_command_spawn_failure_does_not_hang_private_loop() -> None:
-    """A spawn error must reach a caller driving run_command under a private thread-default loop,
-    as _run_gio_blocking does; GLib.idle_add would post to the default context it never iterates."""
+    """A spawn error must reach a caller driving run_command under a private thread-default loop.
+    GLib.idle_add would post to the default context, which such a loop never iterates."""
     context = GLib.MainContext.new()
     context.push_thread_default()
     box: dict[str, Any] = {}

--- a/ulauncher/api/extension.py
+++ b/ulauncher/api/extension.py
@@ -6,7 +6,7 @@ import json
 import logging
 import os
 import signal
-import threading
+import threading  # noqa: TID251 - handler code is third-party, synchronous and not cancellable
 from collections import defaultdict
 from typing import TYPE_CHECKING, Any, Callable, Iterable, Iterator, cast
 

--- a/ulauncher/api/ruff.toml
+++ b/ulauncher/api/ruff.toml
@@ -2,6 +2,7 @@ extend = "../../pyproject.toml"
 
 # override the api ban, while preserving all other ban rules
 [lint.flake8-tidy-imports.banned-api]
+"asyncio" = {msg = "To handle async operations, use Gio or Glib async methods that run in the background. See ulauncher.utils.subprocess_utils."}
 "gi.repository" = {msg = "Import GI modules from ulauncher.gi, not gi.repository directly."}
 "ulauncher.ui" = {msg = "Import ulauncher.ui only from ulauncher/cli/commands/start.py - it pulls in GTK and must not leak into extension or CLI runtime."}
 "functools.lru_cache" = {msg = "Use ulauncher.utils.lru_cache instead to preserve parameter types."}

--- a/ulauncher/api/ruff.toml
+++ b/ulauncher/api/ruff.toml
@@ -8,3 +8,4 @@ extend = "../../pyproject.toml"
 "functools.lru_cache" = {msg = "Use ulauncher.utils.lru_cache instead to preserve parameter types."}
 "functools.cache" = {msg = "Use ulauncher.utils.lru_cache instead to preserve parameter types."}
 "functools.cached_property" = {msg = "cached_property erases property types. If you need to use this, create a typed wrapper similar to ulauncher.utils.lru_cache"}
+"threading" = {msg = "Avoid threading. Use callbacks with Glib async methods that run in the background when possible"}

--- a/ulauncher/cli/commands/__init__.py
+++ b/ulauncher/cli/commands/__init__.py
@@ -2,13 +2,51 @@ from __future__ import annotations
 
 import contextlib
 from pathlib import Path
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Callable, TypeVar
 
 from ulauncher.utils.lru_cache import lru_cache
 
 if TYPE_CHECKING:
     from ulauncher.modes.extensions.extension_record import ExtensionRecord
     from ulauncher.modes.extensions.extension_registry import ExtensionRegistry
+    from ulauncher.utils.subprocess_utils import OnError
+
+T = TypeVar("T")
+
+
+def run_blocking(start: Callable[[Callable[[T], None], OnError], None]) -> T:
+    """Run a main loop until start's operation reports back, then return its value or raise its error."""
+    from ulauncher.gi import GLib
+
+    loop = GLib.MainLoop()
+    result: list[T] = []
+    error: Exception | None = None
+    completed = False
+
+    def on_success(value: T) -> None:
+        nonlocal completed
+        if completed:
+            return
+        result.append(value)
+        completed = True
+        loop.quit()
+
+    def on_error(err: Exception) -> None:
+        nonlocal error, completed
+        if completed:
+            return
+        error = err
+        completed = True
+        loop.quit()
+
+    start(on_success, on_error)
+    # start() can report back before the loop runs, and GLib does not treat that quit() as
+    # pending, so entering the loop afterwards would hang.
+    if not completed:
+        loop.run()
+    if error:
+        raise error
+    return result[0]
 
 
 @lru_cache

--- a/ulauncher/cli/commands/install.py
+++ b/ulauncher/cli/commands/install.py
@@ -1,8 +1,7 @@
-import asyncio
 import logging
 
 from ulauncher.cli import CLIArguments
-from ulauncher.cli.commands import get_ext_registry, normalize_ext_arg
+from ulauncher.cli.commands import get_ext_registry, normalize_ext_arg, run_blocking
 from ulauncher.modes.extensions import ext_exceptions
 from ulauncher.utils.dbus import dbus_trigger_event
 
@@ -12,8 +11,9 @@ logger = logging.getLogger(__name__)
 def run(args: CLIArguments) -> int:
     # registry.install is idempotent and will also upgrade to latest (if installed) or shadow non-manageable.
     url = normalize_ext_arg(args.input)
+    registry = get_ext_registry()
     try:
-        record = asyncio.run(get_ext_registry().install(url))
+        record = run_blocking(lambda done, fail: registry.install(url, done, fail))
         dbus_trigger_event("extensions:reload", [record.id])
     except (ValueError, ext_exceptions.UrlError):  # error already logged
         return 1

--- a/ulauncher/cli/commands/uninstall.py
+++ b/ulauncher/cli/commands/uninstall.py
@@ -18,7 +18,7 @@ def run(args: CLIArguments) -> int:
         except OSError:
             logger.error("Could not uninstall %s", record.id)  # noqa: TRY400 - traceback is noise here
             return 1
-        dbus_trigger_event("extensions:stop", [record.id])
+        dbus_trigger_event("extensions:reload", [record.id])
         return 0
 
     logger.error("Error: Argument '%s' does not match any installed extension", args.input)

--- a/ulauncher/cli/commands/uninstall.py
+++ b/ulauncher/cli/commands/uninstall.py
@@ -1,8 +1,7 @@
-import asyncio
 import logging
 
 from ulauncher.cli import CLIArguments
-from ulauncher.cli.commands import get_ext_record, get_ext_registry
+from ulauncher.cli.commands import get_ext_record, get_ext_registry, run_blocking
 from ulauncher.utils.dbus import dbus_trigger_event
 
 logger = logging.getLogger(__name__)
@@ -13,8 +12,9 @@ def run(args: CLIArguments) -> int:
         if not record.is_manageable:
             logger.error("Extension %s is externally managed and can not be uninstalled (%s)", record.id, record.path)
             return 1
+        registry = get_ext_registry()
         try:
-            asyncio.run(get_ext_registry().uninstall(record))
+            run_blocking(lambda done, fail: registry.uninstall(record, lambda: done(None), fail))
         except OSError:
             logger.error("Could not uninstall %s", record.id)  # noqa: TRY400 - traceback is noise here
             return 1

--- a/ulauncher/cli/commands/upgrade.py
+++ b/ulauncher/cli/commands/upgrade.py
@@ -1,10 +1,9 @@
 from __future__ import annotations
 
-import asyncio
 import logging
 
 from ulauncher.cli import CLIArguments
-from ulauncher.cli.commands import get_ext_record, get_ext_registry
+from ulauncher.cli.commands import get_ext_record, get_ext_registry, run_blocking
 from ulauncher.modes.extensions import ext_exceptions
 from ulauncher.modes.extensions.extension_record import ExtensionRecord
 from ulauncher.utils.dbus import dbus_trigger_event
@@ -24,17 +23,20 @@ def _log_url_error(ext_id: str, url: str, *, fatal: bool) -> None:
         log("Could not upgrade %s: invalid URL '%s'", ext_id, url)
 
 
-async def _upgrade_all_extensions() -> list[str]:
-    updated_extensions: list[str] = []
+def _update_blocking(record: ExtensionRecord) -> bool:
     registry = get_ext_registry()
+    return run_blocking(lambda done, fail: registry.update(record, done, fail))
 
-    for record in registry.iterate():
+
+def _upgrade_all_extensions() -> list[str]:
+    updated_extensions: list[str] = []
+
+    for record in get_ext_registry().iterate():
         if not record.is_manageable or not record.state.url:
             continue
 
         try:
-            updated = await registry.update(record)
-            if updated:
+            if _update_blocking(record):
                 updated_extensions.append(record.id)
         except ext_exceptions.UrlError:
             _log_url_error(record.id, record.state.url, fatal=False)
@@ -52,7 +54,7 @@ def upgrade_one(record: ExtensionRecord) -> bool:
         logger.error("Extension %s is externally managed and can not be upgraded (%s)", record.id, record.path)
         return False
     try:
-        updated = asyncio.run(get_ext_registry().update(record))
+        updated = _update_blocking(record)
     except ext_exceptions.UrlError:
         _log_url_error(record.id, record.state.url, fatal=True)
         return False
@@ -74,7 +76,7 @@ def run(args: CLIArguments) -> int:
         logger.error("Error: Argument '%s' does not match any installed extension", args.input)
         return 1
 
-    updated_extensions = asyncio.run(_upgrade_all_extensions())
+    updated_extensions = _upgrade_all_extensions()
     if updated_extensions:
         dbus_trigger_event("extensions:reload", updated_extensions)
 

--- a/ulauncher/init_helpers.py
+++ b/ulauncher/init_helpers.py
@@ -54,7 +54,6 @@ def configure_logging(*, verbose: bool, use_app_logging: bool) -> None:
     stream_handler.setLevel(log_level)
     handlers.append(stream_handler)
 
-    logging.getLogger("asyncio").setLevel(logging.WARNING)
     logging.root.handlers = []
     logging.basicConfig(
         level=logging.DEBUG,

--- a/ulauncher/modes/extensions/extension_mode.py
+++ b/ulauncher/modes/extensions/extension_mode.py
@@ -67,7 +67,8 @@ class ExtensionMode(Mode):
             self._pending_callback = None
 
     def started(self, ext_id: str) -> None:
-        # start() runs in a worker thread, so re-evaluate the query on the main loop.
+        # Defer: a start can fire from inside another lifecycle callback, and re-running the
+        # query re-enters this mode.
         if self._active_ext and self._active_ext.id == ext_id:
             scheduling.run_when_idle(lambda: events.emit("app:reload_query"))
 

--- a/ulauncher/modes/extensions/extension_record.py
+++ b/ulauncher/modes/extensions/extension_record.py
@@ -92,6 +92,16 @@ class ExtensionRecord:
     def manifest(self) -> ExtensionManifest:
         return ExtensionManifest.load(self.path)
 
+    def reload_state(self) -> None:
+        """Pick up state another process wrote. The CLI disables a non-manageable copy that shadows
+        an uninstalled extension, and the app's cached state would otherwise still say enabled."""
+        if self._state_path.is_file():
+            self.state = ExtensionState.load(str(self._state_path), force=True)
+        else:
+            # No file means no state, not "unchanged", so a stale is_enabled or error can't linger.
+            self.state.clear()
+        self._seed_default_state()
+
     @property
     def is_enabled(self) -> bool:
         return self.is_preview or (self.state.is_enabled and not self.has_error)

--- a/ulauncher/modes/extensions/extension_registry.py
+++ b/ulauncher/modes/extensions/extension_registry.py
@@ -20,6 +20,15 @@ CheckUpdateSuccess = Callable[[bool, str], None]
 Done = Callable[[], None]
 
 
+def resolve_remote(url: str, on_error: OnError) -> ExtensionRemote | None:
+    """Parse url into a remote, or report the UrlError to on_error and return None."""
+    try:
+        return ExtensionRemote(url)
+    except ext_exceptions.UrlError as error:
+        on_error(error)
+        return None
+
+
 def _swap_dir(new_dir: str, target: str) -> bool:
     """Replace `target` with `new_dir`, rolling back to the original on failure. Returns whether it succeeded."""
     previous = f"{new_dir}.bak"
@@ -52,23 +61,15 @@ def _swap_dir(new_dir: str, target: str) -> bool:
 
 
 class ExtensionLifecycle(Protocol):
-    """The running-process operations install/uninstall need. Only the ExtensionService
-    (app runtime) runs extension, so ExtensionRegistry should no-op (_NoLifecycle)."""
-
-    def is_running(self, record: ExtensionRecord) -> bool: ...
-
-    def start_extension(self, record: ExtensionRecord) -> bool: ...
+    """The running-process operation the disk operations need: stopping before touching the
+    extension's directory. Only the ExtensionService (app runtime) runs extensions, so the
+    plain ExtensionRegistry no-ops (_NoLifecycle). Restarting is not part of the protocol:
+    the service reconciles the process after the job wrapping the operation completes."""
 
     def stop_extension(self, record: ExtensionRecord, on_stopped: Callable[[], None] | None = None) -> None: ...
 
 
 class _NoLifecycle:
-    def is_running(self, _record: ExtensionRecord) -> bool:
-        return False
-
-    def start_extension(self, _record: ExtensionRecord) -> bool:
-        return False
-
     def stop_extension(self, _record: ExtensionRecord, on_stopped: Callable[[], None] | None = None) -> None:
         if on_stopped:
             on_stopped()
@@ -127,10 +128,8 @@ class ExtensionRegistry:
 
     def install(self, url: str, on_success: InstallSuccess, on_error: OnError, commit_hash: str | None = None) -> None:
         logger.info("Installing extension: %s", url)
-        try:
-            remote = ExtensionRemote(url)
-        except ext_exceptions.UrlError as error:
-            on_error(error)
+        remote = resolve_remote(url, on_error)
+        if remote is None:
             return
         if Path(remote.target_dir).exists():
             logger.info('Extension with URL "%s" is already installed. Updating', remote.url)
@@ -194,10 +193,8 @@ class ExtensionRegistry:
                 logger.error("Could not update extension '%s'", record.id, exc_info=error)
                 on_error(error)
 
-            try:
-                remote = ExtensionRemote(record.state.url)
-            except ext_exceptions.UrlError as error:
-                fail(error)
+            remote = resolve_remote(record.state.url, fail)
+            if remote is None:
                 return
             self._install_from_remote(record, remote, commit_hash, done, fail)
 
@@ -205,10 +202,8 @@ class ExtensionRegistry:
 
     def check_update(self, record: ExtensionRecord, on_success: CheckUpdateSuccess, on_error: OnError) -> None:
         """Reports whether a new compatible version exists, and its commit hash."""
-        try:
-            remote = ExtensionRemote(record.state.url)
-        except ext_exceptions.UrlError as error:
-            on_error(error)
+        remote = resolve_remote(record.state.url, on_error)
+        if remote is None:
             return
 
         def on_hash(commit_hash: str) -> None:
@@ -225,7 +220,8 @@ class ExtensionRegistry:
         on_error: OnError,
         **extra_state: Any,
     ) -> None:
-        """Install (atomically): download, stop, swap and restart (if previously running).
+        """Install (atomically): download, stop and swap. Restarting is the caller's concern
+        (in the app, the service reconciles once the job wrapping this operation releases).
 
         `extra_state` is merged into the saved state (install records the source url; update adds nothing).
         """
@@ -249,10 +245,6 @@ class ExtensionRegistry:
             downloaded_hash, commit_timestamp = download_result
 
             def on_deps_installed(_stdout: str) -> None:
-                # a preview extension need not and should not be restarted (runs from dev path)
-                is_previewed = self.preview is not None and self.preview.id == record.id
-                should_restart = self._lifecycle.is_running(record) and not is_previewed
-
                 def swap_and_finish() -> None:
                     error: Exception | None = None
                     if _swap_dir(staging_dir, target_path):
@@ -267,17 +259,12 @@ class ExtensionRegistry:
                     else:
                         error = OSError(f"Failed to swap the staged extension into {target_path}")
                     rmtree(staging_dir, ignore_errors=True)
-                    if should_restart:
-                        self._lifecycle.start_extension(record)
                     if error:
                         on_error(error)
                     else:
                         on_done()
 
-                if should_restart:
-                    self._lifecycle.stop_extension(record, swap_and_finish)
-                else:
-                    swap_and_finish()
+                self._lifecycle.stop_extension(record, swap_and_finish)
 
             ExtensionDependencies(remote.ext_id, staging_dir).install(on_deps_installed, fail)
 

--- a/ulauncher/modes/extensions/extension_registry.py
+++ b/ulauncher/modes/extensions/extension_registry.py
@@ -6,53 +6,18 @@ from shutil import move, rmtree
 from typing import Any, Callable, Iterator, Protocol
 
 from ulauncher import paths
-from ulauncher.gi import GLib
 from ulauncher.modes.extensions import ext_exceptions, extension_finder
 from ulauncher.modes.extensions.extension_dependencies import ExtensionDependencies
 from ulauncher.modes.extensions.extension_record import ExtensionRecord, PreviewExtensionRecord
 from ulauncher.modes.extensions.extension_remote import ExtensionRemote
+from ulauncher.utils.subprocess_utils import OnError
 
 logger = logging.getLogger(__name__)
 
-
-def _run_gio_blocking(start: Callable[[Callable[[Any], None], Callable[[Exception], None]], None]) -> Any:
-    """Drive a callback-based Gio operation to completion synchronously on the calling thread.
-
-    Temporary bridge for step one of the asyncio/threading removal: extension_remote is now
-    callback-based, but the registry's install/update flows are still async and run in worker
-    threads (ext_handlers) or the CLI's asyncio loop. Gio.Subprocess callbacks dispatch on a GLib
-    main context, not the asyncio loop, and no GLib loop runs in those threads, so a plain
-    asyncio.Future shim would never resolve. Running a private GLib main loop (pushed as the
-    thread-default context) drives the operation to completion. Remove this when the registry
-    becomes callback-native.
-    """
-    context = GLib.MainContext.new()
-    context.push_thread_default()
-    box: dict[str, Any] = {}
-    completed = False
-    try:
-        loop = GLib.MainLoop.new(context, False)
-
-        def finish(result: Any = None, error: Exception | None = None) -> None:
-            nonlocal completed
-            box["result"], box["error"] = result, error
-            completed = True
-            loop.quit()
-
-        start(finish, lambda error: finish(error=error))
-        # done() can fire synchronously during start() (e.g. an immediate validation failure
-        # that calls back without spawning a subprocess). Then loop.quit() already ran before
-        # loop.run(), which GLib does not treat as a pending quit, so running the loop would
-        # block forever. Only enter the loop while the callback is still pending.
-        if not completed:
-            loop.run()
-    finally:
-        # Always restore the thread-default context, even if start() raises synchronously
-        # (a synchronous raise propagates to the caller, matching the pre-conversion behavior).
-        context.pop_thread_default()
-    if box.get("error"):
-        raise box["error"]
-    return box.get("result")
+InstallSuccess = Callable[[ExtensionRecord], None]
+UpdateSuccess = Callable[[bool], None]
+CheckUpdateSuccess = Callable[[bool, str], None]
+Done = Callable[[], None]
 
 
 def _swap_dir(new_dir: str, target: str) -> bool:
@@ -94,7 +59,7 @@ class ExtensionLifecycle(Protocol):
 
     def start_extension(self, record: ExtensionRecord) -> bool: ...
 
-    async def stop_extension(self, record: ExtensionRecord) -> None: ...
+    def stop_extension(self, record: ExtensionRecord, on_stopped: Callable[[], None] | None = None) -> None: ...
 
 
 class _NoLifecycle:
@@ -104,7 +69,9 @@ class _NoLifecycle:
     def start_extension(self, _record: ExtensionRecord) -> bool:
         return False
 
-    async def stop_extension(self, _record: ExtensionRecord) -> None: ...
+    def stop_extension(self, _record: ExtensionRecord, on_stopped: Callable[[], None] | None = None) -> None:
+        if on_stopped:
+            on_stopped()
 
 
 class ExtensionRegistry:
@@ -114,6 +81,10 @@ class ExtensionRegistry:
     Instantiated exactly once per runtime. The CLI creates a plain instance. The app instead uses
     ExtensionService, a subclass that also resolves the previewed extension from its dev path and
     owns the running extension processes.
+
+    The remote operations report back through callbacks (Gio dispatches them on the caller's
+    thread-default GLib main context). Errors go to on_error, including ones detected
+    synchronously, so callers have a single error path.
     """
 
     # Previews only exist in the app process; ExtensionService sets this (see preview_ext).
@@ -154,69 +125,105 @@ class ExtensionRegistry:
 
         yield from sorted(records.values(), key=sort_key)
 
-    async def install(self, url: str, commit_hash: str | None = None) -> ExtensionRecord:
+    def install(self, url: str, on_success: InstallSuccess, on_error: OnError, commit_hash: str | None = None) -> None:
         logger.info("Installing extension: %s", url)
-        remote = ExtensionRemote(url)
-        if Path(remote.target_dir).exists():  # noqa: ASYNC240
+        try:
+            remote = ExtensionRemote(url)
+        except ext_exceptions.UrlError as error:
+            on_error(error)
+            return
+        if Path(remote.target_dir).exists():
             logger.info('Extension with URL "%s" is already installed. Updating', remote.url)
 
         record = ExtensionRecord(remote.ext_id, remote.target_dir)
-        await self._install_from_remote(record, remote, commit_hash, url=url)
-        logger.info("Extension %s installed successfully", record.id)
-        return record
 
-    async def uninstall(self, record: ExtensionRecord) -> None:
+        def done() -> None:
+            logger.info("Extension %s installed successfully", record.id)
+            on_success(record)
+
+        self._install_from_remote(record, remote, commit_hash, done, on_error, url=url)
+
+    def uninstall(self, record: ExtensionRecord, on_done: Done, on_error: OnError) -> None:
+        def remove_files() -> None:
+            try:
+                removed = record.remove()
+            except OSError as error:
+                on_error(error)
+                return
+            if removed:
+                # A still-locatable extension after removal is a non-manageable copy (e.g. distro-packaged).
+                # Disable it rather than let it silently take over the removed extension's id.
+                fallback_path = extension_finder.locate(record.id)
+                if fallback_path:
+                    fallback_record = ExtensionRecord(record.id, fallback_path)
+                    # TODO: Try to avoid accessing state attribute
+                    fallback_record.state.save(is_enabled=False)
+                    logger.info(
+                        "Non-manageable extension with the same id exists in '%s'. It was kept disabled.",
+                        fallback_path,
+                    )
+            on_done()
+
         if record.is_manageable:
-            await self._lifecycle.stop_extension(record)
-        if not record.remove():
-            return
-        # A still-locatable extension after removal is a non-manageable copy (e.g. distro-packaged).
-        # Disable it rather than let it silently take over the removed extension's id.
-        fallback_path = extension_finder.locate(record.id)
-        if fallback_path:
-            fallback_record = ExtensionRecord(record.id, fallback_path)
-            # TODO: Try to avoid accessing state attribute
-            fallback_record.state.save(is_enabled=False)
+            self._lifecycle.stop_extension(record, remove_files)
+        else:
+            remove_files()
+
+    def update(self, record: ExtensionRecord, on_success: UpdateSuccess, on_error: OnError) -> None:
+        """Reports True to on_success if the extension was updated, False if it was already up-to-date."""
+        logger.debug("Checking for updates to %s", record.id)
+
+        def on_checked(has_update: bool, commit_hash: str) -> None:
+            if not has_update:
+                logger.info('Extension "%s" is already on the latest version', record.id)
+                on_success(False)
+                return
+
             logger.info(
-                "Non-manageable extension with the same id exists in '%s'. It was kept disabled.",
-                fallback_path,
+                'Updating extension "%s" from commit %s to %s',
+                record.id,
+                record.state.commit_hash[:8],
+                commit_hash[:8],
             )
 
-    async def update(self, record: ExtensionRecord) -> bool:
-        """
-        :returns: False if already up-to-date, True if was updated
-        """
-        logger.debug("Checking for updates to %s", record.id)
-        has_update, commit_hash = await self.check_update(record)
-        if not has_update:
-            logger.info('Extension "%s" is already on the latest version', record.id)
-            return False
+            def done() -> None:
+                logger.info("Successfully updated extension: %s", record.id)
+                on_success(True)
 
-        logger.info(
-            'Updating extension "%s" from commit %s to %s',
-            record.id,
-            record.state.commit_hash[:8],
-            commit_hash[:8],
-        )
+            def fail(error: Exception) -> None:
+                logger.error("Could not update extension '%s'", record.id, exc_info=error)
+                on_error(error)
 
+            try:
+                remote = ExtensionRemote(record.state.url)
+            except ext_exceptions.UrlError as error:
+                fail(error)
+                return
+            self._install_from_remote(record, remote, commit_hash, done, fail)
+
+        self.check_update(record, on_checked, on_error)
+
+    def check_update(self, record: ExtensionRecord, on_success: CheckUpdateSuccess, on_error: OnError) -> None:
+        """Reports whether a new compatible version exists, and its commit hash."""
         try:
-            await self._install_from_remote(record, ExtensionRemote(record.state.url), commit_hash)
-        except (ext_exceptions.ExtensionError, OSError):
-            logger.exception("Could not update extension '%s'", record.id)
-            raise
-        logger.info("Successfully updated extension: %s", record.id)
-        return True
+            remote = ExtensionRemote(record.state.url)
+        except ext_exceptions.UrlError as error:
+            on_error(error)
+            return
 
-    async def check_update(self, record: ExtensionRecord) -> tuple[bool, str]:
-        """
-        Returns tuple with commit info about a new version
-        """
-        commit_hash = _run_gio_blocking(ExtensionRemote(record.state.url).get_compatible_hash)
-        has_update = record.state.commit_hash != commit_hash
-        return has_update, commit_hash
+        def on_hash(commit_hash: str) -> None:
+            on_success(record.state.commit_hash != commit_hash, commit_hash)
 
-    async def _install_from_remote(
-        self, record: ExtensionRecord, remote: ExtensionRemote, commit_hash: str | None, **extra_state: Any
+        remote.get_compatible_hash(on_hash, on_error)
+
+    def _install_from_remote(
+        self,
+        record: ExtensionRecord,
+        remote: ExtensionRemote,
+        commit_hash: str | None,
+        on_done: Done,
+        on_error: OnError,
+        **extra_state: Any,
     ) -> None:
         """Install (atomically): download, stop, swap and restart (if previously running).
 
@@ -227,31 +234,51 @@ class ExtensionRegistry:
         # Concurrent installs of the same id clobber each other (wouldn't have worked anyway).
         staging_dir = str(Path(paths.EXTENSIONS_STAGING) / record.id)
         rmtree(staging_dir, ignore_errors=True)
-        Path(staging_dir).mkdir(parents=True)  # noqa: ASYNC240
-        remote.target_dir = staging_dir
-        was_running = False
-
-        def _should_restart() -> bool:
-            # a preview extension need not and should not be restarted (runs from dev path)
-            is_previewed = self.preview is not None and self.preview.id == record.id
-            return was_running and not is_previewed
-
         try:
-            downloaded_hash, commit_timestamp = _run_gio_blocking(
-                lambda on_success, on_error: remote.download(on_success, on_error, commit_hash)
-            )
-            _run_gio_blocking(ExtensionDependencies(remote.ext_id, staging_dir).install)
+            Path(staging_dir).mkdir(parents=True)
+        except OSError as error:
+            on_error(error)
+            return
+        remote.target_dir = staging_dir
 
-            was_running = self._lifecycle.is_running(record)
-            if _should_restart():
-                await self._lifecycle.stop_extension(record)
-            if not _swap_dir(staging_dir, target_path):
-                msg = f"Failed to swap the staged extension into {target_path}"
-                raise OSError(msg)
-            record.save_installed_state(
-                downloaded_hash, commit_timestamp, **extra_state, browser_url=remote.browser_url or ""
-            )
-        finally:
+        def fail(error: Exception) -> None:
             rmtree(staging_dir, ignore_errors=True)
-            if _should_restart():
-                self._lifecycle.start_extension(record)
+            on_error(error)
+
+        def on_downloaded(download_result: tuple[str, float]) -> None:
+            downloaded_hash, commit_timestamp = download_result
+
+            def on_deps_installed(_stdout: str) -> None:
+                # a preview extension need not and should not be restarted (runs from dev path)
+                is_previewed = self.preview is not None and self.preview.id == record.id
+                should_restart = self._lifecycle.is_running(record) and not is_previewed
+
+                def swap_and_finish() -> None:
+                    error: Exception | None = None
+                    if _swap_dir(staging_dir, target_path):
+                        try:
+                            record.save_installed_state(
+                                downloaded_hash, commit_timestamp, **extra_state, browser_url=remote.browser_url or ""
+                            )
+                        # Reloading the manifest can reject the swapped-in files. This runs in a
+                        # Gio callback, so an escape would report neither done nor error.
+                        except (OSError, ext_exceptions.ExtensionError) as save_error:
+                            error = save_error
+                    else:
+                        error = OSError(f"Failed to swap the staged extension into {target_path}")
+                    rmtree(staging_dir, ignore_errors=True)
+                    if should_restart:
+                        self._lifecycle.start_extension(record)
+                    if error:
+                        on_error(error)
+                    else:
+                        on_done()
+
+                if should_restart:
+                    self._lifecycle.stop_extension(record, swap_and_finish)
+                else:
+                    swap_and_finish()
+
+            ExtensionDependencies(remote.ext_id, staging_dir).install(on_deps_installed, fail)
+
+        remote.download(on_downloaded, fail, commit_hash)

--- a/ulauncher/modes/extensions/extension_remote.py
+++ b/ulauncher/modes/extensions/extension_remote.py
@@ -308,7 +308,8 @@ class ExtensionRemote(UrlParseResult):
         # shutil.Error subclasses OSError, so move() failures are covered too. The intentional
         # RemoteError/CompatibilityError raises are ExtensionError (not OSError) and propagate as-is.
         # This must not let a raw OSError escape: it runs inside a Gio callback, where an uncaught
-        # exception would be swallowed and hang _run_gio_blocking instead of reaching the caller.
+        # exception would be swallowed and hang a blocking caller (see cli.commands.run_blocking)
+        # instead of reaching it.
         try:
             with TemporaryDirectory(prefix="ulauncher_ext_") as tmp_root_dir:
                 untar(tar_path, tmp_root_dir)

--- a/ulauncher/modes/extensions/extension_service.py
+++ b/ulauncher/modes/extensions/extension_service.py
@@ -3,9 +3,9 @@ from __future__ import annotations
 import json
 import logging
 import sys
-from collections import defaultdict
+from collections import defaultdict, deque
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, Callable, Literal, Protocol
+from typing import TYPE_CHECKING, Any, Callable, Protocol
 
 from ulauncher import cli, paths
 from ulauncher.gi import GLib
@@ -13,16 +13,39 @@ from ulauncher.internals import log_wire
 from ulauncher.modes.extensions import ext_exceptions
 from ulauncher.modes.extensions.extension_dependencies import ExtensionDependencies
 from ulauncher.modes.extensions.extension_record import ExtensionRecord, PreviewExtensionRecord
-from ulauncher.modes.extensions.extension_registry import ExtensionRegistry
+from ulauncher.modes.extensions.extension_registry import (
+    Done,
+    ExtensionRegistry,
+    InstallSuccess,
+    UpdateSuccess,
+    resolve_remote,
+)
 from ulauncher.modes.extensions.extension_runtime import DEBUGPY_HOST, DEBUGPY_PORT, ExtensionRuntime
 from ulauncher.utils import scheduling
 from ulauncher.utils.eventbus import EventBus
 
 if TYPE_CHECKING:
     from ulauncher.internals import ipc
+    from ulauncher.utils.subprocess_utils import OnError
 
 logger = logging.getLogger(__name__)
 events = EventBus("extensions", skip_if_not_bound=True)
+
+# A job holds its extension's process and directory until it calls the release callback it
+# is given. Every completion path, success or error, must release.
+Job = Callable[[Callable[[], None]], None]
+
+
+def _releasing(callback: Callable[..., None], release: Callable[[], None]) -> Callable[..., None]:
+    """Wrap a job's completion callback so release() always runs after it, success or error."""
+
+    def wrapped(*args: Any) -> None:
+        try:
+            callback(*args)
+        finally:
+            release()
+
+    return wrapped
 
 
 class ExtensionServiceListener(Protocol):
@@ -39,15 +62,23 @@ class ExtensionServiceListener(Protocol):
 
 
 class _ExtensionProcessState:
-    """Per-extension bookkeeping for the process.
+    """Per-extension bookkeeping for the process and the serialized jobs.
     Only ExtensionService touches it, always on the GLib main loop."""
 
     runtime: ExtensionRuntime | None
+    record: ExtensionRecord | None  # the record the live runtime was spawned from
     pending_stop: list[Callable[[], None]] | None  # None: no stop in flight; else callbacks to fire on exit
+    jobs: deque[Job]
+    job_active: bool
+    draining: bool
 
     def __init__(self) -> None:
         self.runtime = None
+        self.record = None
         self.pending_stop = None
+        self.jobs = deque()
+        self.job_active = False
+        self.draining = False
 
 
 class ExtensionService(ExtensionRegistry):
@@ -55,7 +86,24 @@ class ExtensionService(ExtensionRegistry):
 
     Extensions only run in the app process, so only app code uses the service. The CLI does its
     disk work with a plain ExtensionRegistry and asks the app to reconcile the processes via
-    D-Bus events ("extensions:reload", "extensions:stop", ...).
+    D-Bus events ("extensions:reload", ...).
+
+    The lifecycle model has two parts:
+
+    - Desired state is derived, not stored: an extension should run iff its record resolves and
+      `record.is_enabled` (which already folds in the preview overlay and the persisted error).
+      `_reconcile` aligns the process with that whenever something relevant changed.
+    - Operations that need exclusive access to the process and directory (install, update,
+      uninstall, restarts) run as jobs, serialized per extension id. While a job holds an id,
+      `_reconcile` leaves it alone; releasing the job reconciles, which re-reads the record's
+      state file and starts whatever it says should run by then. This is what makes sequences
+      like "disable, update, enable" run in order without every caller passing callbacks around.
+      A job re-resolves its record when it starts rather than trusting the one captured at
+      enqueue time, through `get_installed` rather than `get`, so an id that is being previewed
+      resolves to the installed copy instead of the developer's dev checkout.
+
+    `check_update` is inherited unchanged: it only reads the remote, so it doesn't need to hold
+    the id and isn't a job.
     """
 
     listener: ExtensionServiceListener | None
@@ -77,59 +125,123 @@ class ExtensionService(ExtensionRegistry):
         scheduling.run_when_idle(self._start_extensions)
 
     def _start_extensions(self) -> None:
+        # Start explicitly rather than reconcile, so extensions that errored last session
+        # get retried (start_extension clears the persisted error).
         for ext in self.iterate():
             if ext.state.is_enabled:
                 self.start_extension(ext)
-
-    def _run_batch_job(
-        self,
-        extension_ids: list[str],
-        jobs: list[Literal["start", "stop"]],
-        callback: Callable[[], None] | None = None,
-    ) -> None:
-        records: list[ExtensionRecord] = []
-        for ext_id in extension_ids:
-            if ext := self.get(ext_id):
-                records.append(ext)  # noqa: PERF401
-
-        def run_job(index: int) -> None:
-            if index == len(jobs):
-                if callback:
-                    callback()
-                return
-            if jobs[index] == "start":
-                for record in records:
-                    if record.is_enabled:
-                        self.start_extension(record)
-                run_job(index + 1)
-                return
-
-            pending = len(records)
-            if not pending:
-                run_job(index + 1)
-                return
-
-            def one_stopped() -> None:
-                nonlocal pending
-                pending -= 1
-                if not pending:
-                    run_job(index + 1)
-
-            for record in records:
-                self.stop_extension(record, one_stopped)
-
-        run_job(0)
 
     def is_running(self, record: ExtensionRecord) -> bool:
         state = self._ext_states.get(record.id)
         return state is not None and state.runtime is not None
 
-    def toggle_enabled(self, record: ExtensionRecord, enabled: bool) -> bool:
+    def _reconcile(self, ext_id: str) -> None:
+        """Align the process with the desired state: run iff the id resolves to a record and,
+        after re-reading that record's state file, it is enabled. No-op while a job holds the id
+        or a stop is in flight; both reconcile again when done."""
+        state = self._ext_states[ext_id]
+        if state.job_active or state.pending_stop is not None:
+            return
+        record = self.get(ext_id)
+        if record:
+            record.reload_state()
+        if record and record.is_enabled:
+            if not state.runtime:
+                self.start_extension(record)
+        elif state.runtime:
+            self._stop(ext_id)
+
+    def _enqueue_job(self, ext_id: str, job: Job) -> None:
+        state = self._ext_states[ext_id]
+        state.jobs.append(job)
+        self._run_next_job(ext_id)
+
+    def _run_next_job(self, ext_id: str) -> None:
+        """Run this id's queued jobs until one is still in flight, then reconcile if it drained.
+
+        Jobs that release synchronously loop here rather than recursing, so a long backlog for one
+        id doesn't nest a stack frame per job.
+        """
+        state = self._ext_states[ext_id]
+        if state.draining:
+            return  # the loop below owns the queue and picks up whatever is appended to it
+        state.draining = True
+        try:
+            while not state.job_active and state.jobs:
+                self._start_job(ext_id, state.jobs.popleft())
+        finally:
+            state.draining = False
+
+        if not state.job_active and not state.jobs:
+            self._reconcile(ext_id)
+
+    def _start_job(self, ext_id: str, job: Job) -> None:
+        state = self._ext_states[ext_id]
+        state.job_active = True
+        released = False
+
+        def release() -> None:
+            nonlocal released
+            if released:
+                return
+            released = True
+            state.job_active = False
+            self._run_next_job(ext_id)
+
+        # A job that raises before wiring its callbacks never releases, wedging this id's queue.
+        # Release on a synchronous failure so the remaining jobs still drain.
+        try:
+            job(release)
+        except Exception:
+            logger.exception("Extension job for '%s' failed", ext_id)
+            release()
+
+    def _enqueue_restart(self, ext_id: str) -> None:
+        """Queue a stop while holding the id; the reconcile on release starts whatever the
+        record resolution says should run by then (installed version, preview, or nothing)."""
+        self._enqueue_job(ext_id, lambda release: self._stop(ext_id, release))
+
+    def toggle_enabled(self, record: ExtensionRecord, enabled: bool) -> None:
         record.state.save(is_enabled=enabled, error_type="", error_message="")
-        if enabled:
-            return self.start_extension(record)
-        self.stop_extension(record)
-        return False
+        self._reconcile(record.id)
+
+    def install(self, url: str, on_success: InstallSuccess, on_error: OnError, commit_hash: str | None = None) -> None:
+        remote = resolve_remote(url, on_error)
+        if remote is None:
+            return
+        ext_id = remote.ext_id
+        run = super().install
+
+        def job(release: Callable[[], None]) -> None:
+            run(url, _releasing(on_success, release), _releasing(on_error, release), commit_hash)
+
+        self._enqueue_job(ext_id, job)
+
+    def uninstall(self, record: ExtensionRecord, on_done: Done, on_error: OnError) -> None:
+        run = super().uninstall
+
+        def job(release: Callable[[], None]) -> None:
+            current = self.get_installed(record.id)
+            if current is None:
+                error = ext_exceptions.ExtensionError(f"Extension {record.id} is no longer installed")
+                _releasing(on_error, release)(error)
+                return
+            run(current, _releasing(on_done, release), _releasing(on_error, release))
+
+        self._enqueue_job(record.id, job)
+
+    def update(self, record: ExtensionRecord, on_success: UpdateSuccess, on_error: OnError) -> None:
+        run = super().update
+
+        def job(release: Callable[[], None]) -> None:
+            current = self.get_installed(record.id)
+            if current is None:
+                error = ext_exceptions.ExtensionError(f"Extension {record.id} is no longer installed")
+                _releasing(on_error, release)(error)
+                return
+            run(current, _releasing(on_success, release), _releasing(on_error, release))
+
+        self._enqueue_job(record.id, job)
 
     def _build_launch_args(self, record: ExtensionRecord) -> tuple[list[str], dict[str, str]]:
         ext_deps = ExtensionDependencies(record.id, record.path)
@@ -163,27 +275,33 @@ class ExtensionService(ExtensionRegistry):
         }
         return cmd, env
 
-    def start_extension(self, record: ExtensionRecord) -> bool:
-        """
-        Starts the extension in a subprocess
-        Returns True if the extension was already running or successfully started, False otherwise.
-        """
+    def start_extension(self, record: ExtensionRecord) -> None:
+        """Starts the extension in a subprocess."""
         state = self._ext_states[record.id]
         if state.runtime:
-            return True  # if already started, count as successful
+            return
+
+        if not record.is_preview:
+            record.state.save(error_type="", error_message="")  # clear any previous error
+
+        if state.job_active or state.pending_stop is not None:
+            # A job or in-flight stop reconciles on release, which starts the extension now
+            # that the error is cleared.
+            return
 
         def exit_handler(cause: str, error_msg: str) -> None:
-            if cause != "Stopped":
+            errored = cause != "Stopped"
+
+            if errored:
                 logger.error('Extension "%s" exited with an error: %s (%s)', record.id, error_msg, cause)
                 state.runtime = None
+                state.record = None
                 # A failing preview must not disable the installed extension by persisting its error.
                 if not record.is_preview:
                     record.state.save(error_type=cause, error_message=error_msg)
 
-                if listener := self.listener:
-                    listener.errored(record.id)
-
-                # Nothing asked the preview to stop, but it is over, so it still needs the teardown
+                # Tear down the dead preview before the drain below. The drain can reconcile,
+                # and a reconcile that still saw the overlay would respawn it.
                 if self.preview is record:
                     self.stop_preview()
 
@@ -197,6 +315,15 @@ class ExtensionService(ExtensionRegistry):
             for on_stopped in callbacks:
                 on_stopped()
 
+            if errored and (listener := self.listener):
+                listener.errored(record.id)
+
+            # Only reconcile after an intentional stop. On error the record has the error
+            # persisted (reconcile would not start it) or is a preview, which waits for an
+            # explicit relaunch rather than respawn in a crash loop.
+            if not errored:
+                self._reconcile(record.id)
+
         def message_handler(message: ipc.ExtensionMessage) -> None:
             if listener := self.listener:
                 listener.handle_message(record.id, message)
@@ -206,46 +333,54 @@ class ExtensionService(ExtensionRegistry):
             record.manifest.check_compatibility(verbose=True)
         except ext_exceptions.ManifestError as err:
             exit_handler("Invalid", str(err))
-            return False
+            return
         except ext_exceptions.CompatibilityError as err:
             exit_handler("Incompatible", str(err))
-            return False
-
-        if not record.is_preview:
-            record.state.save(error_type="", error_message="")  # clear any previous error
+            return
 
         cmd, env = self._build_launch_args(record)
 
-        # socketpair/spawnv can fail for host-environment reasons (fd exhaustion, fork limits,
-        # missing interpreter). Route these through exit_handler like a crash so the error is
-        # surfaced consistently and any queued start listeners get cleaned up, rather than
-        # raising out into callers.
+        # socketpair/spawnv can fail for host reasons (fd exhaustion, fork limits, missing
+        # interpreter). Route these through exit_handler like a crash, so the error surfaces
+        # consistently and queued stop callbacks still drain.
         try:
             state.runtime = ExtensionRuntime(record.id, cmd, env, exit_handler, message_handler)
         except (OSError, GLib.Error) as err:
             exit_handler("FailedToStart", str(err))
-            return False
+            return
+        state.record = record
         if listener := self.listener:
             listener.invalidate_cache()
             listener.started(record.id)
-        return self.is_running(record)
 
-    def stop_extension(self, record: ExtensionRecord, on_stopped: Callable[[], None] | None = None) -> None:
-        """Stop the extension process if it is running. Does not block: on_stopped fires once the
-        process has actually exited, or immediately if it is not running."""
-        state = self._ext_states[record.id]
+    def _stop(self, ext_id: str, on_stopped: Callable[[], None] | None = None) -> None:
+        state = self._ext_states[ext_id]
         if runtime := state.runtime:
             state.runtime = None
+            state.record = None
             state.pending_stop = []
             if on_stopped:
                 state.pending_stop.append(on_stopped)
             runtime.stop()
         elif state.pending_stop is not None:
-            # a stop is already in flight; report on the same exit
+            # a stop is already in flight, report on the same exit
             if on_stopped:
                 state.pending_stop.append(on_stopped)
         elif on_stopped:
             on_stopped()
+
+    def stop_extension(self, record: ExtensionRecord, on_stopped: Callable[[], None] | None = None) -> None:
+        """Stop the extension process if it is running. Does not block: on_stopped fires once the
+        process has actually exited, or immediately if it is not running."""
+        state = self._ext_states.get(record.id)
+        if state and state.record and state.record.is_preview and not record.is_preview:
+            # A previewed extension runs from its dev path, so it must survive an install/update
+            # of the installed copy: it isn't the process this call means to stop, despite the
+            # shared id.
+            if on_stopped:
+                on_stopped()
+            return
+        self._stop(record.id, on_stopped)
 
     def send_message(self, record: ExtensionRecord, message: ipc.Event, request_id: int | None = None) -> None:
         """
@@ -279,24 +414,11 @@ class ExtensionService(ExtensionRegistry):
             return
 
         logger.info("Reloading extension(s): %s", ", ".join(extension_ids))
-
-        self._run_batch_job(
-            extension_ids,
-            ["stop", "start"],
-            callback=lambda: logger.info("%s extensions (re)loaded", len(extension_ids)),
-        )
-
-    @events.on
-    def stop(self, extension_ids: list[str] | None = None) -> None:
-        if not extension_ids:
-            logger.warning("Stop message received without any extension IDs. No extensions will be stopped.")
-            return
-
-        logger.info("Stopping extension(s): %s", ", ".join(extension_ids))
-
-        self._run_batch_job(
-            extension_ids, ["stop"], callback=lambda: logger.info("%s extensions stopped", len(extension_ids))
-        )
+        for ext_id in extension_ids:
+            # An id with neither a record nor process state has nothing to converge to, and
+            # _ext_states is a defaultdict, so queueing would only leave an empty entry behind.
+            if self.get(ext_id) or ext_id in self._ext_states:
+                self._enqueue_restart(ext_id)
 
     def _attach_preview_log(self, ext_id: str) -> None:
         """Mirror the previewed extension's records to a file for the CLI that started it to tail.
@@ -331,21 +453,14 @@ class ExtensionService(ExtensionRegistry):
         """
 
         logger.info("[preview] Previewing ext_id=%s path=%s debugger=%s", ext_id, path, with_debugger)
-        preview = PreviewExtensionRecord(ext_id, path, with_debugger=with_debugger)
-        self.preview = preview
-
-        # Only relaunch if the current preview is still active
-        def start_if_still_previewing() -> None:
-            if self.preview is preview:
-                self._attach_preview_log(ext_id)
-                self._run_batch_job([ext_id], ["start"])
-
-        def start_on_main_thread() -> None:
-            # The batch job calls back from a worker thread. Previews are set on the main thread
-            scheduling.run_when_idle(start_if_still_previewing)
-
-        # Relaunch from the dev path, stopping any conflicting installed instances
-        self._run_batch_job([ext_id], ["stop"], callback=start_on_main_thread)
+        previous = self.preview
+        self.preview = PreviewExtensionRecord(ext_id, path, with_debugger=with_debugger)
+        # Attaching drops any previous handler, so the newest preview owns the log
+        self._attach_preview_log(ext_id)
+        if previous and previous.id != ext_id:
+            # a superseded preview of another extension: converge that id back to its installed state
+            self._enqueue_restart(previous.id)
+        self._enqueue_restart(ext_id)
 
     @events.on
     def stop_preview(self) -> None:
@@ -355,27 +470,12 @@ class ExtensionService(ExtensionRegistry):
             logger.debug("[preview] Ignoring stop_preview; no preview active")
             return
 
-        preview = self.preview
-        ext_id = preview.id
+        ext_id = self.preview.id
         logger.info("[preview] Stopping preview %s", ext_id)
-
-        def restore_original() -> None:
-            if self.preview is preview:
-                self.preview = None
-                self.detach_preview_log()
-            elif self.preview and self.preview.id == ext_id:
-                # Another preview started for this extension during the stop, and owns the log now
-                return
-            # Reload from the installed path, or drop the record if the extension was never installed.
-            record = self.get(ext_id)
-            if record and record.is_enabled:
-                self._run_batch_job([ext_id], ["start"])
-
-        def restore_on_main_thread() -> None:
-            # The batch job calls back from a worker thread. Previews are set on the main thread
-            scheduling.run_when_idle(restore_original)
-
-        self._run_batch_job([ext_id], ["stop"], callback=restore_on_main_thread)
+        self.preview = None
+        self.detach_preview_log()
+        # Restore the installed extension, or leave the id stopped if it was never installed.
+        self._enqueue_restart(ext_id)
 
 
 ext_service = ExtensionService()

--- a/ulauncher/modes/extensions/extension_service.py
+++ b/ulauncher/modes/extensions/extension_service.py
@@ -1,12 +1,10 @@
 from __future__ import annotations
 
-import asyncio
 import json
 import logging
 import sys
 from collections import defaultdict
 from pathlib import Path
-from threading import Thread
 from typing import TYPE_CHECKING, Any, Callable, Literal, Protocol
 
 from ulauncher import cli, paths
@@ -49,6 +47,7 @@ class ExtensionService(ExtensionRegistry):
     """
 
     runtimes: dict[str, ExtensionRuntime]
+    stopping: set[str]
     stopped_listeners: dict[str, list[Callable[[], None]]]
     listener: ExtensionServiceListener | None
     _preview_log: tuple[str, logging.Handler] | None
@@ -56,6 +55,7 @@ class ExtensionService(ExtensionRegistry):
     def __init__(self) -> None:
         super().__init__(lifecycle=self)
         self.runtimes = {}
+        self.stopping = set()
         self.stopped_listeners = defaultdict(list)
         self.listener = None
         self._preview_log = None
@@ -85,34 +85,42 @@ class ExtensionService(ExtensionRegistry):
             if ext := self.get(ext_id):
                 records.append(ext)  # noqa: PERF401
 
-        # run the reload in a separate thread to avoid blocking the main thread
-        async def run_batch_async() -> None:
-            for job in jobs:
-                if job == "start":
-                    for record in records:
-                        if record.is_enabled:
-                            self.start_extension(record)
-                elif job == "stop":
-                    await asyncio.gather(*[self.stop_extension(record) for record in records])
-
-        def run_batch() -> None:
-            try:
-                asyncio.run(run_batch_async())
-            finally:
-                # callback must run unconditionally (owns the follow-up work)
+        def run_job(index: int) -> None:
+            if index == len(jobs):
                 if callback:
                     callback()
+                return
+            if jobs[index] == "start":
+                for record in records:
+                    if record.is_enabled:
+                        self.start_extension(record)
+                run_job(index + 1)
+                return
 
-        Thread(target=run_batch).start()
+            pending = len(records)
+            if not pending:
+                run_job(index + 1)
+                return
+
+            def one_stopped() -> None:
+                nonlocal pending
+                pending -= 1
+                if not pending:
+                    run_job(index + 1)
+
+            for record in records:
+                self.stop_extension(record, one_stopped)
+
+        run_job(0)
 
     def is_running(self, record: ExtensionRecord) -> bool:
         return record.id in self.runtimes
 
-    async def toggle_enabled(self, record: ExtensionRecord, enabled: bool) -> bool:
+    def toggle_enabled(self, record: ExtensionRecord, enabled: bool) -> bool:
         record.state.save(is_enabled=enabled, error_type="", error_message="")
         if enabled:
             return self.start_extension(record)
-        await self.stop_extension(record)
+        self.stop_extension(record)
         return False
 
     def _build_launch_args(self, record: ExtensionRecord) -> tuple[list[str], dict[str, str]]:
@@ -156,14 +164,7 @@ class ExtensionService(ExtensionRegistry):
             return True  # if already started, count as successful
 
         def exit_handler(cause: str, error_msg: str) -> None:
-            listeners = self.stopped_listeners.get(record.id, [])
-            for stop_listener in listeners:
-                stop_listener()
-
-            listeners.clear()
-
-            if listener := self.listener:
-                listener.invalidate_cache()
+            self.stopping.discard(record.id)
 
             if cause != "Stopped":
                 logger.error('Extension "%s" exited with an error: %s (%s)', record.id, error_msg, cause)
@@ -178,6 +179,15 @@ class ExtensionService(ExtensionRegistry):
                 # Nothing asked the preview to stop, but it is over, so it still needs the teardown
                 if self.preview is record:
                     self.stop_preview()
+
+            if listener := self.listener:
+                listener.invalidate_cache()
+
+            # Drain last, and pop the list first: a listener may start a new runtime for this id
+            # (which the error path above must not clobber) or queue a new stop (which must wait
+            # for the next exit, not fire in this drain).
+            for stop_listener in self.stopped_listeners.pop(record.id, []):
+                stop_listener()
 
         def message_handler(message: ipc.ExtensionMessage) -> None:
             if listener := self.listener:
@@ -212,33 +222,21 @@ class ExtensionService(ExtensionRegistry):
             listener.started(record.id)
         return self.is_running(record)
 
-    async def stop_extension(self, record: ExtensionRecord) -> None:
-        """Stops the extension process if it is running."""
-        if runtime := self.runtimes.pop(record.id, None):
-            loop = asyncio.get_running_loop()
-            stopped_future: asyncio.Future[None] = loop.create_future()
-
-            def resolve() -> None:
-                if not stopped_future.done():
-                    stopped_future.set_result(None)
-
-            # The listener fires on the GTK main thread. A plain set_result there would not wake
-            # this loop, making every stop take the full timeout below.
-            def on_stopped() -> None:
-                if not loop.is_closed():
-                    loop.call_soon_threadsafe(resolve)
-
-            listeners = self.stopped_listeners[record.id]
-            listeners.append(on_stopped)
+    def stop_extension(self, record: ExtensionRecord, on_stopped: Callable[[], None] | None = None) -> None:
+        """Stop the extension process if it is running. Does not block: on_stopped fires once the
+        process has actually exited, or immediately if it is not running."""
+        ext_id = record.id
+        if runtime := self.runtimes.pop(ext_id, None):
+            self.stopping.add(ext_id)
+            if on_stopped:
+                self.stopped_listeners[ext_id].append(on_stopped)
             runtime.stop()
-
-            try:
-                await asyncio.wait_for(stopped_future, timeout=5.0)
-            except asyncio.TimeoutError:
-                logger.warning('Timed out waiting for extension "%s" to exit', record.id)
-            finally:
-                if on_stopped in listeners:
-                    listeners.remove(on_stopped)
+        elif ext_id in self.stopping:
+            # a stop is already in flight; report on the same exit
+            if on_stopped:
+                self.stopped_listeners[ext_id].append(on_stopped)
+        elif on_stopped:
+            on_stopped()
 
     def send_message(self, record: ExtensionRecord, message: ipc.Event, request_id: int | None = None) -> None:
         """

--- a/ulauncher/modes/extensions/extension_service.py
+++ b/ulauncher/modes/extensions/extension_service.py
@@ -38,6 +38,18 @@ class ExtensionServiceListener(Protocol):
     def handle_message(self, ext_id: str, message: ipc.ExtensionMessage) -> None: ...
 
 
+class _ExtensionProcessState:
+    """Per-extension bookkeeping for the process.
+    Only ExtensionService touches it, always on the GLib main loop."""
+
+    runtime: ExtensionRuntime | None
+    pending_stop: list[Callable[[], None]] | None  # None: no stop in flight; else callbacks to fire on exit
+
+    def __init__(self) -> None:
+        self.runtime = None
+        self.pending_stop = None
+
+
 class ExtensionService(ExtensionRegistry):
     """The app's ExtensionRegistry: also owns the extension processes and handles lifecycle intents.
 
@@ -46,17 +58,12 @@ class ExtensionService(ExtensionRegistry):
     D-Bus events ("extensions:reload", "extensions:stop", ...).
     """
 
-    runtimes: dict[str, ExtensionRuntime]
-    stopping: set[str]
-    stopped_listeners: dict[str, list[Callable[[], None]]]
     listener: ExtensionServiceListener | None
     _preview_log: tuple[str, logging.Handler] | None
 
     def __init__(self) -> None:
         super().__init__(lifecycle=self)
-        self.runtimes = {}
-        self.stopping = set()
-        self.stopped_listeners = defaultdict(list)
+        self._ext_states: defaultdict[str, _ExtensionProcessState] = defaultdict(_ExtensionProcessState)
         self.listener = None
         self._preview_log = None
         events.set_self(self)
@@ -114,7 +121,8 @@ class ExtensionService(ExtensionRegistry):
         run_job(0)
 
     def is_running(self, record: ExtensionRecord) -> bool:
-        return record.id in self.runtimes
+        state = self._ext_states.get(record.id)
+        return state is not None and state.runtime is not None
 
     def toggle_enabled(self, record: ExtensionRecord, enabled: bool) -> bool:
         record.state.save(is_enabled=enabled, error_type="", error_message="")
@@ -160,15 +168,14 @@ class ExtensionService(ExtensionRegistry):
         Starts the extension in a subprocess
         Returns True if the extension was already running or successfully started, False otherwise.
         """
-        if self.is_running(record):
+        state = self._ext_states[record.id]
+        if state.runtime:
             return True  # if already started, count as successful
 
         def exit_handler(cause: str, error_msg: str) -> None:
-            self.stopping.discard(record.id)
-
             if cause != "Stopped":
                 logger.error('Extension "%s" exited with an error: %s (%s)', record.id, error_msg, cause)
-                self.runtimes.pop(record.id, None)
+                state.runtime = None
                 # A failing preview must not disable the installed extension by persisting its error.
                 if not record.is_preview:
                     record.state.save(error_type=cause, error_message=error_msg)
@@ -183,11 +190,12 @@ class ExtensionService(ExtensionRegistry):
             if listener := self.listener:
                 listener.invalidate_cache()
 
-            # Drain last, and pop the list first: a listener may start a new runtime for this id
-            # (which the error path above must not clobber) or queue a new stop (which must wait
-            # for the next exit, not fire in this drain).
-            for stop_listener in self.stopped_listeners.pop(record.id, []):
-                stop_listener()
+            # Drain into a fresh list: a callback may start a new runtime for this id or queue a
+            # new stop, neither of which belongs to this exit.
+            callbacks = state.pending_stop or []
+            state.pending_stop = None
+            for on_stopped in callbacks:
+                on_stopped()
 
         def message_handler(message: ipc.ExtensionMessage) -> None:
             if listener := self.listener:
@@ -213,7 +221,7 @@ class ExtensionService(ExtensionRegistry):
         # surfaced consistently and any queued start listeners get cleaned up, rather than
         # raising out into callers.
         try:
-            self.runtimes[record.id] = ExtensionRuntime(record.id, cmd, env, exit_handler, message_handler)
+            state.runtime = ExtensionRuntime(record.id, cmd, env, exit_handler, message_handler)
         except (OSError, GLib.Error) as err:
             exit_handler("FailedToStart", str(err))
             return False
@@ -225,16 +233,17 @@ class ExtensionService(ExtensionRegistry):
     def stop_extension(self, record: ExtensionRecord, on_stopped: Callable[[], None] | None = None) -> None:
         """Stop the extension process if it is running. Does not block: on_stopped fires once the
         process has actually exited, or immediately if it is not running."""
-        ext_id = record.id
-        if runtime := self.runtimes.pop(ext_id, None):
-            self.stopping.add(ext_id)
+        state = self._ext_states[record.id]
+        if runtime := state.runtime:
+            state.runtime = None
+            state.pending_stop = []
             if on_stopped:
-                self.stopped_listeners[ext_id].append(on_stopped)
+                state.pending_stop.append(on_stopped)
             runtime.stop()
-        elif ext_id in self.stopping:
+        elif state.pending_stop is not None:
             # a stop is already in flight; report on the same exit
             if on_stopped:
-                self.stopped_listeners[ext_id].append(on_stopped)
+                state.pending_stop.append(on_stopped)
         elif on_stopped:
             on_stopped()
 
@@ -242,8 +251,9 @@ class ExtensionService(ExtensionRegistry):
         """
         Sends a JSON message to the extension if it is running.
         """
-        if runtime := self.runtimes.get(record.id):
-            runtime.send_message(message, request_id)
+        state = self._ext_states.get(record.id)
+        if state and state.runtime:
+            state.runtime.send_message(message, request_id)
 
     def save_user_preferences(self, record: ExtensionRecord, data: Any) -> None:
         from ulauncher.internals.ipc import EventType

--- a/ulauncher/ui/preferences/utils/ext_handlers.py
+++ b/ulauncher/ui/preferences/utils/ext_handlers.py
@@ -1,8 +1,6 @@
 from __future__ import annotations
 
-import asyncio
 import logging
-import threading
 from typing import Callable
 
 from gi.repository import Gtk
@@ -12,13 +10,16 @@ from ulauncher.modes.extensions import ext_exceptions
 from ulauncher.modes.extensions.extension_record import ExtensionRecord
 from ulauncher.modes.extensions.extension_service import ext_service
 from ulauncher.ui.preferences.views import DialogLauncher, get_window_for_widget, styled
-from ulauncher.utils.scheduling import run_when_idle
 
 logger = logging.getLogger(__name__)
 
 
 class ExtensionHandlers:
-    """Handles extension operations like install, remove, toggle, update, etc."""
+    """Handles extension operations like install, remove, toggle, update, etc.
+
+    The service operations report back through callbacks on the GLib main loop, so the
+    handlers update the dialogs directly in them. The main loop stays free during the
+    network work (it runs in Gio subprocesses), which keeps the progress dialogs spinning."""
 
     def __init__(self, widget: Gtk.Widget) -> None:
         self.widget = widget
@@ -97,46 +98,20 @@ class ExtensionHandlers:
         )
         progress_dialog.show()
 
-        def install_async() -> None:
-            try:
-                ext = asyncio.run(ext_service.install(url))
-                ext_service.start_extension(ext)
+        def on_installed(ext: ExtensionRecord) -> None:
+            ext_service.start_extension(ext)
+            progress_dialog.destroy()
+            callback(ext)
 
-                # Update UI in main thread
-                def update_ui() -> None:
-                    progress_dialog.destroy()
-                    callback(ext)
+        def on_error(error: Exception) -> None:
+            progress_dialog.destroy()
+            self._show_extension_operation_error(error, url, "install")
 
-                run_when_idle(update_ui)
-
-            except (ext_exceptions.ExtensionError, ValueError, OSError, asyncio.CancelledError) as error:
-
-                def show_error(error: BaseException) -> None:
-                    progress_dialog.destroy()
-                    self._show_extension_operation_error(error, url, "install")
-
-                run_when_idle(show_error, error)
-
-        # Run installation in background thread
-        thread = threading.Thread(target=install_async)
-        thread.daemon = True
-        thread.start()
+        ext_service.install(url, on_installed, on_error)
 
     def toggle_extension(self, state: bool, ext: ExtensionRecord) -> None:
         """Handle extension enable/disable toggle"""
-
-        def toggle_async() -> None:
-            try:
-                asyncio.run(ext_service.toggle_enabled(ext, state))
-
-            except (ext_exceptions.ExtensionError, OSError, asyncio.CancelledError):
-                failed_action = "enable" if state else "disable"
-                error_msg = f"Failed to {failed_action} extension"
-                run_when_idle(self.dialog_launcher.show_error, error_msg, "Toggle operation failed")
-
-        thread = threading.Thread(target=toggle_async)
-        thread.daemon = True
-        thread.start()
+        ext_service.toggle_enabled(ext, state)
 
     def remove_extension(self, ext: ExtensionRecord, callback: Callable[[], None]) -> None:
         """Handle extension removal"""
@@ -150,53 +125,33 @@ class ExtensionHandlers:
             )
             progress_dialog.show()
 
-            def remove_async() -> None:
-                try:
-                    asyncio.run(ext_service.uninstall(ext))
+            def on_removed() -> None:
+                progress_dialog.destroy()
+                callback()
 
-                    def update_ui() -> None:
-                        progress_dialog.destroy()
-                        callback()
+            def on_error(error: Exception) -> None:
+                progress_dialog.destroy()
+                self._show_extension_operation_error(error, ext.state.url, "remove")
 
-                    run_when_idle(update_ui)
-
-                except (ext_exceptions.ExtensionError, OSError, asyncio.CancelledError) as error:
-
-                    def show_error(error: BaseException) -> None:
-                        progress_dialog.destroy()
-                        self._show_extension_operation_error(error, ext.state.url, "remove")
-
-                    run_when_idle(show_error, error)
-
-            thread = threading.Thread(target=remove_async)
-            thread.daemon = True
-            thread.start()
+            ext_service.uninstall(ext, on_removed, on_error)
 
     def check_updates(self, ext: ExtensionRecord, callback: Callable[[], None]) -> None:
         """Handle checking for extension updates"""
 
-        def check_async() -> None:
-            try:
-                has_update, commit_hash = asyncio.run(ext_service.check_update(ext))
-
-                def update_ui() -> None:
-                    if has_update:
-                        self._show_update_dialog(ext, commit_hash, callback)
-                    else:
-                        callback()
-                        self.dialog_launcher.show(
-                            f"No updates available for {ext.manifest.name}", "The extension is up to date."
-                        )
-
-                run_when_idle(update_ui)
-
-            except (ext_exceptions.ExtensionError, OSError, asyncio.CancelledError) as e:
+        def on_checked(has_update: bool, commit_hash: str) -> None:
+            if has_update:
+                self._show_update_dialog(ext, commit_hash, callback)
+            else:
                 callback()
-                run_when_idle(self.dialog_launcher.show_error, "Failed to check for updates", f"Error: {e!s}")
+                self.dialog_launcher.show(
+                    f"No updates available for {ext.manifest.name}", "The extension is up to date."
+                )
 
-        thread = threading.Thread(target=check_async)
-        thread.daemon = True
-        thread.start()
+        def on_error(error: Exception) -> None:
+            callback()
+            self.dialog_launcher.show_error("Failed to check for updates", f"Error: {error!s}")
+
+        ext_service.check_update(ext, on_checked, on_error)
 
     def update_extension(self, ext: ExtensionRecord, callback: Callable[[], None]) -> None:
         """Update the extension"""
@@ -206,37 +161,22 @@ class ExtensionHandlers:
         )
         progress_dialog.show()
 
-        def update_async() -> None:
-            try:
-                updated = asyncio.run(ext_service.update(ext))
+        def on_updated(updated: bool) -> None:
+            callback()
+            progress_dialog.destroy()
+            if updated:
+                self.dialog_launcher.show("Extension updated successfully", f"{ext.manifest.name} has been updated.")
+            else:
+                self.dialog_launcher.show(
+                    f"No updates available for {ext.manifest.name}", "The extension is up to date."
+                )
 
-                def update_ui() -> None:
-                    callback()
-                    progress_dialog.destroy()
-                    if updated:
-                        self.dialog_launcher.show(
-                            "Extension updated successfully", f"{ext.manifest.name} has been updated."
-                        )
-                    else:
-                        self.dialog_launcher.show(
-                            f"No updates available for {ext.manifest.name}", "The extension is up to date."
-                        )
+        def on_error(error: Exception) -> None:
+            callback()
+            progress_dialog.destroy()
+            self._show_extension_operation_error(error, ext.state.url, "update")
 
-                run_when_idle(update_ui)
-
-            except (ext_exceptions.ExtensionError, OSError, asyncio.CancelledError) as e:
-                callback()
-
-                def show_error(error: BaseException) -> None:
-                    url = ext.state.url
-                    progress_dialog.destroy()
-                    self._show_extension_operation_error(error, url, "update")
-
-                run_when_idle(show_error, e)
-
-        thread = threading.Thread(target=update_async)
-        thread.daemon = True
-        thread.start()
+        ext_service.update(ext, on_updated, on_error)
 
     def _show_update_dialog(self, ext: ExtensionRecord, commit_hash: str, callback: Callable[[], None]) -> None:
         """Show dialog when update is available"""

--- a/ulauncher/ui/preferences/utils/ext_handlers.py
+++ b/ulauncher/ui/preferences/utils/ext_handlers.py
@@ -99,7 +99,8 @@ class ExtensionHandlers:
         progress_dialog.show()
 
         def on_installed(ext: ExtensionRecord) -> None:
-            ext_service.start_extension(ext)
+            # no explicit start: the service reconciles after the install job and starts the
+            # extension (fresh installs are enabled by default)
             progress_dialog.destroy()
             callback(ext)
 

--- a/ulauncher/ui/ruff.toml
+++ b/ulauncher/ui/ruff.toml
@@ -6,3 +6,4 @@ extend = "../../pyproject.toml"
 "functools.lru_cache" = {msg = "Use ulauncher.utils.lru_cache instead to preserve parameter types."}
 "functools.cache" = {msg = "Use ulauncher.utils.lru_cache instead to preserve parameter types."}
 "functools.cached_property" = {msg = "cached_property erases property types. If you need to use this, create a typed wrapper similar to ulauncher.utils.lru_cache"}
+"threading" = {msg = "Avoid threading. Use callbacks with Glib async methods that run in the background when possible"}

--- a/ulauncher/ui/ruff.toml
+++ b/ulauncher/ui/ruff.toml
@@ -2,6 +2,7 @@ extend = "../../pyproject.toml"
 
 # override the gi and ui ban, while preserving all other ban rules
 [lint.flake8-tidy-imports.banned-api]
+"asyncio" = {msg = "To handle async operations, use Gio or Glib async methods that run in the background. See ulauncher.utils.subprocess_utils."}
 "functools.lru_cache" = {msg = "Use ulauncher.utils.lru_cache instead to preserve parameter types."}
 "functools.cache" = {msg = "Use ulauncher.utils.lru_cache instead to preserve parameter types."}
 "functools.cached_property" = {msg = "cached_property erases property types. If you need to use this, create a typed wrapper similar to ulauncher.utils.lru_cache"}

--- a/ulauncher/utils/subprocess_utils.py
+++ b/ulauncher/utils/subprocess_utils.py
@@ -20,8 +20,6 @@ def run_command(cmd: list[str], on_success: OnSuccess, on_error: OnError, *, cwd
     try:
         proc = launcher.spawnv(cmd)
     except GLib.Error as error:
-        # Report synchronously, not via GLib.idle_add: idle_add posts to the global default
-        # context, which _run_gio_blocking's private thread-default loop never iterates -> hangs.
         on_error(error)
         return
 


### PR DESCRIPTION
## Replace asyncio with callbacks in the extension lifecycle

The extension service ran a second event loop (asyncio) inside worker threads, on top of the GLib main loop that everything else uses. This replaces that with plain GLib callbacks, and replaces the ad-hoc start/stop batching with a small state machine.

### The problem

Extension operations (install, update, uninstall, enable/disable, restart, preview) all need to stop a process, do disk work, then start something again. The old code did this with `asyncio.gather` inside a `threading.Thread`, and each caller wired up its own callbacks and guard closures to get the ordering right.

That meant the answer to "what should be running right now?" was spread across every caller. Ordering came out of whatever sequence listeners happened to be appended in. Some sequences got it wrong:

- `update` then `uninstall` on the same extension could resurrect the extension that was just removed
- two concurrent updates of one extension clobbered each other in the shared staging directory
- a preview interacting with an install of the same id depended on listener append order

### The two ideas

**1. Desired state is derived, not stored.**

There is one rule for whether an extension should be running:

> An extension should **only** run if its id resolves to a record **and** `record.is_enabled`.

`is_enabled` already folds in everything that matters - whether it is disabled, whether it has a persisted error, and whether a preview overlay is shadowing it. Nothing stores "should be running" separately, so nothing can go stale.

`_reconcile(ext_id)` is the only thing that acts on this. It compares the rule against reality and fixes the difference:

| Should run? | Is running? | Action     |
| ----------- | ----------- | ---------- |
| yes         | no          | start it   |
| no          | yes         | stop it    |
| otherwise   |             | do nothing |

**2. Operations that need exclusive access run as jobs, serialized per extension id.**

Install, update, uninstall and restart all need exclusive use of one extension's process and directory. Each one is queued as a **job** against that extension's id. Only one job per id runs at a time. Others wait in line.

While a job holds an id, `_reconcile` leaves that id completely alone. When the job releases, a reconcile runs.

### Why that combination works

Those two pieces are what removes the callback threading from every caller. A job does not have to say what should happen next - it just finishes and releases. The reconcile that follows reads the state on disk **at that moment** and converges to whatever it says.

So "disable, update, enable" works without any caller passing callbacks around:

```
disable  -> writes is_enabled=false
update   -> queued job: stop, swap files, release
enable   -> writes is_enabled=true
                    |
                    v
         job releases -> reconcile -> reads disk -> enabled -> start the NEW version
```

The final reconcile starts the new version exactly once, at the end, because that is what the disk says by then.

Same for the resurrection bug. `update` then `uninstall`:

```
update job     -> stop, swap, release
uninstall job  -> re-resolves the record, removes files, release
                    |
                    v
         reconcile -> id no longer resolves -> nothing starts
```

A job re-resolves its record when it *starts*, not when it was queued, so a job sitting behind an uninstall does not operate on a directory that is already gone. It resolves through `get_installed` rather than `get`, so a previewed id gives back the installed copy instead of the developer's dev checkout.

### Stops are asynchronous

A process does not exit the moment you ask it to. `_stop` records a pending stop plus the callbacks waiting on it, and the exit handler drains them when the process actually dies. A second stop request while one is in flight attaches to the same exit rather than starting a new one.

The exit handler follows one ordering rule, which is worth stating because it is easy to get backwards:

> **Desired-state changes settle first. Then callbacks drain. Then notifications go out.**

Anything that can trigger a reconcile must run *after* desired state is already correct. Concretely: when a preview crashes, the overlay is cleared **before** the stop callbacks drain, because a callback's release triggers a reconcile, and a reconcile that still saw the overlay would respawn the extension that just died.

The handler also only reconciles after an **intentional** stop. After a crash it does not, so a failing extension does not respawn in a loop.

### Also in here

- **`_reconcile` re-reads the record's state file.** `record.state` comes from `JsonConf.load`, which is `lru_cache`'d per path. Without a forced re-read the app reconciled against whatever *it* last saw, not what another process wrote - so `ulauncher extension uninstall X` (where a distro-packaged copy of X shadows it) would restart the copy the CLI had just disabled.
- **The `extensions:stop` D-Bus event is gone.** It stopped a process directly, bypassing the job queue, and the following reconcile just restarted it. Its only sender was the CLI's uninstall, which now sends `extensions:reload` - a restart job that stops the process and converges to "not installed".
- **`start_extension` no longer returns a bool.** It lied whenever a job or a stop held the id, and nothing read it.
- **The registry no longer restarts after a swap.** The lifecycle protocol it depends on shrinks to just `stop_extension`.
- **Url parsing is shared.** `install`, `update` and `check_update` all go through `resolve_remote`, so an invalid url has one error path.
- **`asyncio` and `threading` are now banned by ruff.** The one remaining `threading` use is in `ulauncher/api/extension.py`, which runs third-party extension handler code. That code is synchronous by API contract and cannot be cancelled, so a thread is genuinely the right tool there. It carries a `noqa`.

### Testing

`tests/modes/extensions/test_extension_lifecycle.py` fakes `ExtensionRuntime` so tests control exactly when a "process" exits. That makes the interleavings scriptable rather than timing-dependent. Covered: update-then-uninstall, an update queued behind an uninstall, disable-update-enable ordering, concurrent updates of one id, disabling mid-update, a crash without a restart loop, stop-during-stop, updating while a preview runs, and a preview that crashes while a stop is pending.

Registry disk and network operations are faked, but they stop through the **real** lifecycle, so the service's own decisions are what the tests exercise.

### Reading order

1. `ExtensionService`'s class docstring - the model in ~15 lines
2. `_reconcile` - the whole rule
3. `_enqueue_job` / `_run_next_job` - the queue
4. `exit_handler` inside `start_extension` - the ordering rule

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Ulauncher/Ulauncher/pull/1786?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

