### PR TITLE
feat(ext): let the manifest declare the extension's urls

### DIFF
--- a/tests/modes/extensions/test_extension_manifest.py
+++ b/tests/modes/extensions/test_extension_manifest.py
@@ -155,6 +155,39 @@ class TestExtensionManifest:
         with pytest.raises(ext_exceptions.ManifestError):
             manifest.validate()
 
+    def test_urls__given__is_parsed(self) -> None:
+        manifest = manifest_with(urls={"remote": "https://host.tld/u/r.git", "issues": "https://host.tld/u/r/issues"})
+        assert manifest.urls.remote == "https://host.tld/u/r.git"
+        assert manifest.urls.issues == "https://host.tld/u/r/issues"
+        assert manifest.urls.website is None
+
+    def test_urls__not_an_object__is_ignored(self) -> None:
+        # The key was undeclared until this field existed, so an extension may already use it for anything
+        manifest = manifest_with(urls="https://host.tld/u/r")
+        assert manifest.urls.website is None
+        manifest.validate()
+
+    @pytest.mark.parametrize(
+        "url",
+        [
+            "javascript:alert(1)",
+            "file:///home/user/repo",
+            ["https://host.tld/u/r"],
+            "http://[::1",
+            "https://",
+        ],
+    )
+    def test_validate__urls_not_http__warns_without_raising(self, url: Any, caplog: pytest.LogCaptureFixture) -> None:
+        manifest = manifest_with(urls={"website": url})
+        manifest.validate()
+        assert "urls.website" in caplog.text
+
+    def test_validate__urls_undeclared_key__is_reported_too(self, caplog: pytest.LogCaptureFixture) -> None:
+        # BaseDataClass keeps keys it does not declare, so they must not skip the scheme check
+        manifest = manifest_with(urls={"docs": "javascript:alert(1)"})
+        manifest.validate()
+        assert "urls.docs" in caplog.text
+
     def test_check_compatibility__manifest_version_0__exception_raised(self) -> None:
         manifest = ExtensionManifest(name="Test", api_version="0")
         with pytest.raises(ext_exceptions.CompatibilityError):
@@ -165,12 +198,12 @@ class TestExtensionManifest:
         manifest.check_compatibility()
 
     def test_defaults_not_included_in_stringify(self) -> None:
-        # Ensure defaults don't leak
-        assert json_stringify(ExtensionManifest()) == '{"input_debounce": 0.05}'
+        # Ensure defaults don't leak. "urls" survives empty because the blacklist drops values before recursing.
+        assert json_stringify(ExtensionManifest()) == '{"input_debounce": 0.05, "urls": {}}'
         # __setitem__ converts the raw dict into ExtensionManifestPreference instances.
         raw: dict[str, Any] = {"preferences": {"ns": {"k": "v"}}}
         manifest = ExtensionManifest(**raw)
-        assert json_stringify(manifest) == '{"input_debounce": 0.05, "preferences": {"ns": {"k": "v"}}}'
+        assert json_stringify(manifest) == '{"input_debounce": 0.05, "urls": {}, "preferences": {"ns": {"k": "v"}}}'
 
     def test_manifest_backwards_compatibility(self) -> None:
         # Legacy key names, renamed by ExtensionManifest.__setitem__ rather than declared as fields.

--- a/tests/modes/extensions/test_extension_record.py
+++ b/tests/modes/extensions/test_extension_record.py
@@ -2,7 +2,11 @@ from __future__ import annotations
 
 import json
 from pathlib import Path
+from typing import Any
 
+import pytest
+
+from ulauncher.modes.extensions import ext_exceptions
 from ulauncher.modes.extensions.extension_record import ExtensionErrorData, ExtensionRecord
 
 
