### PR TITLE
fix: schedule focus-out hide on GLib main loop, not a Python thread

### DIFF
--- a/ulauncher/ui/windows/UlauncherWindow.py
+++ b/ulauncher/ui/windows/UlauncherWindow.py
@@ -2,7 +2,6 @@
 import os
 import time
 import logging
-import threading
 
 import gi
 gi.require_version('Gtk', '3.0')
@@ -151,8 +150,13 @@ class UlauncherWindow(Gtk.Window, WindowHelper):
         # this is a simple workaround to avoid hiding window
         # when user hits Alt+key combination or changes input source, etc.
         self.is_focused = False
-        t = threading.Timer(0.07, lambda: self.is_focused or self.hide())
-        t.start()
+
+        def check_focus_and_hide():
+            if not self.is_focused:
+                self.hide()
+            return GLib.SOURCE_REMOVE
+
+        GLib.timeout_add(70, check_focus_and_hide)
 
     def on_focus_in_event(self, *args):
         if self.settings.get_property('grab-mouse-pointer'):


### PR DESCRIPTION
## Summary

Fixes #1792.

`on_focus_out_event` used `threading.Timer` to delay the hide check by 70ms. That runs the callback on a separate Python thread, and GTK/GDK are not thread-safe — calling `self.hide()` from that thread intermittently segfaults deep inside GDK/GTK's signal-emission internals (`gdk_window_hide`/`gtk_widget_unmap` cascade).

This switches to `GLib.timeout_add`, so the delayed check runs on the main loop like every other GTK call in the codebase, instead of a bare Python thread.

## Evidence

Confirmed via `coredumpctl` on a system with several months of SIGSEGV crash history: every available core dump shows the same signature — segfault inside `libglib-2.0` reached through `gdk_window_hide`/`gdk_window_withdraw` via a `gtk_widget_unmap`/`g_signal_emit` cascade, on a thread that is not the process's main thread. `threading.Timer` here is the only place in the codebase that invokes a GTK method from a spawned thread, which matches.

## Test plan

- [x] `grep` confirms `threading` had no other use in the file after removing the import
- [ ] Manually verified no more crashes after a period of normal use with rapid focus-out/focus-in (e.g. Alt-tabbing, switching input sources)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Ulauncher/Ulauncher/pull/1793?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

