### PR TITLE
refactor(data): add type level errors preventing props from being dropped

### DIFF
--- a/docs/architecture/base_data_class.md
+++ b/docs/architecture/base_data_class.md
@@ -43,9 +43,51 @@ unannotated field still works, but type checkers reject passing it.
 `JsonConf` declares its own `__init__` to opt out, since it holds arbitrary keys.
 Its subclasses get the checked signature again.
 
+## Declared props can't be dropped
+
+A prop declared without a default is required by the generated `__init__`, so
+removing it later leaves the instance contradicting its own type. The dict
+methods that can do that are marked deprecated for type checkers:
+
+```python
+data.pop("name")   # error
+data.popitem()     # error
+data.clear()       # error
+del data["name"]   # error
+```
+
+None of this is enforced at runtime.
+
+`JsonConf` re-declares `clear` to opt back in. File data is partial, so every
+prop of a file-backed class needs a default, which is exactly what `clear`
+restores.
+
+### Gaps
+
+Writes are not covered, only removals:
+
+```python
+del data.name              # not reported
+data["count"] = "5"        # not reported
+data.update({"count": 5})  # not reported
+```
+
+No type checker routes the `del` statement through `__delattr__`, so the marker
+on it never fires.
+
+The other two would need per-key value types, which nothing outside `TypedDict`
+synthesizes. A class can be parametrised by a hand-written companion `TypedDict`
+to get them checked, but that means declaring every prop twice, in two places
+that drift apart. Attribute access stays fully checked either way, so prefer
+`data.count = 5` over the dict API when the key is known.
+
+The `# error` labels above are what pyrefly reports. Other checkers may be weaker
+(as of writing this, this includes ty and Pyright).
+
 ## Key Features
 
-- **Inherits from dict** - Works with all dict methods (`get()`, `items()`, etc.)
+- **Inherits from dict** - All the read methods work (`get()`, `items()`, etc.).
+  The ones that drop props are rejected, see above.
 - **Deep-copied defaults** - Mutable defaults (lists, dicts) are copied per instance
 - **Keyword arguments only** - Type checkers require keywords for annotated fields
 - **Runtime properties** - New properties can be added after instantiation

--- a/ulauncher/data/base_data_class.py
+++ b/ulauncher/data/base_data_class.py
@@ -1,12 +1,12 @@
 from __future__ import annotations
 
 from copy import deepcopy
-from typing import TYPE_CHECKING, Any, Callable, TypeVar
+from typing import TYPE_CHECKING, Any, Callable, Dict, TypeVar
 
 from ulauncher.utils.lru_cache import lru_cache
 
 if TYPE_CHECKING:
-    from typing_extensions import dataclass_transform
+    from typing_extensions import dataclass_transform, deprecated
 else:
     # Type-check-only decorator (PEP 681). typing_extensions must stay out of the runtime,
     # and typing.dataclass_transform needs py3.11, so at runtime this is a no-op.
@@ -34,7 +34,7 @@ def _apply_class_defaults(instance: BaseDataClass) -> None:
 
 
 @dataclass_transform(kw_only_default=True, eq_default=False)
-class BaseDataClass(dict):  # type: ignore [type-arg]
+class BaseDataClass(Dict[str, Any]):
     """
     BaseDataClass
 
@@ -46,6 +46,7 @@ class BaseDataClass(dict):  # type: ignore [type-arg]
     * Implemented using the AttrDict pattern, but it avoids self.__dict__ = self
 
     * Annotated props become constructor keywords for type checkers (PEP 681), so annotate every field.
+    * Removing a declared prop is a type-check-only error. Nothing enforces it at runtime.
 
     # Example use:
     class Person(BaseDataClass):
@@ -69,8 +70,8 @@ class BaseDataClass(dict):  # type: ignore [type-arg]
     def clear(self) -> None:
         """Reset to class defaults, removing any runtime-added keys.
 