@@ -33,3 +37,79 @@ def test_reload_state__resets_to_the_defaults_when_the_file_is_gone(tmp_path: Pa
     assert record.state.is_enabled is True
     assert record.state.error is None
     assert record.state.url == "https://example.com"
+
+
+INSTALL_URL = "https://host.tld/user/repo"
+MOVED_URL = "https://newhost.tld/user/repo"
+TRACKER_URL = "https://tracker.tld/user/repo/-/issues"
+
+
+def record_with_manifest(ext_id: str, path: Path, manifest: dict[str, Any] | None = None) -> ExtensionRecord:
+    if manifest is not None:
+        (path / "manifest.json").write_text(json.dumps(manifest))
+    record = ExtensionRecord(ext_id, str(path))
+    record.state.url = INSTALL_URL
+    return record
+
+
+@pytest.mark.parametrize(
+    ("case", "manifest", "browser_url", "expected"),
+    [
+        ("declared_wins", {"urls": {"website": MOVED_URL}}, INSTALL_URL, MOVED_URL),
+        ("falls_back_to_derived", None, INSTALL_URL, INSTALL_URL),
+        ("non_http_is_dropped", None, "file:///home/user/repo", ""),
+        ("invalid_declared_falls_back", {"urls": {"website": "file:///home/user/repo"}}, INSTALL_URL, INSTALL_URL),
+    ],
+)
+def test_website_url(
+    case: str, manifest: dict[str, Any] | None, browser_url: str, expected: str, tmp_path: Path
+) -> None:
+    record = record_with_manifest(f"test_record_website_{case}", tmp_path, manifest)
+    record.state.browser_url = browser_url
+
+    assert record.website_url == expected
+
+
+@pytest.mark.parametrize(
+    ("case", "manifest", "expected"),
+    [
+        ("declared", {"urls": {"issues": TRACKER_URL}}, TRACKER_URL),
+        ("not_declared", {"urls": {"website": INSTALL_URL}}, ""),
+    ],
+)
+def test_issues_url(case: str, manifest: dict[str, Any], expected: str, tmp_path: Path) -> None:
+    record = record_with_manifest(f"test_record_issues_{case}", tmp_path, manifest)
+
+    assert record.issues_url == expected
+
+
+@pytest.mark.parametrize(
+    ("case", "manifest", "expected"),
+    [
+        ("no_declared_remote", None, INSTALL_URL),
+        ("declared_remote", {"urls": {"remote": MOVED_URL}}, MOVED_URL),
+        ("non_http_remote", {"urls": {"remote": "file:///etc"}}, INSTALL_URL),
+        ("unreadable_manifest", {"triggers": "not an object"}, INSTALL_URL),
+    ],
+)
+def test_update_url(case: str, manifest: dict[str, Any] | None, expected: str, tmp_path: Path) -> None:
+    record = record_with_manifest(f"test_record_update_{case}", tmp_path, manifest)
+
+    assert record.update_url == expected
+
+
+def test_display_manifest__unreadable__falls_back_without_raising(tmp_path: Path) -> None:
+    ext_id = "test_record_display_manifest_unreadable"
+    record = record_with_manifest(ext_id, tmp_path, {"triggers": "not an object"})
+    record.state.browser_url = INSTALL_URL
+
+    with pytest.raises(ext_exceptions.ManifestError):
+        _ = record.manifest
+
+    # Every display path degrades instead of taking the preferences window down with it
+    assert record.display_manifest.name == ext_id
+    assert record.preferences == {}
+    assert record.triggers == {}
+    assert record.get_icon_value() == ""
+    assert record.website_url == INSTALL_URL
+    assert record.issues_url == ""

--- a/tests/ui/preferences/utils/test_ext_utils.py
+++ b/tests/ui/preferences/utils/test_ext_utils.py
@@ -1,4 +1,46 @@
-from ulauncher.ui.preferences.utils.ext_utils import autofmt_pango_code_block
+import pytest
+
+from ulauncher.modes.extensions.extension_record import ExtensionErrorData
+from ulauncher.ui.preferences.utils.ext_utils import autofmt_pango_code_block, get_error_message
+
+WEBSITE = "https://host.tld/u/r"
+ISSUES = "https://tracker.tld/u/r/-/issues"
+WEBSITE_LINK = f'<a href="{WEBSITE}">{WEBSITE}</a>'
+ISSUES_LINK = f'<a href="{ISSUES}">{ISSUES}</a>'
+
+
+class TestGetErrorMessage:
+    @pytest.mark.parametrize(
+        ("website_url", "issues_url", "expected_suffix"),
+        [
+            (WEBSITE, ISSUES, f"\n\n<small>You can report the issue: {ISSUES_LINK}</small>"),
+            (WEBSITE, "", f"\n\n<small>You can report this to the author via their repository: {WEBSITE_LINK}</small>"),
+            ("", "", ""),
+        ],
+    )
+    def test_report_link_prefers_the_tracker_and_is_omitted_without_urls(
+        self, website_url: str, issues_url: str, expected_suffix: str
+    ) -> None:
+        error = ExtensionErrorData(type="Exited", message="boom")
+        assert get_error_message(error, website_url, issues_url) == f"boom{expected_suffix}"
+
+    def test_missing_module_links_the_issue_tracker(self) -> None:
+        error = ExtensionErrorData(type="MissingModule", message="requests")
+        message = get_error_message(error, WEBSITE, ISSUES)
+        assert "pip3 install requests --user" in message
+        assert f'report the issue: <a href="{ISSUES}">{ISSUES}</a>' in message
+
+    def test_terminated_links_the_issue_tracker(self) -> None:
+        error = ExtensionErrorData(type="Terminated")
+        message = get_error_message(error, WEBSITE, ISSUES)
+        assert f"You can report the issue: {ISSUES_LINK}" in message
+        assert WEBSITE not in message
+
+    def test_url_is_escaped_into_the_markup(self) -> None:
+        error = ExtensionErrorData(type="Exited", message="boom")
+        message = get_error_message(error, "", 'https://host.tld/?a="><b>x</b>')
+        assert "<b>x</b>" not in message
+        assert "&quot;&gt;&lt;b&gt;" in message
 
 
 class TestAutofmtPangoCodeBlock:

--- a/ulauncher/cli/commands/extensions.py
+++ b/ulauncher/cli/commands/extensions.py
@@ -10,7 +10,7 @@ def run(_: CLIArguments) -> int:
     extensions = list(get_ext_registry().iterate(sort=True))
     for ext in extensions:
         disabled_label = " [DISABLED]" if not ext.is_enabled else ""
-        logger.info("- %s (%s)%s", ext.manifest.name, ext.id, disabled_label)
+        logger.info("- %s (%s)%s", ext.display_manifest.name, ext.id, disabled_label)
     if not extensions:
         logger.info("No extensions installed.")
 

--- a/ulauncher/cli/commands/upgrade.py
+++ b/ulauncher/cli/commands/upgrade.py
@@ -32,14 +32,14 @@ def _upgrade_all_extensions() -> list[str]:
     updated_extensions: list[str] = []
 
     for record in get_ext_registry().iterate():
-        if not record.is_manageable or not record.state.url:
+        if not record.is_manageable or not record.update_url:
             continue
 
         try:
             if _update_blocking(record):
                 updated_extensions.append(record.id)
         except ext_exceptions.UrlError:
-            _log_url_error(record.id, record.state.url, fatal=False)
+            _log_url_error(record.id, record.update_url, fatal=False)
         except (ext_exceptions.NetworkError, ext_exceptions.RemoteError):
             logger.warning("Network error: Could not upgrade %s", record.id)
         except (ext_exceptions.ExtensionError, OSError):
@@ -56,7 +56,7 @@ def upgrade_one(record: ExtensionRecord) -> bool:
     try:
         updated = _update_blocking(record)
     except ext_exceptions.UrlError:
-        _log_url_error(record.id, record.state.url, fatal=True)
+        _log_url_error(record.id, record.update_url, fatal=True)
         return False
     except (ext_exceptions.NetworkError, ext_exceptions.RemoteError):
         logger.error("Network error: Could not upgrade %s", record.id)  # noqa: TRY400 - traceback is noise here

--- a/ulauncher/modes/extensions/extension_manifest.py
+++ b/ulauncher/modes/extensions/extension_manifest.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import logging
 from typing import Any
+from urllib.parse import urlparse
 
 from ulauncher import api_version
 from ulauncher.data import BaseDataClass, JsonConf
@@ -15,6 +16,17 @@ def _expected_object(key: str, value: Any) -> str:
     return f'Invalid "{key}" in extension manifest: expected an object, got {type(value).__name__}'
 
 
+def is_http_url(url: Any) -> bool:
+    if not isinstance(url, str):
+        return False
+    try:
+        parts = urlparse(url)
+    except ValueError:
+        # Manifests are third-party data, and urlparse raises on a malformed host like "http://[::1"
+        return False
+    return parts.scheme in ("http", "https") and bool(parts.hostname)
+
+
 class ExtensionManifestPreference(BaseDataClass):
     name: str = ""
     type: str = ""
@@ -23,6 +35,14 @@ class ExtensionManifestPreference(BaseDataClass):
     default_value: str | int | bool = ""
     max: int | None = None
     min: int | None = None
+
+
+class ExtensionManifestUrls(BaseDataClass):
+    """Author-declared locations. `remote` is where updates are fetched from, the rest is displayed."""
+
+    remote: str | None = None
+    website: str | None = None
+    issues: str | None = None
 
 
 class ExtensionManifestTrigger(BaseDataClass):
@@ -45,6 +65,7 @@ class ExtensionManifest(JsonConf):
     icon: str = ""
     instructions: str = ""
     input_debounce: float = 0.05
+    urls: ExtensionManifestUrls = ExtensionManifestUrls()
     triggers: dict[str, ExtensionManifestTrigger] = {}
     preferences: dict[str, ExtensionManifestPreference] = {}
 
@@ -61,6 +82,12 @@ class ExtensionManifest(JsonConf):
             value = isinstance(value, dict) and float(value.get("query_debounce", -1))
             if value <= 0:
                 return
+        # Dropped rather than rejected: the key was free for any use before it was declared here
+        elif key == "urls":
+            if not isinstance(value, dict):
+                logger.warning("%s. Ignoring it.", _expected_object(key, value))
+                return
+            value = ExtensionManifestUrls(**value)
         # Convert triggers dicts to ExtensionManifestTrigger instances
         elif key == "triggers":
             if not isinstance(value, dict):
@@ -100,6 +127,11 @@ class ExtensionManifest(JsonConf):
         if missing_fields := [f for f in required_fields if not self.get(f)]:
             err_msg = f'Extension manifest is missing required field(s): "{", ".join(missing_fields)}"'
             raise ext_exceptions.ManifestError(err_msg)
+
+        # Not an error: this only runs on activation, so every consumer re-checks the scheme anyway
+        for name, url in self.urls.items():
+            if url and not is_http_url(url):
+                logger.warning('Ignoring "urls.%s" of extension %s: not a http(s) URL: %s', name, self.name, url)
 
         for t_id, t in self.triggers.items():
             if not t.name:

--- a/ulauncher/modes/extensions/extension_mode.py
+++ b/ulauncher/modes/extensions/extension_mode.py
@@ -135,7 +135,7 @@ class ExtensionMode(Mode):
             return Result(name="Extension failed to start")
 
         error = ext.get_error()
-        name = ext.manifest.name or "Extension"
+        name = ext.display_manifest.name or "Extension"
         error_msg = error.message if error else None
         return Result(name=f"{name} failed to start", description=error_msg or "", icon=ext.get_icon_value())
 
@@ -255,7 +255,7 @@ class ExtensionMode(Mode):
             events.emit(
                 "app:show_notification",
                 f"ext-{ext.id}-{message['notification_id']}",
-                f"Message from {ext.manifest.name} extension",
+                f"Message from {ext.display_manifest.name} extension",
                 message["body"],
             )
         else:

--- a/ulauncher/modes/extensions/extension_record.py
+++ b/ulauncher/modes/extensions/extension_record.py
@@ -9,10 +9,11 @@ from typing import Any, Literal, Union
 
 from ulauncher import paths
 from ulauncher.data import BaseDataClass, JsonConf
-from ulauncher.modes.extensions import extension_finder
+from ulauncher.modes.extensions import ext_exceptions, extension_finder
 from ulauncher.modes.extensions.extension_manifest import (
     ExtensionManifest,
     ExtensionManifestPreference,
+    is_http_url,
 )
 from ulauncher.utils.json_utils import json_load
 
@@ -70,6 +71,10 @@ def _load_preferences(ext_id: str) -> JsonConf:
     return JsonConf.load(f"{paths.EXTENSIONS_CONFIG}/{ext_id}.json")
 
 
+def _http_url(url: str | None) -> str:
+    return url if url and is_http_url(url) else ""
+
+
 class ExtensionRecord:
     """Represents an installed extension: its files, state and preferences."""
 
@@ -117,6 +122,32 @@ class ExtensionRecord:
     def manifest(self) -> ExtensionManifest:
         return ExtensionManifest.load(self.path)
 
+    @property
+    def display_manifest(self) -> ExtensionManifest:
+        """A placeholder manifest instead of an error when the file cannot be read, so a broken
+        extension still renders. Use `manifest` where the failure has to surface, such as validation."""
+        try:
+            return self.manifest
+        except ext_exceptions.ManifestError:
+            return ExtensionManifest(name=self.id)
+
+    @property
+    def website_url(self) -> str:
+        return _http_url(self.display_manifest.urls.website) or _http_url(self.state.browser_url)
+
+    @property
+    def issues_url(self) -> str:
+        return _http_url(self.display_manifest.urls.issues)
+
+    @property
+    def update_url(self) -> str:
+        """Resolved per update instead of persisted, so the manifest stays the only place it lives.
+
+        A broken or non-http declaration falls back to the installed-from url, because a broken
+        manifest is often the reason for updating. ExtensionManifest.validate reports the bad url.
+        """
+        return _http_url(self.display_manifest.urls.remote) or self.state.url
+
     def reload_state(self) -> None:
         """Pick up state another process wrote. The CLI disables a non-manageable copy that shadows
         an uninstalled extension, and the app's cached state would otherwise still say enabled."""
@@ -139,7 +170,7 @@ class ExtensionRecord:
     def preferences(self) -> dict[str, ExtensionPreference]:
         prefs_json = _load_preferences(self.id)
         prefs = {}
-        for p_id, manifest_pref in self.manifest.preferences.items():
+        for p_id, manifest_pref in self.display_manifest.preferences.items():
             # copy to avoid mutating
             pref = ExtensionPreference(**manifest_pref)
             pref.value = prefs_json.get("preferences", {}).get(p_id, manifest_pref.default_value)
@@ -150,7 +181,7 @@ class ExtensionRecord:
     def triggers(self) -> dict[str, ExtensionRecordTrigger]:
         user_prefs_json = _load_preferences(self.id)
         triggers = {}
-        for t_id, manifest_trigger in self.manifest.triggers.items():
+        for t_id, manifest_trigger in self.display_manifest.triggers.items():
             trigger = ExtensionRecordTrigger(**manifest_trigger)
             trigger.keyword = user_prefs_json.get("triggers", {}).get(t_id, {}).get("keyword", trigger.default_keyword)
             triggers[t_id] = trigger
@@ -163,7 +194,7 @@ class ExtensionRecord:
         user_prefs_json.save(data)
 
     def get_icon_value(self, icon: str | None = None) -> str:
-        icon_value = icon or self.manifest.icon
+        icon_value = icon or self.display_manifest.icon
         expanded_path = join(self.path, icon_value)
         if isfile(expanded_path):
             return expanded_path

--- a/ulauncher/modes/extensions/extension_registry.py
+++ b/ulauncher/modes/extensions/extension_registry.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import logging
 from pathlib import Path
 from shutil import move, rmtree
-from typing import Any, Callable, Iterator, Protocol
+from typing import Callable, Iterator, Protocol
 
 from ulauncher import paths
 from ulauncher.modes.extensions import ext_exceptions, extension_finder
@@ -140,7 +140,7 @@ class ExtensionRegistry:
             logger.info("Extension %s installed successfully", record.id)
             on_success(record)
 
-        self._install_from_remote(record, remote, commit_hash, done, on_error, url=url)
+        self._install_from_remote(record, remote, commit_hash, done, on_error)
 
     def uninstall(self, record: ExtensionRecord, on_done: Done, on_error: OnError) -> None:
         def remove_files() -> None:
@@ -193,7 +193,11 @@ class ExtensionRegistry:
                 logger.error("Could not update extension '%s'", record.id, exc_info=error)
                 on_error(error)
 
-            remote = resolve_remote(record.state.url, fail)
+            update_url = record.update_url
+            if update_url != record.state.url:
+                logger.info("Extension %s is updated from %s, which its manifest declares", record.id, update_url)
+
+            remote = resolve_remote(update_url, fail)
             if remote is None:
                 return
             self._install_from_remote(record, remote, commit_hash, done, fail)
@@ -202,7 +206,7 @@ class ExtensionRegistry:
 
     def check_update(self, record: ExtensionRecord, on_success: CheckUpdateSuccess, on_error: OnError) -> None:
         """Reports whether a new compatible version exists, and its commit hash."""
-        remote = resolve_remote(record.state.url, on_error)
+        remote = resolve_remote(record.update_url, on_error)
         if remote is None:
             return
 
@@ -218,12 +222,9 @@ class ExtensionRegistry:
         commit_hash: str | None,
         on_done: Done,
         on_error: OnError,
-        **extra_state: Any,
     ) -> None:
         """Install (atomically): download, stop and swap. Restarting is the caller's concern
         (in the app, the service reconciles once the job wrapping this operation releases).
-
-        `extra_state` is merged into the saved state (install records the source url; update adds nothing).
         """
         target_path = record.path
         # Fixed path per extension so failed installs don't accumulate.