-        Overrides dict.clear so that declared fields are always present after a clear,
-        preserving the type contract of subclasses that declare non-optional fields.
+        Props declared without a default stay absent, which is why type checkers reject this call.
+        Subclasses whose props all have defaults re-declare it to opt back in.
         """
         super().clear()
         _apply_class_defaults(self)
@@ -85,7 +86,8 @@ class BaseDataClass(dict):  # type: ignore [type-arg]
         return dir(type(self)) + list(self.keys())
 
     def __delattr__(self, key: str) -> None:
-        del self[key]
+        # Subscript form, so a subclass __delitem__ still runs.
+        del self[key]  # type: ignore[deprecated]
 
     def __getattribute__(self, key: str) -> Any:
         try:
@@ -117,3 +119,22 @@ class BaseDataClass(dict):  # type: ignore [type-arg]
     def update(self, *args: Any, **kwargs: Any) -> None:
         for k, v in dict(*args, **kwargs).items():
             self[k] = v
+
+    if TYPE_CHECKING:
+        # Signatures only, so the runtime keeps the inherited behavior. Must come after the real
+        # definitions to be the ones type checkers see.
+
+        @deprecated("Removes a declared prop. Build a new instance instead.")
+        def __delitem__(self, key: str) -> None: ...
+
+        @deprecated("Removes a declared prop. Build a new instance instead.")
+        def __delattr__(self, key: str) -> None: ...
+
+        @deprecated("Removes a declared prop. Use `get` if you only need to read it.")
+        def pop(self, *args: Any, **kwargs: Any) -> Any: ...
+
+        @deprecated("Removes a declared prop. Build a new instance instead.")
+        def popitem(self) -> tuple[str, Any]: ...
+
+        @deprecated("Drops props declared without a default. Build a new instance instead.")
+        def clear(self) -> None: ...

--- a/ulauncher/data/base_data_class.py
+++ b/ulauncher/data/base_data_class.py
@@ -49,16 +49,16 @@ class BaseDataClass(dict):  # type: ignore [type-arg]
 
     # Example use:
     class Person(BaseDataClass):
-        # All props you declare need an annotation and a default value (not None)
-        first_name: str = ""
-        last_name: str = ""
-        age: int = 0
+        # All props you declare need a type annotation.
+        first_name: str  # Required (no default)
+        last_name: str | None = None  # Optional with a default
+        age: int | None = None
         metadata: dict[str, str] = {}  # Cloned per instance, so you can ignore linter warnings
 
         def full_name(self):
-            return self.first_name + " " + self.last_name
+            return f"{self.first_name} {self.last_name}" if self.last_name else self.first_name
 
-    print(Person(first_name=John, last_name="Wayne").full_name()) # John Wayne
+    print(Person(first_name="John", last_name="Wayne").full_name()) # John Wayne
     """
 
     def __init__(self, *args: Any, **kwargs: Any) -> None:

--- a/ulauncher/data/json_conf.py
+++ b/ulauncher/data/json_conf.py
@@ -27,6 +27,9 @@ class JsonConf(BaseDataClass):
         # override __init__, so they still get the synthesis.
         def __init__(self, *args: Any, **kwargs: Any) -> None: ...
 
+        # Opts back in to clear. Safe here because file data is partial, so every prop needs a default.
+        def clear(self) -> None: ...
+
     @classmethod
     def load(cls: type[T], path: str, *, force: bool = False) -> T:
         return _load_cached_file_instance(cls, path, force=force)

--- a/ulauncher/modes/extensions/extension_manifest.py
+++ b/ulauncher/modes/extensions/extension_manifest.py
@@ -86,7 +86,7 @@ class ExtensionManifest(JsonConf):
                                 self.triggers[p_id] = ExtensionManifestTrigger(
                                     name=pref.name,
                                     description=pref.description,
-                                    default_keyword=pref.default_value,
+                                    default_keyword=str(pref.default_value),
                                     icon=pref.get("icon", ""),
                                 )
                 value = prefs

--- a/ulauncher/modes/extensions/extension_remote.py
+++ b/ulauncher/modes/extensions/extension_remote.py
@@ -149,15 +149,15 @@ class ExtensionRemote(UrlParseResult):
     target_dir: str
 
     def __init__(self, url: str) -> None:
-        super().__init__()
+        stripped_url = url.strip()
         try:
-            self.url = url.strip()
-            self.update(parse_extension_url(self.url))
+            super().__init__(**parse_extension_url(stripped_url))
         except (ValueError, OSError) as e:
             logger.warning("Invalid URL: %s", url)
             msg = f"Invalid URL: {url}"
             raise ext_exceptions.UrlError(msg) from e
 
+        self.url = stripped_url
         self.target_dir = f"{paths.USER_EXTENSIONS}/{self.ext_id}"
         self._repo = _BareRepo(f"{paths.USER_EXTENSIONS}/.git/{self.ext_id}.git", self.remote_url, self.url)
 


### PR DESCRIPTION
Now that we have required props in some `BaseDataClass` subclasses, some of the methods inherited from python dicts become problematic:

```python
data.pop("name")
data.popitem()
data.clear()
del data["name"]
```

None of these are enforced at runtime, but now type checks will reject them.

Unfortunately, these couldn't be covered for technical reasons, so they are still unsafe:

```python
del data.name              # dropping required typ via del keyword
data["count"] = "5"        # invalid type assigned via key as a dict
data.update({"count": 5})  # invalid type assigned via update method.
```

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Ulauncher/Ulauncher/pull/1787?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