@@ -249,8 +250,10 @@ class ExtensionRegistry:
                     error: Exception | None = None
                     if _swap_dir(staging_dir, target_path):
                         try:
+                            # Saved together, so an update to a declared remote can't leave the
+                            # state pointing half at the previous host
                             record.save_installed_state(
-                                downloaded_hash, commit_timestamp, **extra_state, browser_url=remote.browser_url or ""
+                                downloaded_hash, commit_timestamp, url=remote.url, browser_url=remote.browser_url or ""
                             )
                         # Reloading the manifest can reject the swapped-in files. This runs in a
                         # Gio callback, so an escape would report neither done nor error.
@@ -266,6 +269,6 @@ class ExtensionRegistry:
 
                 self._lifecycle.stop_extension(record, swap_and_finish)
 
-            ExtensionDependencies(remote.ext_id, staging_dir).install(on_deps_installed, fail)
+            ExtensionDependencies(record.id, staging_dir).install(on_deps_installed, fail)
 
         remote.download(on_downloaded, fail, commit_hash)

--- a/ulauncher/ui/preferences/utils/ext_handlers.py
+++ b/ulauncher/ui/preferences/utils/ext_handlers.py
@@ -116,7 +116,7 @@ class ExtensionHandlers:
 
     def remove_extension(self, ext: ExtensionRecord, callback: Callable[[], None]) -> None:
         """Handle extension removal"""
-        text = f'Remove extension "{ext.manifest.name}"?'
+        text = f'Remove extension "{ext.display_manifest.name}"?'
         secondary_text = "This action cannot be undone."
         response = self.dialog_launcher.show_question(text, secondary_text)
 
@@ -145,7 +145,7 @@ class ExtensionHandlers:
             else:
                 callback()
                 self.dialog_launcher.show(
-                    f"No updates available for {ext.manifest.name}", "The extension is up to date."
+                    f"No updates available for {ext.display_manifest.name}", "The extension is up to date."
                 )
 
         def on_error(error: Exception) -> None:
@@ -166,22 +166,24 @@ class ExtensionHandlers:
             callback()
             progress_dialog.destroy()
             if updated:
-                self.dialog_launcher.show("Extension updated successfully", f"{ext.manifest.name} has been updated.")
+                self.dialog_launcher.show(
+                    "Extension updated successfully", f"{ext.display_manifest.name} has been updated."
+                )
             else:
                 self.dialog_launcher.show(
-                    f"No updates available for {ext.manifest.name}", "The extension is up to date."
+                    f"No updates available for {ext.display_manifest.name}", "The extension is up to date."
                 )
 
         def on_error(error: Exception) -> None:
             callback()
             progress_dialog.destroy()
-            self._show_extension_operation_error(error, ext.state.url, "update")
+            self._show_extension_operation_error(error, ext.issues_url or ext.website_url, "update")
 
         ext_service.update(ext, on_updated, on_error)
 
     def _show_update_dialog(self, ext: ExtensionRecord, commit_hash: str, callback: Callable[[], None]) -> None:
         """Show dialog when update is available"""
-        text = f"Update available for '{ext.manifest.name}'"
+        text = f"Update available for '{ext.display_manifest.name}'"
         secondary_text = f"New version: {commit_hash[:7]}\n\nDo you want to update now?"
         response = self.dialog_launcher.show_question(text, secondary_text)
         if response == Gtk.ResponseType.YES:

--- a/ulauncher/ui/preferences/utils/ext_utils.py
+++ b/ulauncher/ui/preferences/utils/ext_utils.py
@@ -42,7 +42,20 @@ def get_status_str(ext: ExtensionRecord) -> ExtStatus:
     return "on"
 
 
-def get_error_message(error: ExtensionErrorData, browser_url: str) -> str:
+def _anchor(text: str, url: str) -> str:
+    escaped = html.escape(url)
+    return f'{text}: <a href="{escaped}">{escaped}</a>'
+
+
+def _report_link(website_url: str, issues_url: str) -> str:
+    if issues_url:
+        return _anchor("report the issue", issues_url)
+    if website_url:
+        return _anchor("report this to the author via their repository", website_url)
+    return ""
+
+
+def get_error_message(error: ExtensionErrorData, website_url: str, issues_url: str) -> str:
     """Generate appropriate error message based on error type"""
     error_message = error.message or ""
 
@@ -65,8 +78,8 @@ def get_error_message(error: ExtensionErrorData, browser_url: str) -> str:
             "The extension crashed. Ensure that you read and followed the instructions on the "
             "extension repository page, and check the error log and report the error otherwise."
         )
-        if browser_url:
-            message += f'\n\n<small>Repository: <a href="{browser_url}">{browser_url}</a></small>'
+        if report_link := _report_link(website_url, issues_url):
+            message += f"\n\n<small>You can {report_link}</small>"
         return message
 
     if error.type == "MissingInternals":
@@ -85,15 +98,11 @@ def get_error_message(error: ExtensionErrorData, browser_url: str) -> str:
             f"{fmt_pango_code_block(f'pip3 install {module_name} --user')}\n\n"
             f"Then restart Ulauncher."
         )
-        if browser_url:
-            message += (
-                f"\n\n<small>If that doesn't help, report this to the author via their repository: "
-                f'<a href="{browser_url}">{browser_url}</a></small>'
-            )
+        if report_link := _report_link(website_url, issues_url):
+            message += f"\n\n<small>If that doesn't help, {report_link}</small>"
         return message
 
     message = error_message or f"Unknown error type: {error.type}"
-    if browser_url:
-        message += "\n\n<small>You can report this to the author via their repository: "
-        message += f'<a href="{browser_url}">{browser_url}</a></small>'
+    if report_link := _report_link(website_url, issues_url):
+        message += f"\n\n<small>You can {report_link}</small>"
     return message

--- a/ulauncher/ui/preferences/views/extensions.py
+++ b/ulauncher/ui/preferences/views/extensions.py
@@ -84,7 +84,7 @@ class ExtensionsView(BaseView):
 
         for ext in ext_service.iterate(sort=True):
             extension_cache[ext.id] = (
-                ext.manifest.name,
+                ext.display_manifest.name,
                 ext_utils.get_status_str(ext),
                 ext.get_icon_value(),
             )
@@ -231,15 +231,15 @@ class ExtensionsView(BaseView):
     def _create_name_toggle_column(self, ext: ExtensionRecord) -> tuple[Gtk.Box, Gtk.Box | None]:
         """Create the name column content"""
         name_box = Gtk.Box(orientation=Gtk.Orientation.HORIZONTAL, spacing=10)
-        name_label = styled(Gtk.Label(label=ext.manifest.name, halign=Gtk.Align.START), "title")
+        name_label = styled(Gtk.Label(label=ext.display_manifest.name, halign=Gtk.Align.START), "title")
         name_box.pack_start(name_label, False, False, 0)
 
         # Create a vertical box for authors and updated date
         secondary_info_box = Gtk.Box(orientation=Gtk.Orientation.VERTICAL, spacing=0, valign=Gtk.Align.END)
 
-        if ext.manifest.authors:
+        if ext.display_manifest.authors:
             authors_label = styled(
-                Gtk.Label(label=f"by {ext.manifest.authors}", halign=Gtk.Align.START), "caption", "dim-label"
+                Gtk.Label(label=f"by {ext.display_manifest.authors}", halign=Gtk.Align.START), "caption", "dim-label"
             )
             secondary_info_box.pack_start(authors_label, False, False, 0)
 
@@ -264,15 +264,21 @@ class ExtensionsView(BaseView):
         parts: list[Gtk.Widget] = []
 
         # Repository URL (if available)
-        if ext.state.browser_url and ext.state.browser_url.startswith("http"):
-            display_url = ext.state.browser_url.replace("https://", "").replace("http://", "")
-            repo_link = Gtk.LinkButton.new_with_label(ext.state.browser_url, display_url)
+        if website_url := ext.website_url:
+            display_url = website_url.replace("https://", "").replace("http://", "")
+            repo_link = Gtk.LinkButton.new_with_label(website_url, display_url)
             repo_link.set_halign(Gtk.Align.CENTER)
             # Enable ellipsis on the internal label to handle long URLs
             label = repo_link.get_child()
             if isinstance(label, Gtk.Label):
                 label.set_ellipsize(Pango.EllipsizeMode.END)
             parts.append(repo_link)
+
+        # Labelled rather than spelled out, so it doesn't crowd the repository URL
+        if issues_url := ext.issues_url:
+            issues_link = Gtk.LinkButton.new_with_label(issues_url, "issue tracker")
+            issues_link.set_halign(Gtk.Align.CENTER)
+            parts.append(issues_link)
 
         # Installation status
         status_text = "user installed" if ext.is_manageable else "externally managed"
@@ -322,7 +328,7 @@ class ExtensionsView(BaseView):
         button_box.pack_start(self.save_button, False, False, 0)
 
         # Check Updates button
-        if ext.is_manageable and ext.state.url:
+        if ext.is_manageable and ext.update_url:
             update_button = Gtk.Button(label="Check Updates")
             update_button.connect("clicked", self._on_check_updates, ext)
             button_box.pack_start(update_button, False, False, 0)
@@ -339,7 +345,7 @@ class ExtensionsView(BaseView):
         """Create the installation instructions section"""
         container = Gtk.Box(orientation=Gtk.Orientation.VERTICAL)
 
-        if ext.manifest.instructions and ext.manifest.instructions.strip():
+        if ext.display_manifest.instructions and ext.display_manifest.instructions.strip():
             instructions_container = styled(
                 Gtk.Box(orientation=Gtk.Orientation.VERTICAL), "ext-installation-instructions"
             )
@@ -349,7 +355,7 @@ class ExtensionsView(BaseView):
 
             # Instructions content with HTML rendering
             instructions_label = Gtk.Label(
-                label=ext_utils.autofmt_pango_code_block(ext.manifest.instructions),
+                label=ext_utils.autofmt_pango_code_block(ext.display_manifest.instructions),
                 use_markup=True,
                 selectable=True,
                 margin=10,
@@ -518,7 +524,7 @@ class ExtensionsView(BaseView):
         if error := ext.get_error():
             error_box = Gtk.Box(orientation=Gtk.Orientation.VERTICAL, spacing=10, margin=10)
             # Create appropriate error message based on type
-            message_text = ext_utils.get_error_message(error, ext.state.browser_url)
+            message_text = ext_utils.get_error_message(error, ext.website_url, ext.issues_url)
 
             # Create warning-style container
             warning_frame = styled(Gtk.Box(), "ext-error-box")


### PR DESCRIPTION
Adds an optional "urls" object to the extension manifest, with "remote", "website" and "issues". An author can now state where the extension lives instead of Ulauncher guessing it from the url the user installed from (which works for the remote itself but was flaky for the website and even more for the issue tracker). Extensions without the new fields behave exactly as before.

Updates are fetched from urls.remote, so an author who moves their repo can point existing installs at the new location instead of leaving them on a dead url.

Every url is filtered to http(s) at the point of use, which keeps other schemes out of the link handlers and keeps a manifest from pointing the installer at a local path.

The old parsed website data is still used as a fallback, if available (since extension manifests won't be having urls until authors had the time to update). 

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Ulauncher/Ulauncher/pull/1788?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

